### PR TITLE
fix max_num_batches calculation

### DIFF
--- a/pytext/data/bptt_lm_data_handler.py
+++ b/pytext/data/bptt_lm_data_handler.py
@@ -148,13 +148,15 @@ class BPTTLanguageModelDataHandler(DataHandler):
         rank: int = 0,
         world_size: int = 1,
     ) -> BatchIterator:
-        dataset_shard = self._get_dataset_shard(train_dataset, rank, world_size)
+        dataset_shard, max_num_examples = self._get_dataset_shard(
+            train_dataset, rank, world_size
+        )
         # Compute the per-worker batch size
         assert (
             batch_size >= world_size
         ), "batch size needs to be >= the distributed world size"
         batch_size = batch_size // world_size
-        num_all_batches = math.ceil(len(train_dataset) / float(batch_size))
+
         return BatchIterator(
             textdata.BPTTIterator(
                 dataset_shard,
@@ -168,7 +170,7 @@ class BPTTLanguageModelDataHandler(DataHandler):
                 sort_key=self.sort_key,
             ),
             self._postprocess_batch,
-            num_batches=math.ceil(num_all_batches / float(world_size)),
+            num_batches=math.ceil(max_num_examples / float(batch_size)),
         )
 
     def _train_input_from_batch(self, batch):

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -123,6 +123,7 @@ class Task(Component):
             train_config,
             self.optimizers,
             self.lr_scheduler,
+            rank=rank,
         )
 
     def test(self, test_path):

--- a/pytext/trainers/hogwild_trainer.py
+++ b/pytext/trainers/hogwild_trainer.py
@@ -41,6 +41,8 @@ class HogwildTrainer(Trainer):
         optimizers: List[torch.optim.Optimizer],
         pytext_config: PyTextConfig,
         scheduler=None,
+        *args,
+        **kwargs
     ):
         print("Num of workers for Hogwild Training is {}".format(self.num_workers))
 

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -116,11 +116,17 @@ class Trainer(TrainerBase):
             loss.backward()
             if scheduler:
                 scheduler.step_batch()
+
             if self.config.max_clip_norm is not None:
-                torch.nn.utils.clip_grad_norm_(
+                grad_norm = torch.nn.utils.clip_grad_norm_(
                     model.parameters(), self.config.max_clip_norm
                 )
+            else:
+                grad_norm = None
+
             optimizer_step(optimizers)
+            # grad_norm could be used to check grads sync in distributed training
+            return grad_norm
 
         for epoch in range(1, self.config.epochs + 1):
             print(f"Rank {rank} worker: Starting epoch #{epoch}")

--- a/pytext/utils/dist_utils.py
+++ b/pytext/utils/dist_utils.py
@@ -26,7 +26,11 @@ def dist_init(
 def suppress_output():
     import builtins as __builtin__
 
+    builtin_print = __builtin__.print
+
     def print(*args, **kwargs):
-        pass
+        # force print the result when kwargs contains force and value is True
+        if kwargs.pop("force", False):
+            builtin_print(*args, **kwargs)
 
     __builtin__.print = print


### PR DESCRIPTION
Summary:
In distributed training, we have the logic that each shard will keep yield the results until it reach the max_num_batches.
But if the max_num_batches calculation generate the wrong result, which cause the last shard have more batches than the max_num_batches,
the last process will stuck on the grads sync.

Here is an example P60390119

```
Give len(dataset) = 122, world_size = 8, batch_size = 64

num_examples_per_device ==> [15, 15, 15, 15, 15, 15, 15, 17]

batch_size = batch_size // world_size ==> 64 // 8 = 8
num_all_batches = math.ceil(len(train_dataset) / float(batch_size)) ==> ceil(122 / 8.0) = 16
total_num_batches = math.ceil(num_all_batches / float(world_size)) ==> ceil(16 / 8.0) = 2

We pass total_num_batches = 2 in all BatchIterator, but the last shard have 17 examples, which batch_size is 3

Differential Revision: D13311684
