### PR TITLE
rename getting_started to hack_on_python

### DIFF
--- a/pytext/docs/source/hack_on_pytext.rst
+++ b/pytext/docs/source/hack_on_pytext.rst
@@ -1,23 +1,23 @@
-Getting started guide
-=====================
+Hack on PyText
+==============
 
 To get started, run the following commands in a terminal::
 
-		git clone git@github.com:facebookresearch/pytext.git
-		cd pytext
+		$ git clone git@github.com:facebookresearch/pytext.git
+		$ cd pytext
 
-		source activation_venv
-		./install_deps
-		./run_tests
+		$ source activation_venv
+		(pytext) $ ./install_deps
+		(pytext) $ ./run_tests
 
 To resume development in an already checked-out repo::
 
-		cd pytext
-		source activation_venv
+		$ cd pytext
+		$ source activation_venv
 
 To exit the virtual environment::
 
-		deactivate
+		(pytext) $ deactivate
 
 
 Alternatively, if you don't want to run in a virtual env, you can install the dependencies globally with `sudo ./install_deps`.

--- a/pytext/docs/source/index.rst
+++ b/pytext/docs/source/index.rst
@@ -31,7 +31,7 @@ PyText is a deep-learning based NLP modeling framework built on PyTorch. PyText 
   :caption: Getting Started
 
   installation
-  getting_started
+  hack_on_pytext
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
Rename the "Getting Started" tutorial to "Hack on PyText" as it is centered around installing PyText from GitHub to be able to make and test local changes to PyText.