### PR TITLE
add predict for pytorch model

### DIFF
--- a/pytext/data/joint_data_handler.py
+++ b/pytext/data/joint_data_handler.py
@@ -127,15 +127,15 @@ class JointModelDataHandler(DataHandler):
             DatasetFieldName.TOKEN_RANGE: features.token_ranges,
         }
         if DatasetFieldName.DOC_LABEL_FIELD in self.labels:
-            res[DatasetFieldName.DOC_LABEL_FIELD] = row_data[DFColumn.DOC_LABEL]
+            res[DatasetFieldName.DOC_LABEL_FIELD] = row_data.get(DFColumn.DOC_LABEL)
         if DatasetFieldName.WORD_LABEL_FIELD in self.labels:
             # TODO move it into word label field
             res[DatasetFieldName.WORD_LABEL_FIELD] = data_utils.align_slot_labels(
                 features.token_ranges,
-                row_data[DFColumn.WORD_LABEL],
+                row_data.get(DFColumn.WORD_LABEL),
                 self.labels[DatasetFieldName.WORD_LABEL_FIELD].use_bio_labels,
             )
-            res[DatasetFieldName.RAW_WORD_LABEL] = row_data[DFColumn.WORD_LABEL]
+            res[DatasetFieldName.RAW_WORD_LABEL] = row_data.get(DFColumn.WORD_LABEL)
         return res
 
     def _train_input_from_batch(self, batch):

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -12,7 +12,12 @@ import torch
 from pytext import create_predictor
 from pytext.config import PyTextConfig, TestConfig
 from pytext.config.serialize import config_from_json, config_to_json
-from pytext.workflow import export_saved_model_to_caffe2, test_model, train_model
+from pytext.workflow import (
+    batch_predict,
+    export_saved_model_to_caffe2,
+    test_model,
+    train_model,
+)
 from torch.multiprocessing.spawn import spawn
 
 
@@ -154,7 +159,7 @@ def export(context, model, output_path):
 
 
 @main.command()
-@click.option("--exported-model", help="where to save the exported model")
+@click.option("--exported-model", help="where to load the exported model")
 @click.pass_context
 def predict(context, exported_model):
     """Start a repl executing examples against a caffe2 model."""
@@ -167,6 +172,17 @@ def predict(context, exported_model):
         input = json.loads(line)
         predictions = predictor(input)
         pprint.pprint(predictions)
+
+
+@main.command()
+@click.option("--model-file", help="where to load the pytorch model")
+@click.pass_context
+def predict_py(context, model_file):
+    """Start a repl executing examples against a PyTorch model."""
+    print("Reading example JSON from stdin")
+    examples = [json.loads(line) for line in sys.stdin.readlines()]
+    result = batch_predict(model_file, examples)
+    pprint.pprint(result)
 
 
 if __name__ == "__main__":

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -104,7 +104,7 @@ class Model(nn.Module, Component):
     def get_loss(self, logit, target, context):
         return self.output_layer.get_loss(logit, target, context)
 
-    def get_pred(self, logit, target, context, *args):
+    def get_pred(self, logit, target=None, context=None, *args):
         return self.output_layer.get_pred(logit, target, context)
 
     def forward(self, *inputs) -> List[torch.Tensor]:

--- a/pytext/utils/data_utils.py
+++ b/pytext/utils/data_utils.py
@@ -78,6 +78,8 @@ def parse_json_array(json_text: str) -> List[str]:
 def align_slot_labels(
     token_ranges: List[Tuple[int, int]], slots_field: str, use_bio_labels: bool = False
 ):
+    if not slots_field:
+        return ""
     slot_list = parse_slot_string(slots_field)
 
     token_labels = []

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import os
-from typing import Any, Tuple, get_type_hints
+from typing import Any, Dict, List, Tuple, get_type_hints
 
 import torch
 from pytext.config import PyTextConfig, TestConfig
@@ -113,3 +113,8 @@ def test_model(test_config: TestConfig, metrics_channel: Channel = None) -> Any:
         task.test(test_config.test_path),
         train_config.task.metric_reporter.output_path,
     )
+
+
+def batch_predict(model_file: str, examples: List[Dict[str, Any]]):
+    task, train_config = load(model_file)
+    return task.predict(examples)


### PR DESCRIPTION
Summary:
support doc, word and joint model now, usage:
  buck run mode/dev-nosan pytext/fb/assistant/nlu:main --    predict_py --model-file="model.pt" < doc_test_data

Differential Revision: D13253874
