### PR TITLE
Per-token MLP layers in pytext WordEmbedding

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -27,6 +27,7 @@ class WordFeatConfig(ConfigBase):
     vocab_from_all_data: bool = False  # build vocab from train, eval, test data
     lowercase_tokens: bool = True
     min_freq: int = 1
+    mlp_layer_dims: Optional[List[int]] = []
 
 
 class DictFeatConfig(ConfigBase):

--- a/pytext/models/test/embedding_list_test.py
+++ b/pytext/models/test/embedding_list_test.py
@@ -15,6 +15,7 @@ class EmbeddingListTest(unittest.TestCase):
             embeddings_weight=None,
             init_range=[-1, 1],
             unk_token_idx=4,
+            mlp_layer_dims=[],
         )
         char_embedding = CharacterEmbedding(
             num_embeddings=5, embed_dim=4, out_channels=2, kernel_sizes=[1, 2]

--- a/pytext/models/test/word_embedding_test.py
+++ b/pytext/models/test/word_embedding_test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from pytext.models.embeddings.word_embedding import WordEmbedding
+
+
+class WordEmbeddingTest(unittest.TestCase):
+    def test_basic(self):
+        # Setup embedding
+        num_embeddings = 5
+        output_dim = 6
+        embedding_module = WordEmbedding(
+            num_embeddings=num_embeddings,
+            embedding_dim=4,
+            embeddings_weight=None,
+            init_range=[-1, 1],
+            unk_token_idx=4,
+            mlp_layer_dims=[3, output_dim],
+        )
+        self.assertEqual(embedding_module.embedding_dim, output_dim)
+
+        # Check output shape
+        input_batch_size, input_len = 4, 6
+        token_ids = torch.randint(
+            low=0, high=num_embeddings, size=[input_batch_size, input_len]
+        )
+        output_embedding = embedding_module(token_ids)
+        expected_output_dims = [input_batch_size, input_len, output_dim]
+        self.assertEqual(list(output_embedding.size()), expected_output_dims)


### PR DESCRIPTION
Summary: Implement option to add per-token MLP layers on top of the embedding lookup, in pytext's WordEmbedding module.

Differential Revision: D13310431
