### PR TITLE
Clean up MetricReporter

### DIFF
--- a/pytext/metric_reporters/classification_metric_reporter.py
+++ b/pytext/metric_reporters/classification_metric_reporter.py
@@ -26,7 +26,6 @@ class IntentModelChannel(FileChannel):
 
 
 class ClassificationMetricReporter(MetricReporter):
-    model_select_metric_name = "f1"
 
     def __init__(self, label_names: List[str], channels: List[Channel]) -> None:
         super().__init__(channels)

--- a/pytext/metric_reporters/compositional_metric_reporter.py
+++ b/pytext/metric_reporters/compositional_metric_reporter.py
@@ -42,7 +42,6 @@ class CompositionalFileChannel(FileChannel):
 
 
 class CompositionalMetricReporter(MetricReporter):
-    model_select_metric_name = "frame_accuracy"
 
     def __init__(self, actions_vocab, channels: List[Channel]) -> None:
         super().__init__(channels)

--- a/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
+++ b/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
@@ -89,7 +89,6 @@ def create_frame(intent_label, slot_names_str, utterance):
 
 
 class IntentSlotMetricReporter(MetricReporter):
-    model_select_metric_name = "frame_accuracy"
 
     def __init__(
         self,

--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -22,7 +22,6 @@ class LanguageModelChannel(FileChannel):
 
 
 class LanguageModelMetricReporter(MetricReporter):
-    model_select_metric_name = "perplexity_per_word"
     lower_is_better = True
 
     @classmethod

--- a/pytext/metric_reporters/word_tagging_metric_reporter.py
+++ b/pytext/metric_reporters/word_tagging_metric_reporter.py
@@ -27,7 +27,6 @@ def get_slots(word_names):
 
 
 class WordTaggingMetricReporter(MetricReporter):
-    model_select_metric_name = "f1"
 
     def __init__(
         self, label_names: List[str], use_bio_labels: bool, channels: List[Channel]


### PR DESCRIPTION
Summary: remove model_select_metric_name as it was only used for FBL learning rate report which is not used anymore

Differential Revision: D13345779
