### PR TITLE
Fix batch size mismatch issue

### DIFF
--- a/pytext/utils/data_utils.py
+++ b/pytext/utils/data_utils.py
@@ -78,8 +78,7 @@ def parse_json_array(json_text: str) -> List[str]:
 def align_slot_labels(
     token_ranges: List[Tuple[int, int]], slots_field: str, use_bio_labels: bool = False
 ):
-    if not slots_field:
-        return ""
+    slots_field = slots_field or ""
     slot_list = parse_slot_string(slots_field)
 
     token_labels = []

--- a/pytext/utils/tests/utils_test.py
+++ b/pytext/utils/tests/utils_test.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from pytext.utils import test_utils
+from pytext.utils.data_utils import align_slot_labels
 
 
 RAW_TEST_PATH = os.path.join(
@@ -19,7 +20,7 @@ def get_test_sample():
     return data
 
 
-class TestUtilTest(unittest.TestCase):
+class UtilTest(unittest.TestCase):
     def test_merge_token_labels_to_slot(self):
         data = get_test_sample()
         for i in data:
@@ -35,3 +36,18 @@ class TestUtilTest(unittest.TestCase):
                 ),
                 i["output"],
             )
+
+    def test_align_slot_labels(self):
+        self.assertEqual(
+            align_slot_labels(
+                [[0, 4], [5, 8], [9, 14], [15, 19], [20, 25]],
+                "20:25:music/type,5:14:music/artistName",
+                True,
+            ),
+            "NoLabel B-music/artistName I-music/artistName NoLabel B-music/type",
+        )
+
+    def test_align_slot_labels_with_none_label(self):
+        self.assertEqual(
+            align_slot_labels([[0, 4], [5, 8]], None, True), "NoLabel NoLabel"
+        )


### PR DESCRIPTION
Summary: align_slot_labels function returns a list of "No-label" when slots_field is empty string, so should not just return "" when it's None

Reviewed By: chenyangyu1988

Differential Revision: D13356159
