### PR TITLE
In data handler, make min_freq and lowercase_tokens recognized

### DIFF
--- a/pytext/fields/field.py
+++ b/pytext/fields/field.py
@@ -196,10 +196,11 @@ class TextFeatureField(VocabUsingField):
         unk_token=VocabMeta.UNK_TOKEN,
         init_token=None,
         eos_token=None,
-        lower=True,
+        lower=False,
         tokenize=data_utils.no_tokenize,
         fix_length=None,
         pad_first=None,
+        min_freq=1,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -223,6 +224,7 @@ class TextFeatureField(VocabUsingField):
             tokenize=tokenize,
             fix_length=fix_length,
             pad_first=pad_first,
+            min_freq=min_freq,
         )
 
 


### PR DESCRIPTION
Summary:
* Made the `min_freq` option recognized. This is required for proper UNKificiation in RNNG, which is triggered only when `min_freq` is more than 1.
* Lower-casing should be specified in the Featurizer instead of the Field. I changed the default `lower` option in the `TextFeatureField` to False to prevent it from silently lower-casing everything.

Differential Revision: D13347959
