### PR TITLE
Readme specifies Python Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ PyText is a deep-learning based NLP modeling framework built on PyTorch. PyText 
 
 # Installing PyText
 
+## WARNING: PyText currently only supports Python 3.6. Support for 3.7 is coming soon!
+
 To get started, run the following commands in a terminal:
 
 ```


### PR DESCRIPTION
Summary: Add an angry warning that you can only use Python 3.6.
Test Plan: Not Necessary