### PR TITLE
Simplify run_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - checkout
-      - run: source .circleci/setup_circleimg.sh && ./run_tests && ./run_coverage
+      - run: source .circleci/setup_circleimg.sh && pytest && ./run_coverage
       - store_artifacts:
           path: htmlcov
           destination: coverage

--- a/.circleci/setup_circleimg.sh
+++ b/.circleci/setup_circleimg.sh
@@ -3,3 +3,4 @@ sudo apt-get update
 sudo apt-get install -y cmake python-pip python-dev build-essential protobuf-compiler libprotoc-dev
 sudo ./install_deps
 sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+sudo pip install --progress-bar off pytest

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ source activation_venv
 ./install_deps
 ```
 [Install PyTorch Using Pip](https://pytorch.org/) make sure to get the correct version for your OS and GPU Situation.
-Once that is installed, you can run the unit tests with:
+Once that is installed, you can run the unit tests. We reccomend using pytest as a runner.
 ```
-./run_tests
+pip install -U pytest
+pytest
 ```
 
 To resume development in an already checked-out repo:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:.*caffe2.*

--- a/pytext/docs/source/hack_on_pytext.rst
+++ b/pytext/docs/source/hack_on_pytext.rst
@@ -10,9 +10,10 @@ To get started, run the following commands in a terminal::
 		(pytext) $ ./install_deps
 
 Next Install the PyTorch using Pip using the instructions on https://pytorch.org, making sure to match your OS and GPU situation
-Once you're done with that, you can run the tests with::
-  
-		(pytext) $ ./run_tests
+Once you're done with that, you can run the tests. We recommend using pytest::
+     
+		(pytext) $ pip install -U pytest
+		(pytext) $ pytest
 
 To resume development in an already checked-out repo::
 

--- a/pytext/metrics/tests/basic_metrics_test.py
+++ b/pytext/metrics/tests/basic_metrics_test.py
@@ -12,7 +12,7 @@ from pytext.metrics import (
     compute_soft_metrics,
 )
 
-from .metrics_test_base import MetricsTestBase
+from pytext.metrics.tests.metrics_test_base import MetricsTestBase
 
 
 LABEL_NAMES1 = ["label1", "label2", "label3"]

--- a/pytext/metrics/tests/intent_slot_metrics_test.py
+++ b/pytext/metrics/tests/intent_slot_metrics_test.py
@@ -21,7 +21,7 @@ from pytext.metrics.intent_slot_metrics import (
     compute_top_intent_accuracy,
 )
 
-from .metrics_test_base import MetricsTestBase
+from pytext.metrics.tests.metrics_test_base import MetricsTestBase
 
 
 TEST_EXAMPLES: List[Dict[str, Any]] = [

--- a/run_tests
+++ b/run_tests
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-find pytext tests -name \*test\*.py -depth  -exec python3 -m unittest -b {} +


### PR DESCRIPTION
Summary:
This greatly simplifies both the actual command, but also greatly increases the signal when running the tests.
The tests are all still run, but run in a single process which means the results are summarized in a single place. Further, by using the buffer option (`-b`) we suppress most of the output besides those of failing tests.

This diff also lays the groundwork for introducing xml reporting in circleci in the future, by consolidating results into a single process.
Test Plan:
```
(venv) cmd-mbp:pytext cmd$ ./run_tests
WARNING:root:This caffe2 python run does not have GPU support. Will run in CPU only mode.
INFO:caffe2.python.net_drawer:Cannot import pydot, which is required for drawing a network. This can usually be installed in python with "pip install pydot". Also, pydot requires graphviz to convert dot files to pdf: in ubuntu, this can usually be installed with "sudo apt-get install graphviz".
net_drawer will not run correctly. Please install the correct dependencies.
/Users/cmd/code/pytext/venv/lib/python3.6/site-packages/hypothesis/_settings.py:197: HypothesisDeprecationWarning:
The min_satisfying_examples setting has been deprecated and disabled, due to
overlap with the filter_too_much healthcheck and poor interaction with the
max_examples setting.

  note_deprecation(d.deprecation_message, self)
............................................[E init_intrinsics_check.cc:43] CPU feature avx is present on your machine, but the Caffe2 binary is not compiled with it. It means you may not get the full speed of your CPU.
[E init_intrinsics_check.cc:43] CPU feature avx2 is present on your machine, but the Caffe2 binary is not compiled with it. It means you may not get the full speed of your CPU.
[E init_intrinsics_check.cc:43] CPU feature fma is present on your machine, but the Caffe2 binary is not compiled with it. It means you may not get the full speed of your CPU.
...................................
----------------------------------------------------------------------
Ran 79 tests in 9.036s

OK
```
I also turned a test into a failure in order to validate they show up.