### PR TITLE
Use JUnit test results for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,19 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - checkout
-      - run: source .circleci/setup_circleimg.sh && pytest && ./run_coverage
+      - run: 
+          name: setup
+          command: source .circleci/setup_circleimg.sh 
+      - run:
+          name: run tests
+          command: pytest --junitxml=test-reports/junit.xml
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports      
+      - run:
+          name: collect coverage
+          command: ./run_coverage
       - store_artifacts:
           path: htmlcov
           destination: coverage


### PR DESCRIPTION
Summary:
Use the built in support for JUnit style xml output in pytest to provide test level metadata to circleci. Following instructions found here:
https://circleci.com/docs/2.0/collect-test-data/#pytest
Test Plan:
circleci will do it