### PR TITLE
Test all configs

### DIFF
--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -4,6 +4,12 @@ from enum import Enum
 from typing import Dict, List, Tuple, Union
 
 from .component import Registry
+from .pytext_config import PyTextConfig, TestConfig
+
+
+class Mode(Enum):
+    TRAIN = "train"
+    TEST = "test"
 
 
 class ConfigParseError(Exception):
@@ -196,3 +202,15 @@ def config_to_json(cls, config_obj):
         value = getattr(config_obj, field)
         json_result[field] = _value_to_json(f_cls, value)
     return json_result
+
+
+def parse_config(mode, config_json):
+    """
+    Parse PyTextConfig object from parameter string or parameter file
+    """
+    config_cls = {Mode.TRAIN: PyTextConfig, Mode.TEST: TestConfig}[mode]
+    # TODO T32608471 should assume the entire json is PyTextConfig later, right
+    # now we're matching the file format for pytext trainer.py inside fbl
+    if "config" not in config_json:
+        return config_from_json(config_cls, config_json)
+    return config_from_json(config_cls, config_json["config"])

--- a/pytext/config/test/pytext_all_config_test.py
+++ b/pytext/config/test/pytext_all_config_test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import glob
+import json
+import unittest
+
+from pytext.builtin_task import register_builtin_tasks
+from pytext.config.serialize import Mode, parse_config
+
+
+register_builtin_tasks()
+
+
+# These JSON files are not parseable configs
+EXCLUDE_JSON = {
+    # used by test_merge_token_labels_to_slot
+    "pytext/utils/tests/test_samples.json"
+}
+
+
+class LoadAllConfigTest(unittest.TestCase):
+    def test_load_all_configs(self):
+        """
+            Try an load all the json files in pytext to make sure we didn't
+            break the config API.
+        """
+        print()
+        for filename in glob.iglob("pytext/**/*.json", recursive=True):
+            if filename in EXCLUDE_JSON:
+                continue
+            print("--- loading:", filename)
+            with open(filename) as file:
+                config_json = json.load(file)
+                # Most configs don't work in Mode.TEST
+                config = parse_config(Mode.TRAIN, config_json)
+                self.assertIsNotNone(config)

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import enum
 import json
 import pprint
 import sys
@@ -11,7 +10,7 @@ import click
 import torch
 from pytext import create_predictor
 from pytext.config import PyTextConfig, TestConfig
-from pytext.config.serialize import config_from_json, config_to_json
+from pytext.config.serialize import Mode, config_from_json, config_to_json, parse_config
 from pytext.task import load
 from pytext.utils.documentation_helper import (
     ROOT_CONFIG,
@@ -27,26 +26,9 @@ from pytext.workflow import (
 from torch.multiprocessing.spawn import spawn
 
 
-class Mode(enum.Enum):
-    TRAIN = "train"
-    TEST = "test"
-
-
 class Attrs:
     def __repr__(self):
         return f"Attrs({', '.join(f'{k}={v}' for k, v in vars(self).items())})"
-
-
-def parse_config(mode, config_json):
-    """
-    Parse PyTextConfig object from parameter string or parameter file
-    """
-    config_cls = {Mode.TRAIN: PyTextConfig, Mode.TEST: TestConfig}[mode]
-    # TODO T32608471 should assume the entire json is PyTextConfig later, right
-    # now we're matching the file format for pytext trainer.py inside fbl
-    if "config" not in config_json:
-        return config_from_json(config_cls, config_json)
-    return config_from_json(config_cls, config_json["config"])
 
 
 def train_model_distributed(config):


### PR DESCRIPTION
Summary:
Try and load all json configs to see if they're still parseable.

Some of the json files in pytxt are not configs, some are but don't
work. So I'm including a black list of files to skip. We can fix the broken
ones later.

Differential Revision: D13390698
