### PR TITLE
Build actions field with all data by default and don't rebuild vocab.

### DIFF
--- a/pytext/data/compositional_data_handler.py
+++ b/pytext/data/compositional_data_handler.py
@@ -180,8 +180,13 @@ class CompositionalDataHandler(DataHandler):
                     "\nTokens from Featurizer and Seqlogical format are not same "
                     + f'for the utterance "{utterance}"'
                 )
-                print(f"Tokens from Featurizer: {features.tokens}")
-                print(f"Tokens from Seqlogical format: {tokens_from_seqlogical}")
+                print(
+                    f"{len(features.tokens)} tokens from Featurizer: {features.tokens}"
+                )
+                print(
+                    f"{len(tokens_from_seqlogical)} tokens from Seqlogical format: "
+                    + f"{tokens_from_seqlogical}"
+                )
                 return {}
 
         return {

--- a/pytext/data/data_handler.py
+++ b/pytext/data/data_handler.py
@@ -395,7 +395,7 @@ class DataHandler(Component):
                         min_freq=feat.min_freq,
                     )
                 else:
-                    print(f"Vocab for feature {name} has been built. Not building.")
+                    print(f"Vocab for feature {name} has been built. Not rebuilding.")
                 print("{} field's vocabulary size is {}".format(name, len(feat.vocab)))
 
                 # Initialize pretrained embedding weights.
@@ -428,13 +428,16 @@ class DataHandler(Component):
             # appear in train and eval but test can have B-[Label] and I-[Label]
 
             if label.use_vocab:
-                print("Building vocab for label {}".format(name))
-                label.build_vocab(train_data, eval_data, test_data)
-                print(
-                    "{} field's vocabulary size is {}".format(
-                        name, len(label.vocab.itos)
+                if not hasattr(label, "vocab"):  # Don't rebuild vocab
+                    print("Building vocab for label {}".format(name))
+                    label.build_vocab(train_data, eval_data, test_data)
+                    print(
+                        "{} field's vocabulary size is {}".format(
+                            name, len(label.vocab.itos)
+                        )
                     )
-                )
+                else:
+                    print(f"Vocab for label {name} has been built. Not rebuilding.")
 
         self.metadata.target = [field.get_meta() for field in self.labels.values()]
         if len(self.metadata.target) == 1:

--- a/pytext/fields/field.py
+++ b/pytext/fields/field.py
@@ -317,4 +317,5 @@ class ActionField(VocabUsingField):
             tokenize=data_utils.no_tokenize,
             unk_token=None,  # Don't include UNK in the list of labels
             pad_token=None,  # Don't include PAD in the list of labels
+            vocab_from_all_data=True,  # Actions must be built from all data.
         )


### PR DESCRIPTION
Summary:
Currently, actions field is built with training data only and action label is built with all data. This doesn't pose a problem in functionality because they share the same `ActionsField` object. However, the logging is misleading as it shows that they are not same when eval/test data has extra actions.

Fix this logging error by setting `vocab_from_all_data=True` by default for ActionsField and not rebuilding lael fields if they are built already.

Differential Revision: D13394031
