### PR TITLE
Make disjoint multitask work with externally registered tasks

### DIFF
--- a/pytext/task/__init__.py
+++ b/pytext/task/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .serialize import load, save
-from .task import Task, create_task
+from .task import Task, TaskBase, create_task
 
 
-__all__ = ["Task", "save", "load", "create_task"]
+__all__ = ["Task", "TaskBase", "save", "load", "create_task"]

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from collections import OrderedDict
 from pprint import pprint
-from typing import Dict, Union
+from typing import Dict
 
 from pytext.config import config_to_json
 from pytext.config.component import (
@@ -21,34 +21,16 @@ from pytext.optimizer import create_optimizer
 from pytext.optimizer.scheduler import Scheduler
 from pytext.utils import cuda_utils
 
-from . import Task
-from .tasks import (
-    ContextualIntentSlotTask,
-    DocClassificationTask,
-    LMTask,
-    SemanticParsingTask,
-    SeqNNTask,
-    WordTaggingTask,
-)
+from . import Task, TaskBase
 
 
-class DisjointMultitask(Task):
+class DisjointMultitask(TaskBase):
     """Modules which have the same shared_module_key and type share parameters.
        Only the first instance of such module should be configured in tasks list.
     """
 
-    class Config(Task.Config):
-        tasks: Dict[
-            str,
-            Union[
-                DocClassificationTask.Config,
-                WordTaggingTask.Config,
-                LMTask.Config,
-                SeqNNTask.Config,
-                ContextualIntentSlotTask.Config,
-                SemanticParsingTask.Config,
-            ],
-        ]
+    class Config(TaskBase.Config):
+        tasks: Dict[str, Task.Config]
         data_handler: DisjointMultitaskDataHandler.Config = DisjointMultitaskDataHandler.Config()
         metric_reporter: DisjointMultitaskMetricReporter.Config = DisjointMultitaskMetricReporter.Config()
 

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -38,14 +38,13 @@ def create_task(task_config, metadata=None, model_state=None):
     return create_component(ComponentType.TASK, task_config, metadata, model_state)
 
 
-class Task(Component):
+class TaskBase(Component):
     """
     Task is the central place to define and wire up components for data processing,
     model training, metric reporting, etc. Task class has a Config class containing
     the config of each component in a descriptive way.
     """
 
-    __EXPANSIBLE__ = True
     __COMPONENT_TYPE__ = ComponentType.TASK
 
     class Config(ConfigBase):
@@ -220,3 +219,7 @@ class Task(Component):
         ):
             results[idx] = result
         return results
+
+
+class Task(TaskBase):
+    __EXPANSIBLE__ = True

--- a/pytext/utils/embeddings_utils.py
+++ b/pytext/utils/embeddings_utils.py
@@ -31,7 +31,7 @@ class PretrainedEmbedding(object):
                 raw_embeddings_path = embeddings_path
             else:
                 raise FileNotFoundError(
-                    "f{embeddings_path} not found. Can't load pretrained embeddings."
+                    f"{embeddings_path} not found. Can't load pretrained embeddings."
                 )
 
             if os.path.isfile(serialized_embed_path):


### PR DESCRIPTION
Summary: DisjointMultitask needs to Task to be __EXPANSIBLE__ to support tasks that are registered outside of PyText core.  This currently creates some stack-overflow issue with config parsing, because DisjointMultitask.Config has a field Task.Config, which expands into a union which also has DisjointMultitask.  As a workaround, I'm creating TaskBase, as the parent class of Task and only make Task __EXPANSIBLE__.  All tasks inherit from Task, DisjointMultitask inherits from TaskBase.

Differential Revision: D13404795
