### PR TITLE
Add copyright header and shebang linting to pytext shell files

### DIFF
--- a/.circleci/setup_circleimg.sh
+++ b/.circleci/setup_circleimg.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 sudo apt-get update
 sudo apt-get install -y cmake python-pip python-dev build-essential protobuf-compiler libprotoc-dev
 sudo ./install_deps

--- a/demo/flask_server/setup.sh
+++ b/demo/flask_server/setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh


### PR DESCRIPTION
Summary: Copyright headers need to be applied to shell files in OSS. Made a lint rule and applied it to all scripts which didn't have it.

Differential Revision: D13412160
