### PR TITLE
Ensure MLP layers on word embeddings are not frozen

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -16,7 +16,7 @@ class EmbedInitStrategy(Enum):
 
 class WordFeatConfig(ConfigBase):
     embed_dim: int = 100
-    freeze: bool = False
+    freeze: bool = False  # only freezes embedding lookup, not MLP layers
     embedding_init_strategy: EmbedInitStrategy = EmbedInitStrategy.RANDOM
     embedding_init_range: Optional[List[float]] = None
     export_input_names: List[str] = ["tokens_vals"]

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -82,6 +82,7 @@ class WordEmbedding(EmbeddingBase):
         # Create MLP layers
         self.mlp_layers = nn.ModuleList([])
         for next_dim in mlp_layer_dims or []:
+            assert next_dim > 0
             self.mlp_layers.append(nn.Linear(embedding_dim, next_dim))
             embedding_dim = next_dim
 
@@ -98,3 +99,7 @@ class WordEmbedding(EmbeddingBase):
             embedding = F.relu(embedding)
 
         return embedding
+
+    def freeze(self):
+        for param in self.word_embedding.parameters():
+            param.requires_grad = False

--- a/pytext/models/module.py
+++ b/pytext/models/module.py
@@ -49,8 +49,7 @@ def create_module(
         module.load_state_dict(torch.load(module_config.load_path))
     if getattr(module_config, "freeze", False):
         print(f"Freezing the parameters of module {name} ...")
-        for param in module.parameters():
-            param.requires_grad = False
+        module.freeze()
     if shared_module_key:
         SHARED_MODULE_REGISTRY[(shared_module_key, type(module_config))] = module
     return module
@@ -72,3 +71,7 @@ class Module(nn.Module, Component):
     def __init__(self, config=None) -> None:
         nn.Module.__init__(self)
         Component.__init__(self, config)
+
+    def freeze(self) -> None:
+        for param in self.parameters():
+            param.requires_grad = False

--- a/pytext/models/test/module_test.py
+++ b/pytext/models/test/module_test.py
@@ -32,13 +32,17 @@ class ModuleTest(unittest.TestCase):
         model = create_model(
             DocModel.Config(),
             FeatureConfig(
-                word_feat=WordFeatConfig(freeze=True), dict_feat=DictFeatConfig()
+                word_feat=WordFeatConfig(freeze=True, mlp_layers=[4]),
+                dict_feat=DictFeatConfig(),
             ),
             metadata=mock_metadata(),
         )
         # word embedding
-        for param in model.embedding[0].parameters():
+        for param in model.embedding[0].word_embedding.parameters():
             self.assertFalse(param.requires_grad)
+        for param in model.embedding[0].mlp_layers.parameters():
+            self.assertTrue(param.requires_grad)
+
         # dict feat embedding
         for param in model.embedding[1].parameters():
             self.assertTrue(param.requires_grad)


### PR DESCRIPTION
Summary: One intended use of MLP layers on word embeddings is to freeze the pretrained embeddings and learn the MLP layers during training. Currently, when the embedding's "freeze" param is True, `create_module()` freezes all of the embedding's param. This diff adds a call to a new `Module.freeze(config)` method, and the `WordEmbedding.freeze` overrides this to only freeze the embedding lookup.

Differential Revision: D13386266
