### PR TITLE
Add support for pretrained embedding feature export

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -49,6 +49,7 @@ class CharFeatConfig(ConfigBase):
 class PretrainedModelEmbeddingConfig(ConfigBase):
     embed_dim: int = 0
     model_paths: Optional[Dict[str, str]] = None
+    export_input_names: List[str] = ["pretrained_embeds"]
 
 
 class FloatVectorConfig(ConfigBase):

--- a/pytext/fields/pretrained_model_embedding_field.py
+++ b/pytext/fields/pretrained_model_embedding_field.py
@@ -6,7 +6,7 @@ from typing import List
 import torch
 from pytext.utils import data_utils
 
-from .field import Field
+from .field import Field, TextFeatureField
 
 
 class PretrainedModelEmbeddingField(Field):
@@ -19,6 +19,11 @@ class PretrainedModelEmbeddingField(Field):
             dtype=torch.float,
             unk_token=None,
             pad_token=None,
+        )
+        embed_dim = kwargs.get("embed_dim")
+        num_tokens = TextFeatureField.dummy_model_input.size(0)
+        self.dummy_model_input = torch.tensor(
+            [[[1.0] * embed_dim]] * num_tokens, dtype=torch.float, device="cpu"
         )
 
     def pad(self, minibatch: List[List[List[float]]]) -> List[List[List[float]]]:

--- a/pytext/models/representations/pass_through.py
+++ b/pytext/models/representations/pass_through.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import torch
+
+from .representation_base import RepresentationBase
+
+
+class PassThroughRepresentation(RepresentationBase):
+    def __init__(self, config: RepresentationBase.Config, embed_dim: int) -> None:
+        super().__init__(config)
+        self.representation_dim = embed_dim
+
+    def forward(self, embedded_tokens: torch.Tensor, *args) -> torch.Tensor:
+        return embedded_tokens

--- a/pytext/models/word_model.py
+++ b/pytext/models/word_model.py
@@ -8,6 +8,7 @@ from pytext.models.model import Model
 from pytext.models.output_layers import CRFOutputLayer, WordTaggingOutputLayer
 from pytext.models.representations.bilstm_slot_attn import BiLSTMSlotAttention
 from pytext.models.representations.biseqcnn import BSeqCNNRepresentation
+from pytext.models.representations.pass_through import PassThroughRepresentation
 
 
 class WordTaggingModel(Model):
@@ -24,7 +25,9 @@ class WordTaggingModel(Model):
 
     class Config(Model.Config):
         representation: Union[
-            BiLSTMSlotAttention.Config, BSeqCNNRepresentation.Config
+            BiLSTMSlotAttention.Config,
+            BSeqCNNRepresentation.Config,
+            PassThroughRepresentation.Config,
         ] = BiLSTMSlotAttention.Config()
         output_layer: Union[
             WordTaggingOutputLayer.Config, CRFOutputLayer.Config


### PR DESCRIPTION
Summary: Pretrained embedding features don't have support for getting exported. This diff adds the support. Point to jeep in mind is that the `PretrainedModelEmbeddingField.dummy_model_input` depends on `TextFeatureField.dummy_model_input`.

Differential Revision: D13421790
