### PR TITLE
add roc_auc metric

### DIFF
--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -187,12 +187,14 @@ class ClassificationMetrics(NamedTuple):
         macro_prf1_metrics: Macro precision/recall/F1 scores.
         per_label_soft_scores: Per label soft metrics.
         mcc: Matthews correlation coefficient.
+        roc_auc: Area under the Receiver Operating Characteristic curve.
     """
 
     accuracy: float
     macro_prf1_metrics: MacroPRF1Metrics
     per_label_soft_scores: Optional[Dict[str, SoftClassificationMetrics]]
     mcc: Optional[float]
+    roc_auc: Optional[float]
 
     def print_metrics(self) -> None:
         print(f"Accuracy: {self.accuracy * 100:.2f}\n")
@@ -209,6 +211,8 @@ class ClassificationMetrics(NamedTuple):
                     print(f"\t{label:<10}\t{recall * 100:<10.2f}")
         if self.mcc:
             print(f"\nMatthews correlation coefficient: {self.mcc :.2f}")
+        if self.roc_auc:
+            print(f"\nROC AUC: {self.roc_auc:.3f}")
 
 
 class Confusions:
@@ -488,6 +492,32 @@ def compute_matthews_correlation_coefficients(
     return mcc
 
 
+def compute_roc_auc(predictions: Sequence[LabelPrediction]) -> Optional[float]:
+    """
+    Computes area under the Receiver Operating Characteristic curve, for binary
+    classification.
+    """
+    # Collect scores - arbitrarily select class 0 as positive, as metric is symmetric
+    y_true = [expected == 0 for _, _, expected in predictions]
+    y_score = [label_scores[0] for label_scores, _, _ in predictions]
+    y_true_sorted, _ = sort_by_score(y_true, y_score)
+
+    # Compute auc as probability that a positive example is scored higher than
+    # a negative example.
+    n_false = 0
+    n_correct_pair_order = 0
+
+    for y in reversed(y_true_sorted):  # want low predicted to high predicted
+        n_false += 1 - y
+        n_correct_pair_order += y * n_false
+
+    n_true = len(y_true) - n_false
+    if n_true == 0 or n_false == 0:
+        return None
+
+    return n_correct_pair_order / (n_true * n_false)
+
+
 def compute_classification_metrics(
     predictions: Sequence[LabelPrediction],
     label_names: Sequence[str],
@@ -537,12 +567,15 @@ def compute_classification_metrics(
         FN = confusion_dict[label_names[0]].FN
         TN = confusion_dict[label_names[1]].TP
         mcc: Optional[float] = compute_matthews_correlation_coefficients(TP, FP, FN, TN)
+        roc_auc: Optional[float] = compute_roc_auc(predictions)
     else:
         mcc = None
+        roc_auc = None
 
     return ClassificationMetrics(
         accuracy=accuracy,
         macro_prf1_metrics=macro_prf1_metrics,
         per_label_soft_scores=soft_metrics,
         mcc=mcc,
+        roc_auc=roc_auc,
     )

--- a/pytext/metrics/tests/basic_metrics_test.py
+++ b/pytext/metrics/tests/basic_metrics_test.py
@@ -59,6 +59,7 @@ class BasicMetricsTest(MetricsTestBase):
                 ),
                 per_label_soft_scores=None,
                 mcc=None,
+                roc_auc=None,
             ),
         )
 
@@ -84,3 +85,7 @@ class BasicMetricsTest(MetricsTestBase):
         self.assertAlmostEqual(metrics.mcc, 1.0 / 6)
         # Just to test the metrics print without errors
         metrics.print_metrics()
+
+    def test_compute_roc_auc(self) -> None:
+        metrics = compute_classification_metrics(PREDICTIONS2, LABEL_NAMES2)
+        self.assertAlmostEqual(metrics.roc_auc, 1.0 / 6)


### PR DESCRIPTION
Summary: Add roc_auc as one of the classification metrics. Implementation borrowed from https://www.ibm.com/developerworks/community/blogs/jfp/entry/Fast_Computation_of_AUC_ROC_score?lang=en.

Differential Revision: D13436532
