### PR TITLE
Enable shuffle data at each epoch

### DIFF
--- a/pytext/data/disjoint_multitask_data_handler.py
+++ b/pytext/data/disjoint_multitask_data_handler.py
@@ -45,9 +45,7 @@ class RoundRobinBatchIterator(BatchIterator):
     def __iter__(self):
         iterators = {
             name: iter(
-                itertools.cycle(iterator)
-                if (self.epoch_size < float("inf"))
-                else iterator
+                self.cycle(iterator) if (self.epoch_size < float("inf")) else iterator
             )
             for name, iterator in self.iterators.items()
         }
@@ -73,6 +71,12 @@ class RoundRobinBatchIterator(BatchIterator):
                 return
             context[BatchContext.TASK_NAME] = name
             yield input, target, context
+
+    @classmethod
+    def cycle(cls, iterator):
+        while True:
+            for item in iterator:
+                yield item
 
 
 class DisjointMultitaskDataHandler(DataHandler):

--- a/pytext/data/test/round_robin_batchiterator_test.py
+++ b/pytext/data/test/round_robin_batchiterator_test.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+from pytext.data.disjoint_multitask_data_handler import RoundRobinBatchIterator
+
+
+class RoundRobinBatchIteratorTest(unittest.TestCase):
+    def test_batch_iterator(self):
+        iteratorA = [(input, None, {}) for input in [1, 2, 3, 4]]
+        iteratorB = [(input, None, {}) for input in ["a", "b", "c"]]
+        round_robin_iterator = RoundRobinBatchIterator(
+            {"A": iteratorA, "B": iteratorB}, epoch_size=10
+        )
+        expected_output = [1, "a", 2, "b", 3, "c", 4, "a", 1, "b"]
+        for actual, expected in zip(round_robin_iterator, expected_output):
+            assert actual[0] == expected


### PR DESCRIPTION
Summary:
- Instead of using itertools.cycle, which repeats the iterator in the same sequence, just reuse the batch iterator.  If the batch iterator is set to shuffle data when initialized, this will result in data shuffling at each epoch.

- Also added a unit test for the round robin batch iterator, which technically should have been part of the original diff.

Differential Revision: D13408205
