### PR TITLE
Document top-level API a little, make testing from the command line easier.

### DIFF
--- a/pytext/__init__.py
+++ b/pytext/__init__.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import json
 import uuid
+from typing import Callable, Mapping, Optional
 
 import numpy as np
 from caffe2.python import workspace
 from caffe2.python.predictor import predictor_exporter
 
 from .builtin_task import register_builtin_tasks
+from .config import PyTextConfig, config_from_json
 from .config.component import create_featurizer
 from .data.featurizer import InputRecord
 from .utils.onnx_utils import CAFFE2_DB_TYPE, convert_caffe2_blob_name
 
 
 register_builtin_tasks()
+
+
+Predictor = Callable[[Mapping[str, str]], Mapping[str, np.array]]
 
 
 def _predict(workspace_id, feature_config, predict_net, featurizer, input):
@@ -49,7 +55,26 @@ def _predict(workspace_id, feature_config, predict_net, featurizer, input):
     }
 
 
-def create_predictor(config, model_file=None):
+def load_config(filename: str) -> PyTextConfig:
+    """
+    Load a PyText configuration file from a file path.
+    See pytext.config.pytext_config for more info on configs.
+    """
+    with open(filename) as file:
+        config_json = json.loads(file.read())
+    if "config" not in config_json:
+        return config_from_json(PyTextConfig, config_json)
+    return config_from_json(PyTextConfig, config_json["config"])
+
+
+def create_predictor(
+    config: PyTextConfig, model_file: Optional[str] = None
+) -> Predictor:
+    """
+    Create a simple prediction API from a training config and an exported caffe2
+    model file. This model file should be created by calling export on a trained
+    model snapshot.
+    """
     workspace_id = str(uuid.uuid4())
     workspace.SwitchWorkspace(workspace_id, True)
     predict_net = predictor_exporter.prepare_prediction_net(

--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -7,11 +7,6 @@ from .component import Registry
 from .pytext_config import PyTextConfig, TestConfig
 
 
-class Mode(Enum):
-    TRAIN = "train"
-    TEST = "test"
-
-
 class ConfigParseError(Exception):
     pass
 
@@ -219,13 +214,10 @@ def _get_class_type(cls):
     return cls.__origin__ if hasattr(cls, "__origin__") else cls
 
 
-def parse_config(mode, config_json):
+def parse_config(config_json):
     """
     Parse PyTextConfig object from parameter string or parameter file
     """
-    config_cls = {Mode.TRAIN: PyTextConfig, Mode.TEST: TestConfig}[mode]
-    # TODO T32608471 should assume the entire json is PyTextConfig later, right
-    # now we're matching the file format for pytext trainer.py inside fbl
     if "config" not in config_json:
-        return config_from_json(config_cls, config_json)
-    return config_from_json(config_cls, config_json["config"])
+        return config_from_json(PyTextConfig, config_json)
+    return config_from_json(PyTextConfig, config_json["config"])

--- a/pytext/config/test/pytext_all_config_test.py
+++ b/pytext/config/test/pytext_all_config_test.py
@@ -6,7 +6,7 @@ import json
 import unittest
 
 from pytext.builtin_task import register_builtin_tasks
-from pytext.config.serialize import Mode, parse_config
+from pytext.config.serialize import parse_config
 
 
 register_builtin_tasks()
@@ -32,6 +32,5 @@ class LoadAllConfigTest(unittest.TestCase):
             print("--- loading:", filename)
             with open(filename) as file:
                 config_json = json.load(file)
-                # Most configs don't work in Mode.TEST
-                config = parse_config(Mode.TRAIN, config_json)
+                config = parse_config(config_json)
                 self.assertIsNotNone(config)


### PR DESCRIPTION
Summary:
Add docstrings and types to a couple functions exported to the top-level PyText API.

Update the test cli mode to take in a PyTextConfig rather than a TestConfig for easier command line usage.

Differential Revision: D13367488
