### PR TITLE
fix type annotation of init_range and add pad_token_idx argument

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Tuple
 
 from pytext.common.constants import DatasetFieldName
 
@@ -18,7 +18,7 @@ class WordFeatConfig(ConfigBase):
     embed_dim: int = 100
     freeze: bool = False  # only freezes embedding lookup, not MLP layers
     embedding_init_strategy: EmbedInitStrategy = EmbedInitStrategy.RANDOM
-    embedding_init_range: Optional[List[float]] = None
+    embedding_init_range: Optional[Tuple[float, float]] = None
     export_input_names: List[str] = ["tokens_vals"]
     pretrained_embeddings_path: str = ""
     vocab_file: str = ""

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import List
+from typing import List, Tuple
 
 import torch
 import torch.nn as nn
@@ -62,7 +62,7 @@ class WordEmbedding(EmbeddingBase):
         num_embeddings: int,
         embedding_dim: int,
         embeddings_weight: torch.Tensor,
-        init_range: List[int],
+        init_range: Tuple[float, float],
         unk_token_idx: int,
         mlp_layer_dims: List[int],
     ) -> None:

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -54,6 +54,7 @@ class WordEmbedding(EmbeddingBase):
             embeddings_weight=metadata.pretrained_embeds_weight,
             init_range=config.embedding_init_range,
             unk_token_idx=metadata.unk_token_idx,
+            pad_token_idx=metadata.pad_token_idx,
             mlp_layer_dims=config.mlp_layer_dims,
         )
 
@@ -64,6 +65,7 @@ class WordEmbedding(EmbeddingBase):
         embeddings_weight: torch.Tensor,
         init_range: Tuple[float, float],
         unk_token_idx: int,
+        pad_token_idx: int,
         mlp_layer_dims: List[int],
     ) -> None:
         output_embedding_dim = mlp_layer_dims[-1] if mlp_layer_dims else embedding_dim
@@ -71,7 +73,8 @@ class WordEmbedding(EmbeddingBase):
 
         # Create word embedding
         self.word_embedding = nn.Embedding(
-            num_embeddings, embedding_dim, _weight=embeddings_weight
+            num_embeddings, embedding_dim,
+            padding_idx=pad_token_idx, _weight=embeddings_weight
         )
         if embeddings_weight is None and init_range:
             self.word_embedding.weight.data.uniform_(init_range[0], init_range[1])

--- a/pytext/models/test/embedding_list_test.py
+++ b/pytext/models/test/embedding_list_test.py
@@ -13,8 +13,9 @@ class EmbeddingListTest(unittest.TestCase):
             num_embeddings=5,
             embedding_dim=4,
             embeddings_weight=None,
-            init_range=[-1, 1],
+            init_range=(-1, 1),
             unk_token_idx=4,
+            pad_token_idx=3,
             mlp_layer_dims=[],
         )
         char_embedding = CharacterEmbedding(

--- a/pytext/models/test/module_test.py
+++ b/pytext/models/test/module_test.py
@@ -22,6 +22,7 @@ def mock_metadata():
     field_meta.vocab_size = 10
     field_meta.pretrained_embeds_weight = None
     field_meta.unk_token_idx = 0
+    field_meta.pad_token_idx = 1
     meta.features = {"word_feat": field_meta, "dict_feat": field_meta}
     meta.target = field_meta
     return meta

--- a/pytext/models/test/word_embedding_test.py
+++ b/pytext/models/test/word_embedding_test.py
@@ -17,6 +17,7 @@ class WordEmbeddingTest(unittest.TestCase):
             embeddings_weight=None,
             init_range=[-1, 1],
             unk_token_idx=4,
+            pad_token_idx=3,
             mlp_layer_dims=[3, output_dim],
         )
         self.assertEqual(embedding_module.embedding_dim, output_dim)


### PR DESCRIPTION
## Motivation and Context

- [x] fixed the type annotation of `init_range` of `pytext.models.WordEmbedding`
- [x] supported `pad_token_idx` in `pytext.models.WordEmbedding`

## How Has This Been Tested

All existing tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.