### PR TITLE
Update vocab handling

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -23,8 +23,10 @@ class WordFeatConfig(ConfigBase):
     pretrained_embeddings_path: str = ""
     vocab_file: str = ""
     vocab_size: int = 0
-    vocab_from_train_data: bool = True  # build vocab from train data
-    vocab_from_all_data: bool = False  # build vocab from train, eval, test data
+    vocab_from_train_data: bool = True  # add tokens from train data to vocab
+    vocab_from_all_data: bool = False  # add tokens from train, eval, test data to vocab
+    # add tokens from pretrained embeddings to vocab
+    vocab_from_pretrained_embeddings: bool = False
     lowercase_tokens: bool = True
     min_freq: int = 1
     mlp_layer_dims: Optional[List[int]] = []

--- a/pytext/data/test/datahandler_test.py
+++ b/pytext/data/test/datahandler_test.py
@@ -3,8 +3,13 @@
 
 import unittest
 
-from pytext.common.constants import DFColumn
+from pytext.common.constants import DFColumn, VocabMeta
+from pytext.config.component import create_featurizer
+from pytext.config.doc_classification import ModelInput, ModelInputConfig, TargetConfig
+from pytext.config.field_config import FeatureConfig, WordFeatConfig
 from pytext.data.data_handler import DataHandler
+from pytext.data.doc_classification_data_handler import DocClassificationDataHandler
+from pytext.data.featurizer import SimpleFeaturizer
 from pytext.utils.test_utils import import_tests_module
 
 
@@ -44,3 +49,111 @@ class DataHandlerTest(unittest.TestCase):
             "change my alarm tomorrow to wake me up 30 minutes earlier",
             data[0][DFColumn.UTTERANCE],
         )
+
+    def test_init_feature_metadata(self):
+        # Specify data
+        feat_name = ModelInput.WORD_FEAT
+        train_text = "Hi there you"
+        eval_text = ""
+        test_text = "Go away"
+        pretrained_embedding_file = tests_module.test_file("pretrained_embed_raw")
+        pretrained_tokens = {
+            "</s>",
+            "the",
+            "to",
+            "and",
+            "a",
+            "I",
+            "you",
+            "is",
+            "aloha",
+            "for",
+        }
+
+        # Specify test cases
+        test_cases = (
+            # Vocab from train / eval / test data
+            {
+                "feat": WordFeatConfig(
+                    vocab_from_all_data=True,
+                    vocab_from_train_data=False,
+                    vocab_from_pretrained_embeddings=False,
+                ),
+                "expected_tokens": {
+                    "hi",
+                    "there",
+                    "you",
+                    "go",
+                    "away",
+                    VocabMeta.UNK_TOKEN,
+                    VocabMeta.PAD_TOKEN,
+                },
+                "expected_num_pretrained_tokens": 0,
+            },
+            # Vocab from train data or pretrained embeddings
+            {
+                "feat": WordFeatConfig(
+                    vocab_from_all_data=False,
+                    vocab_from_train_data=True,
+                    vocab_from_pretrained_embeddings=True,
+                    pretrained_embeddings_path=pretrained_embedding_file,
+                    embed_dim=5,
+                ),
+                "expected_tokens": pretrained_tokens.union(
+                    {"hi", "there", VocabMeta.UNK_TOKEN, VocabMeta.PAD_TOKEN}
+                ),
+                "expected_num_pretrained_tokens": len(pretrained_tokens) + 4,
+            },
+            # Vocab from limited number of pretrained embeddings
+            {
+                "feat": WordFeatConfig(
+                    vocab_from_all_data=False,
+                    vocab_from_train_data=False,
+                    vocab_from_pretrained_embeddings=True,
+                    pretrained_embeddings_path=pretrained_embedding_file,
+                    embed_dim=5,
+                    vocab_size=2,
+                ),
+                "expected_tokens": {
+                    "</s>",
+                    "the",
+                    VocabMeta.UNK_TOKEN,
+                    VocabMeta.PAD_TOKEN,
+                },
+                # special tokens excluded from vocab_size = 2
+                "expected_num_pretrained_tokens": 4,
+            },
+        )
+
+        for case in test_cases:
+            # Setup data handler
+            featurizer = create_featurizer(
+                SimpleFeaturizer.Config(), FeatureConfig(word_feat=case["feat"])
+            )
+            data_handler = DocClassificationDataHandler.from_config(
+                DocClassificationDataHandler.Config(),
+                ModelInputConfig(word_feat=case["feat"]),
+                TargetConfig(),
+                featurizer=featurizer,
+            )
+            train_data = data_handler.gen_dataset(
+                [{"text": train_text}], include_label_fields=False
+            )
+            eval_data = data_handler.gen_dataset(
+                [{"text": eval_text}], include_label_fields=False
+            )
+            test_data = data_handler.gen_dataset(
+                [{"text": test_text}], include_label_fields=False
+            )
+            data_handler.init_feature_metadata(train_data, eval_data, test_data)
+
+            # Check created vocab
+            meta = data_handler.metadata.features[feat_name]
+            self.assertEqual(set(meta.vocab.stoi.keys()), case["expected_tokens"])
+            if case["expected_num_pretrained_tokens"] == 0:
+                self.assertIsNone(meta.pretrained_embeds_weight)
+            else:
+                self.assertEqual(
+                    meta.pretrained_embeds_weight.size(0),
+                    case["expected_num_pretrained_tokens"],
+                )

--- a/pytext/fields/field.py
+++ b/pytext/fields/field.py
@@ -104,8 +104,10 @@ class VocabUsingField(Field):
         embedding_init_strategy=EmbedInitStrategy.RANDOM,
         vocab_file="",
         vocab_size="",
-        vocab_from_train_data=True,  # build vocab from train data
-        vocab_from_all_data=False,  # build vocab from train, eval, test data
+        vocab_from_train_data=True,  # add tokens from train data to vocab
+        vocab_from_all_data=False,  # add tokens from train, eval, test data to vocab
+        # add tokens from pretrained embeddings to vocab
+        vocab_from_pretrained_embeddings=False,
         min_freq=1,
         *args,
         **kwargs,
@@ -116,6 +118,7 @@ class VocabUsingField(Field):
         self.vocab_size = vocab_size
         self.vocab_from_train_data = vocab_from_train_data
         self.vocab_from_all_data = vocab_from_all_data
+        self.vocab_from_pretrained_embeddings = vocab_from_pretrained_embeddings
         self.min_freq = min_freq
         self.embed_dim = embed_dim
         self.embedding_init_strategy = embedding_init_strategy
@@ -188,6 +191,7 @@ class TextFeatureField(VocabUsingField):
         vocab_size="",
         vocab_from_train_data=True,
         vocab_from_all_data=False,
+        vocab_from_pretrained_embeddings=False,
         postprocessing=None,
         use_vocab=True,
         include_lengths=True,
@@ -212,6 +216,7 @@ class TextFeatureField(VocabUsingField):
             vocab_size=vocab_size,
             vocab_from_train_data=vocab_from_train_data,
             vocab_from_all_data=vocab_from_all_data,
+            vocab_from_pretrained_embeddings=vocab_from_pretrained_embeddings,
             postprocessing=postprocessing,
             use_vocab=use_vocab,
             include_lengths=include_lengths,
@@ -239,6 +244,7 @@ class SeqFeatureField(VocabUsingNestedField):
         vocab_size="",
         vocab_from_train_data=True,
         vocab_from_all_data=False,
+        vocab_from_pretrained_embeddings=False,
         postprocessing=None,
         use_vocab=True,
         include_lengths=True,
@@ -257,6 +263,7 @@ class SeqFeatureField(VocabUsingNestedField):
             vocab_size=vocab_size,
             vocab_from_train_data=vocab_from_train_data,
             vocab_from_all_data=vocab_from_all_data,
+            vocab_from_pretrained_embeddings=vocab_from_pretrained_embeddings,
             postprocessing=postprocessing,
             use_vocab=use_vocab,
             include_lengths=include_lengths,

--- a/pytext/utils/tests/embeddings_utils_test.py
+++ b/pytext/utils/tests/embeddings_utils_test.py
@@ -43,16 +43,13 @@ class PretrainedEmbeddingTest(unittest.TestCase):
         self.assertEqual(pretrained_emb.embedding_vectors.size()[0], VOCAB_SIZE)
         self.assertEqual(pretrained_emb.embedding_vectors.size()[1], EMB_SIZE)
 
-    def test_init_pretrained_embeddings(self):
-        """Although not a method of PretrainedEmbedding, critical to test."""
+    def test_initialize_embeddings_weights(self):
         text_field = get_text_field()
-        pretrained_emb_tensor = embeddings_utils.init_pretrained_embeddings(
-            text_field.vocab.stoi,
-            RAW_EMBEDDING_PATH,
-            EMB_SIZE,
-            VocabMeta.UNK_TOKEN,
-            EmbedInitStrategy.ZERO,
-            text_field.lower,
+        pretrained_emb = embeddings_utils.PretrainedEmbedding(
+            RAW_EMBEDDING_PATH, text_field.lower
+        )
+        pretrained_emb_tensor = pretrained_emb.initialize_embeddings_weights(
+            text_field.vocab.stoi, VocabMeta.UNK_TOKEN, EMB_SIZE, EmbedInitStrategy.ZERO
         )
 
         self.assertEqual(pretrained_emb_tensor.size()[0], 4)

--- a/tests/pretrained_embeds_test.py
+++ b/tests/pretrained_embeds_test.py
@@ -62,16 +62,9 @@ class PretrainedEmbedsTest(unittest.TestCase):
         embeddings_ref.load_cached_embeddings(EMBED_CACHED_PATH)
         VOCAB = ["UNK", "aloha", "the"]
         EMBED_DIM = 5
-        # Get Vocab to Idx:
-        UNK_IDX = 0
-        embed_vocab_to_idx = {}
-        for word in embeddings_ref.embed_vocab:
-            if word in VOCAB:
-                embed_vocab_to_idx[word] = VOCAB.index(word)
-            else:
-                embed_vocab_to_idx[word] = UNK_IDX
+        embed_vocab_to_idx = {tok: i for i, tok in enumerate(VOCAB)}
         pretrained_embeds = embeddings_ref.initialize_embeddings_weights(
-            embed_vocab_to_idx, UNK_IDX, len(VOCAB), EMBED_DIM, EmbedInitStrategy.RANDOM
+            embed_vocab_to_idx, "UNK", EMBED_DIM, EmbedInitStrategy.RANDOM
         )
         assert pretrained_embeds.shape[0] == len(VOCAB)
         assert pretrained_embeds.shape[1] == EMBED_DIM
@@ -120,16 +113,9 @@ class PretrainedEmbedsTest(unittest.TestCase):
         embeddings_ref.load_cached_embeddings(EMBED_XLU_CACHED_PATH)
         VOCAB = ["UNK", "aloha-en_US", "the-es_XX"]
         EMBED_DIM = 5
-        # Get Vocab to Idx:
-        UNK_IDX = 0
-        embed_vocab_to_idx = {}
-        for word in embeddings_ref.embed_vocab:
-            if word in VOCAB:
-                embed_vocab_to_idx[word] = VOCAB.index(word)
-            else:
-                embed_vocab_to_idx[word] = UNK_IDX
+        embed_vocab_to_idx = {tok: i for i, tok in enumerate(VOCAB)}
         pretrained_embeds = embeddings_ref.initialize_embeddings_weights(
-            embed_vocab_to_idx, UNK_IDX, len(VOCAB), EMBED_DIM, EmbedInitStrategy.RANDOM
+            embed_vocab_to_idx, "UNK", EMBED_DIM, EmbedInitStrategy.RANDOM
         )
         assert pretrained_embeds.shape[0] == len(VOCAB)
         assert pretrained_embeds.shape[1] == EMBED_DIM


### PR DESCRIPTION
Summary:
Currently the vocab for WordEmbedding comes from the train / eval / test data or a special vocab file. Add flags to

- add all tokens from the pretrained embeddings to the vocab
  - this can be useful if the train data is small, and we want to keep a larger vocab size for the final model
- restrict the final vocab to be made of only tokens with pretrained embeddings
  - this can be useful if we want the vocab to be from the train data and we freeze the pretrained embeddings. Frozen random embeddings for new tokens wouldn't make sense.

Also change the parse mode for the pretrained embeddings file to "backslashreplace", to avoid any parsing errors. (anything that would have errored previously gets mapped to a reasonable string, and these are probably very rare tokens anyway).

Differential Revision: D13472879
