### PR TITLE
init metadata brefore spawn process

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -12,6 +12,7 @@ import torch
 from pytext import create_predictor
 from pytext.config import PyTextConfig
 from pytext.config.serialize import config_from_json, config_to_json, parse_config
+from pytext.data.data_handler import CommonMetadata
 from pytext.task import load
 from pytext.utils.documentation_helper import (
     ROOT_CONFIG,
@@ -22,6 +23,7 @@ from pytext.utils.documentation_helper import (
 )
 from pytext.workflow import (
     export_saved_model_to_caffe2,
+    prepare_task_metadata,
     test_model_from_snapshot_path,
     train_model,
 )
@@ -54,12 +56,15 @@ def train_model_distributed(config, summary_writer):
 
     print(f"\n=== Starting training, World size is {config.distributed_world_size}")
     if not config.use_cuda_if_available or not torch.cuda.is_available():
-        run_single(0, config_to_json(PyTextConfig, config), 1, None, summary_writer)
+        run_single(
+            0, config_to_json(PyTextConfig, config), 1, None, summary_writer, None
+        )
     else:
         with tempfile.NamedTemporaryFile(
             delete=False, suffix=".dist_sync"
         ) as sync_file:
             dist_init_method = "file://" + sync_file.name
+            metadata = prepare_task_metadata(config)
             spawn(
                 run_single,
                 (
@@ -67,6 +72,7 @@ def train_model_distributed(config, summary_writer):
                     config.distributed_world_size,
                     dist_init_method,
                     summary_writer,
+                    metadata,
                 ),
                 config.distributed_world_size,
             )
@@ -78,12 +84,15 @@ def run_single(
     world_size: int,
     dist_init_method: str,
     summary_writer: SummaryWriter,
+    metadata: CommonMetadata,
 ):
     config = config_from_json(PyTextConfig, config_json)
     if rank != 0:
         summary_writer = None
 
-    train_model(config, dist_init_method, rank, rank, world_size, summary_writer)
+    train_model(
+        config, dist_init_method, rank, rank, world_size, summary_writer, metadata
+    )
 
 
 def gen_config_impl(task_name, options):

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, get_type_hints
 import torch
 from pytext.config import PyTextConfig, TestConfig
 from pytext.config.component import create_exporter
+from pytext.data.data_handler import CommonMetadata
 from pytext.metric_reporters.channel import TensorBoardChannel
 from pytext.task import Task, create_task, load, save
 from pytext.utils.dist_utils import dist_init
@@ -45,6 +46,16 @@ def _set_cuda(
     )
 
 
+def prepare_task_metadata(config: PyTextConfig) -> CommonMetadata:
+    """
+    Loading the whole dataset into cpu memory on every single processes could
+    cause OOMs for data parallel distributed training.
+    To avoid such practice, we move the operations that required loading the
+    whole dataset out of spawn, and pass the context to every single process.
+    """
+    return create_task(config.task).data_handler.metadata
+
+
 def train_model(
     config: PyTextConfig,
     dist_init_url: str = None,
@@ -52,9 +63,10 @@ def train_model(
     rank: int = 0,
     world_size: int = 1,
     summary_writer: Optional[SummaryWriter] = None,
+    metadata: CommonMetadata = None,
 ) -> Tuple:
     task = prepare_task(
-        config, dist_init_url, device_id, rank, world_size, summary_writer
+        config, dist_init_url, device_id, rank, world_size, summary_writer, metadata
     )
     trained_model, best_metric = task.train(config, rank, world_size)
     # Only rank 0 gets to finalize the job and export the model
@@ -70,9 +82,11 @@ def prepare_task(
     rank: int = 0,
     world_size: int = 1,
     summary_writer: Optional[SummaryWriter] = None,
+    metadata: CommonMetadata = None,
 ) -> Task:
 
     if dist_init_url and world_size > 1:
+        assert metadata is not None
         dist_init(rank, world_size, dist_init_url)
 
     print("\nParameters: {}\n".format(config))
@@ -80,7 +94,7 @@ def prepare_task(
     if config.load_snapshot_path and os.path.isfile(config.load_snapshot_path):
         task = load(config.load_snapshot_path)
     else:
-        task = create_task(config.task)
+        task = create_task(config.task, metadata=metadata)
 
     if summary_writer:
         task.metric_reporter.add_channel(


### PR DESCRIPTION
Summary:
init metadata before spawn processes
Currently init_metadata will load the whole dataset for building vocab, and if we do this operation in every single process in distributed training, it will increase 8x memory usage which might cause OOMs given some dataset would take 30G (x8 is 240G).

Instead of init metadata inside each process, we prepare the distributed context (metadata) before spawn and pass metadata for create task

Differential Revision: D13503441
