### PR TITLE
load dataset shard for training

### DIFF
--- a/pytext/data/test/language_model_data_handler_test.py
+++ b/pytext/data/test/language_model_data_handler_test.py
@@ -47,6 +47,11 @@ class LanguageModelDataHandlerTest(unittest.TestCase):
         self.assertEqual(text_feat_meta.init_token_idx, 2)
         self.assertEqual(text_feat_meta.eos_token_idx, 3)
 
+        self.assertEqual(
+            data_handler.metadata.datasets_size.train_dataset_size,
+            len(data_handler.gen_dataset_from_path(FILE_NAME)),
+        )
+
         train_iter = data_handler.get_train_iter_from_path(FILE_NAME, BATCH_SIZE)
 
         batches = [t for t in train_iter]


### PR DESCRIPTION
Summary:
load dataset shard for training (not loading the whole dataset and then take the shard)
Currently get_train_iter will load the whole dataset for building vocab. It will increase 8x cpu memory usage in distributed training if we do this operation in every single process.
Instead of loading whole dataset into memory, we only need to load the dataset shard that will be processed by the process.

Same PytextConfig
Previously: f90142495 took more than 234G memory and cause OOMs
With the change: only took 84G, https://our.intern.facebook.com/intern/chronos/jobinstance/?jobinstanceid=3634641039&smc=chronos_gp_admin_client&log_type=stdout&offset=0&pretty_logs=false

Differential Revision: D13503488
