### PR TITLE
Updating model execution tutorial with DocNN configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,28 @@ jobs:
       - store_artifacts:
           path: htmlcov
           destination: coverage
+  build_docs:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: setup
+          command: source .circleci/setup_circleimg.sh
+      - run:
+          name: install_pytorch
+          command: sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+      - run:
+          name: install docs build deps
+          command: sudo pip install -r pytext/docs/requirements.txt
+      - run:
+          name: build docs
+          command: |
+              cd pytext/docs/
+              make html
+      - store_artifacts:
+          path: pytext/docs/build/html
+          destination: docs
   python_lint:
     docker:
       - image: circleci/python:3.6
@@ -67,3 +89,4 @@ workflows:
       - build_Py3.6
       - build_Py3.7
       - python_lint
+      - build_docs

--- a/pytext/docs/source/execute_your_first_model.rst
+++ b/pytext/docs/source/execute_your_first_model.rst
@@ -1,19 +1,7 @@
 Execute your first model
 =================================
 
-In :doc:`train_your_first_model`, we learnt how to train a very small, simple model. You can easily continue this tutorial with that model, but the results won't be very compelling. Here we'll use the much more powerful model from :doc:`atis_tutorial`. To make the commands below compatible with either, we recommend setting a shell variable to the config you're using.
-
-If you want to quickly run through this with the test model trained in the previous tutorial, do
-
-.. code-block:: console
-
-    (pytext) $ CONFIG=demo/configs/docnn.json
-
-If you're following along with the ATIS tutorial, use this config
-
-.. code-block:: console
-
-    (pytext) $ CONFIG=demo/atis_joint_model/atis_joint_config.json
+In :doc:`train_your_first_model`, we learnt how to train a very small, simple model. We can continue this tutorial with that model here, knowing that the results won't be very compelling. For a more representative scenario, use the much more powerful model from :doc:`atis_tutorial` instead.
 
 Evaluate the model
 --------------------
@@ -22,36 +10,49 @@ We want to run the model on our test dataset and see how well it performs. Some 
 
 .. code-block:: console
 
-    (pytext) $ pytext test < "$CONFIG"
+    (pytext) $ pytext test < demo/configs/docnn.json
 
-    Intent Metrics
-            Per label scores                                Precision       Recall          F1              Support
+    Stage.TEST
+    loss: 2.059336
+    Accuracy: 20.00
 
-            flight                                          98.27           99.05           98.66           632
-            flight_no                                       88.89           100.00          94.12           8
-            abbreviation                                    94.29           100.00          97.06           33
-            ground_service                                  94.74           100.00          97.30           36
-            airfare                                         92.31           100.00          96.00           48
-            airline                                         97.44           100.00          98.70           38
+    Macro P/R/F1 Scores:
+        Label               				Precision 				Recall    				F1        				Support
+
+        reminder/set_reminder				25.00     				100.00    				40.00     				1
+        alarm/time_left_on_alarm			0.00      				0.00      				0.00      				1
+        alarm/show_alarms   				0.00      				0.00      				0.00      				1
+        alarm/set_alarm     				0.00      				0.00      				0.00      				2
+        Overall macro scores				6.25      				25.00     				10.00
+
+    Soft Metrics:
+        Label     				    Average precision
+        alarm/set_alarm				    50.00
+        alarm/time_left_on_alarm		    20.00
+        reminder/set_reminder			    25.00
+        alarm/show_alarms			    20.00
+        weather/find			    	    nan
+        alarm/modify_alarm			    nan
+        alarm/snooze_alarm			    nan
+        reminder/show_reminders			    nan
+        Label     				Recall at precision 0.2
+        alarm/set_alarm				100.00
+        Label     				Recall at precision 0.4
+        alarm/set_alarm				100.00
+        Label     				Recall at precision 0.6
+        alarm/set_alarm				0.00
+        Label     				Recall at precision 0.8
+        alarm/set_alarm				0.00
+        Label     				Recall at precision 0.9
+        alarm/set_alarm				0.00
     ...[snip]
-           ... [snip]
+        Label     				Recall at precision 0.6
+        reminder/show_reminders			0.00
+        Label     				Recall at precision 0.8
+        reminder/show_reminders			0.00
+        Label     				Recall at precision 0.9
+        reminder/show_reminders			0.00
 
-            Overall micro scores                            96.64           96.64           96.64           893
-            Overall macro scores                            73.03           69.55           69.14
-
-
-    Slot Metrics
-            Per label scores                                Precision       Recall          F1              Support
-
-            toloc.city_name                                 97.12           98.88           97.99           715
-            fromloc.city_name                               98.46           99.72           99.08           703
-            fare_basis_code                                 88.89           94.12           91.43           17
-    ...[snip]
-
-            Overall micro scores                            94.88           95.13           95.01           2260
-            Overall macro scores                            70.13           71.12           69.09
-
-Not bad!
 
 Export the model
 -------------------
@@ -76,7 +77,7 @@ You can also pass in a configuration to infer some of these options. In this cas
 
 .. code-block:: console
 
-    (pytext) $ pytext export --output-path exported_model.c2 < "$CONFIG"
+    (pytext) $ pytext export --output-path exported_model.c2 < demo/configs/docnn.json
     ...[snip]
     Saving caffe2 model to: exported_model.c2
 
@@ -142,7 +143,7 @@ Execute the app
 
 .. code-block:: console
 
-    (pytext) $ python flask_app.py "$CONFIG" exported_model.c2
+    (pytext) $ python flask_app.py demo/configs/docnn.json exported_model.c2
     * Serving Flask app "flask_app" (lazy loading)
     * Environment: production
       WARNING: Do not use the development server in a production environment.


### PR DESCRIPTION
Since this follows immediately after the train tutorial using DocNN, many readers are confused about the outputs seen current on this page as they're expecting to use DocNN, not ATIS that's shown here. We're updating this tutorial to reflect DocNN instead. Although poor in results, the assumption is that someone running ATIS would be better equipped at this stage to understand the results of the test step than a beginner just trying out train and test with PyText.
![screen shot 2018-12-19 at 09 59 06](https://user-images.githubusercontent.com/683812/50238635-cd7b2480-0374-11e9-9c3e-1151974cf4aa.png)
