### PR TITLE
Build Docs in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,28 @@ jobs:
       - store_artifacts:
           path: htmlcov
           destination: coverage
+  build_docs:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: setup
+          command: source .circleci/setup_circleimg.sh
+      - run:
+          name: install_pytorch
+          command: sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+      - run:
+          name: install docs build deps
+          command: sudo pip install -r pytext/docs/requirements.txt
+      - run:
+          name: build docs
+          command: |
+              cd pytext/docs/
+              make html
+      - store_artifacts:
+          path: build/html
+          destination: docs
   python_lint:
     docker:
       - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
               cd pytext/docs/
               make html
       - store_artifacts:
-          path: build/html
+          path: pytext/docs/build/html
           destination: docs
   python_lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,3 +89,4 @@ workflows:
       - build_Py3.6
       - build_Py3.7
       - python_lint
+      - build_docs


### PR DESCRIPTION
Summary:

Test Plan:
CircleCI

## Motivation and Context

It is cumbersome to share the built docs when you have a diff that modifies them. With this change, we will build them in CircleCI and store them as an artifact for easy viewing.

## How Has This Been Tested

CircleCI will test it

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
