### PR TITLE
implement knowledge distillation

### DIFF
--- a/pytext/builtin_task.py
+++ b/pytext/builtin_task.py
@@ -8,6 +8,7 @@ from pytext.task.tasks import (
     DocClassificationTask,
     EnsembleTask,
     JointTextTask,
+    KDDocClassificationTask,
     LMTask,
     PairClassification,
     SemanticParsingTask,
@@ -29,5 +30,6 @@ def register_builtin_tasks():
             ContextualIntentSlotTask,
             SemanticParsingTask,
             DisjointMultitask,
+            KDDocClassificationTask,
         )
     )

--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -76,6 +76,7 @@ class DocLabelConfig(ConfigBase):
     export_output_names: List[str] = ["doc_scores"]
     label_weights: Dict[str, float] = {}
     _name = DatasetFieldName.DOC_LABEL_FIELD
+    target_prob: bool = False
 
 
 TargetConfigBase = Union[DocLabelConfig, WordLabelConfig]

--- a/pytext/config/kd_doc_classification.py
+++ b/pytext/config/kd_doc_classification.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Optional
+
+from .field_config import (
+    CharFeatConfig,
+    DictFeatConfig,
+    DocLabelConfig,
+    PretrainedModelEmbeddingConfig,
+    WordFeatConfig,
+)
+from .module_config import ModuleConfig
+
+
+class ModelInputConfig(ModuleConfig):
+    word_feat: WordFeatConfig = WordFeatConfig()
+    dict_feat: Optional[DictFeatConfig] = None
+    char_feat: Optional[CharFeatConfig] = None
+    pretrained_model_embedding: Optional[PretrainedModelEmbeddingConfig] = None
+
+
+TargetConfig = DocLabelConfig
+
+
+class ModelInput:
+    WORD_FEAT = "word_feat"
+    DICT_FEAT = "dict_feat"
+    CHAR_FEAT = "char_feat"
+    PRETRAINED_MODEL_EMBEDDING = "pretrained_model_embedding"
+    SEQ_LENS = "seq_lens"
+
+
+class Target:
+    DOC_LABEL = "doc_label"
+    TARGET_PROB_FIELD = "target_prob"
+    TARGET_LABEL_FIELD = "target_label"
+
+
+class ExtraField:
+    RAW_TEXT = "utterance"

--- a/pytext/data/__init__.py
+++ b/pytext/data/__init__.py
@@ -8,6 +8,7 @@ from .data_handler import BatchIterator, CommonMetadata, DataHandler
 from .disjoint_multitask_data_handler import DisjointMultitaskDataHandler
 from .doc_classification_data_handler import DocClassificationDataHandler, RawData
 from .joint_data_handler import JointModelDataHandler
+from .kd_doc_classification_data_handler import KDDocClassificationDataHandler
 from .language_model_data_handler import LanguageModelDataHandler
 from .pair_classification_data_handler import PairClassificationDataHandler
 from .seq_data_handler import SeqModelDataHandler
@@ -27,4 +28,5 @@ __all__ = [
     "DocClassificationDataHandler",
     "RawData",
     "DisjointMultitaskDataHandler",
+    "KDDocClassificationDataHandler",
 ]

--- a/pytext/data/kd_doc_classification_data_handler.py
+++ b/pytext/data/kd_doc_classification_data_handler.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Any, Dict, List
+
+from pytext.config.field_config import DocLabelConfig
+from pytext.config.kd_doc_classification import (
+    ExtraField,
+    ModelInput,
+    ModelInputConfig,
+    Target,
+    TargetConfig,
+)
+from pytext.data.featurizer import InputRecord
+from pytext.fields import (
+    CharFeatureField,
+    DictFeatureField,
+    DocLabelField,
+    Field,
+    PretrainedModelEmbeddingField,
+    RawField,
+    TextFeatureField,
+    create_fields,
+    create_label_fields,
+)
+from pytext.utils.data_utils import parse_json_array
+from pytext.utils.python_utils import cls_vars
+from torchtext import data as textdata
+
+from .doc_classification_data_handler import DocClassificationDataHandler
+
+
+class RawData:
+    DOC_LABEL = "doc_label"
+    TEXT = "text"
+    DICT_FEAT = "dict_feat"
+    TARGET_PROBS = "target_probs"
+    TARGET_LABELS = "target_labels"
+
+
+class KDDocClassificationDataHandler(DocClassificationDataHandler):
+    """
+    The `KDDocClassificationDataHandler` prepares the data for knowledge distillation
+    document classififcation. Each sentence is read line by line with its label as the
+    target.
+    """
+
+    class Config(DocClassificationDataHandler.Config):
+        """
+        Configuration class for `KDDocClassificationDataHandler`.
+
+        Attributes:
+            columns_to_read (List[str]): List containing the names of the
+                columns to read from the data files.
+            max_seq_len (int): Maximum sequence length for the input. The input
+                is trimmed after the maximum sequence length.
+        """
+
+        columns_to_read: List[str] = cls_vars(RawData)
+        max_seq_len: int = -1
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Config,
+        model_input_config: ModelInputConfig,
+        target_config: TargetConfig,
+        **kwargs,
+    ):
+        """
+        Factory method to construct an instance of `DocClassificationDataHandler`
+        from the module's config object and feature config object.
+
+        Args:
+            config (DocClassificationDataHandler.Config): Configuration object
+                specifying all the parameters of `DocClassificationDataHandler`.
+            model_input_config (ModelInputConfig): Configuration object
+                specifying all the parameters of the model config.
+            target_config (TargetConfig): Configuration object specifying all
+                the parameters of the target.
+
+        Returns:
+            type: An instance of `KDDocClassificationDataHandler`.
+        """
+        model_input_fields: Dict[str, Field] = create_fields(
+            model_input_config,
+            {
+                ModelInput.WORD_FEAT: TextFeatureField,
+                ModelInput.DICT_FEAT: DictFeatureField,
+                ModelInput.CHAR_FEAT: CharFeatureField,
+                ModelInput.PRETRAINED_MODEL_EMBEDDING: PretrainedModelEmbeddingField,
+            },
+        )
+        target_fields: Dict[str, Field] = create_label_fields(
+            target_config, {DocLabelConfig._name: DocLabelField}
+        )
+        extra_fields: Dict[str, Field] = {ExtraField.RAW_TEXT: RawField()}
+        if target_config.target_prob:
+            target_fields[Target.TARGET_PROB_FIELD] = RawField()
+
+        if target_config.target_prob:
+            extra_fields[Target.TARGET_LABEL_FIELD] = RawField()
+        kwargs.update(config.items())
+        return cls(
+            raw_columns=config.columns_to_read,
+            labels=target_fields,
+            features=model_input_fields,
+            extra_fields=extra_fields,
+            **kwargs,
+        )
+
+    def preprocess_row(self, row_data: Dict[str, Any]) -> Dict[str, Any]:
+        features = self.featurizer.featurize(
+            InputRecord(
+                raw_text=row_data.get(RawData.TEXT, ""),
+                raw_gazetteer_feats=row_data.get(RawData.DICT_FEAT, ""),
+            )
+        )
+        res = {
+            # feature
+            ModelInput.WORD_FEAT: self._get_tokens(features),
+            ModelInput.DICT_FEAT: (
+                features.gazetteer_feats,
+                features.gazetteer_feat_weights,
+                features.gazetteer_feat_lengths,
+            ),
+            ModelInput.CHAR_FEAT: features.characters,
+            ModelInput.PRETRAINED_MODEL_EMBEDDING: features.pretrained_token_embedding,
+            # target
+            DocLabelConfig._name: row_data.get(RawData.DOC_LABEL),
+            # extra data
+            ExtraField.RAW_TEXT: row_data.get(RawData.TEXT),
+        }
+        if Target.TARGET_PROB_FIELD in self.labels:
+            res[Target.TARGET_PROB_FIELD] = parse_json_array(
+                row_data[RawData.TARGET_PROBS]
+            )
+            res[Target.TARGET_LABEL_FIELD] = parse_json_array(
+                row_data[RawData.TARGET_LABELS]
+            )
+
+        return res
+
+    def init_target_metadata(
+        self,
+        train_data: textdata.Dataset,
+        eval_data: textdata.Dataset,
+        test_data: textdata.Dataset,
+    ):
+        # build vocabs for label fields
+        for name, label in self.labels.items():
+            if name in [Target.TARGET_PROB_FIELD]:
+                continue
+            # Need test data to make sure we cover all of the labels in it
+            # It is particularly important when BIO is enabled as a B-[Label] can
+            # appear in train and eval but test can have B-[Label] and I-[Label]
+
+            if label.use_vocab:
+                print("Building vocab for label {}".format(name))
+                label.build_vocab(train_data, eval_data, test_data)
+                print(
+                    "{} field's vocabulary size is {}".format(
+                        name, len(label.vocab.itos)
+                    )
+                )
+
+        self.metadata.target = [
+            field.get_meta()
+            for name, field in self.labels.items()
+            if name not in [Target.TARGET_PROB_FIELD]
+        ]
+        if len(self.metadata.target) == 1:
+            self.metadata.target = self.metadata.target[0]
+
+    def _align_target_label(self, target, label_list, batch_label_list):
+        """
+        align the target in the order of label_list, batch_label_list stores the
+        original target order.
+        """
+        if sorted(label_list) != sorted(batch_label_list[0]):
+            raise Exception(
+                "label list %s is not matched with doc label %s",
+                (str(batch_label_list), str(label_list)),
+            )
+
+        def get_sort_idx(l):
+            return [i[0] for i in sorted(enumerate(l), key=lambda x: x[1])]
+
+        def reorder(l, o):
+            return [l[i] for i in o]
+
+        unsort_idx = get_sort_idx(get_sort_idx(label_list))
+        align_target = [
+            reorder(reorder(t, get_sort_idx(b)), unsort_idx)
+            for t, b in zip(target, batch_label_list)
+        ]
+        return align_target
+
+    def _target_from_batch(self, batch):
+        label_list = self.metadata.target.vocab.itos
+        batch_label_list = getattr(batch, Target.TARGET_LABEL_FIELD)
+        targets = []
+        for name in self.labels:
+            target = getattr(batch, name)
+            if name in [Target.TARGET_PROB_FIELD]:
+                target = self._align_target_label(target, label_list, batch_label_list)
+            targets.append(target)
+        if len(targets) == 1:
+            return targets[0]
+        return tuple(targets)

--- a/pytext/data/test/kd_doc_classification_data_handler_test.py
+++ b/pytext/data/test/kd_doc_classification_data_handler_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+from pytext.config.field_config import FeatureConfig
+from pytext.config.kd_doc_classification import ModelInputConfig, Target, TargetConfig
+from pytext.data import KDDocClassificationDataHandler
+from pytext.data.featurizer import SimpleFeaturizer
+from pytext.data.kd_doc_classification_data_handler import ModelInput, RawData
+from pytext.utils.test_utils import import_tests_module
+
+
+tests_module = import_tests_module()
+
+
+class KDDocClassificationDataHandlerTest(unittest.TestCase):
+    def setUp(self):
+        file_name = tests_module.test_file("knowledge_distillation_test_tiny.tsv")
+        label_config_dict = {"target_prob": True}
+        data_handler_dict = {
+            "columns_to_read": ["text", "target_probs", "target_labels", "doc_label"]
+        }
+        self.data_handler = KDDocClassificationDataHandler.from_config(
+            KDDocClassificationDataHandler.Config(**data_handler_dict),
+            ModelInputConfig(),
+            TargetConfig(**label_config_dict),
+            featurizer=SimpleFeaturizer.from_config(
+                SimpleFeaturizer.Config(), FeatureConfig()
+            ),
+        )
+        self.data = self.data_handler.read_from_file(
+            file_name, self.data_handler.raw_columns
+        )
+
+    def test_create_from_config(self):
+        expected_columns = [
+            RawData.TEXT,
+            RawData.TARGET_PROBS,
+            RawData.TARGET_LABELS,
+            RawData.DOC_LABEL,
+        ]
+        # check that the list of columns is as expected
+        self.assertTrue(self.data_handler.raw_columns == expected_columns)
+
+    def test_read_from_file(self):
+        # Check if the data has 10 rows and 4 columns
+        self.assertEqual(len(self.data), 10)
+        self.assertEqual(len(self.data[0]), 4)
+
+        self.assertEqual(self.data[0][RawData.TEXT], "Who R U ?")
+        self.assertEqual(
+            self.data[0][RawData.TARGET_PROBS],
+            "[-0.001166735659353435, -6.743621826171875]",
+        )
+        self.assertEqual(
+            self.data[0][RawData.TARGET_LABELS], '["cu:other", "cu:ask_Location"]'
+        )
+
+    def test_tokenization(self):
+        data = list(self.data_handler.preprocess(self.data))
+
+        # test tokenization without language-specific tokenizers
+        self.assertListEqual(data[0][ModelInput.WORD_FEAT], ["who", "r", "u", "?"])
+        self.assertListEqual(
+            data[0][Target.TARGET_PROB_FIELD],
+            [-0.001166735659353435, -6.743621826171875],
+        )
+
+    def test_align_target_label(self):
+        target = [[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]
+        label_list = ["l1", "l2", "l3"]
+        batch_label_list = [["l3", "l2", "l1"], ["l1", "l3", "l2"]]
+        align_target = self.data_handler._align_target_label(
+            target, label_list, batch_label_list
+        )
+        self.assertListEqual(align_target, [[0.3, 0.2, 0.1], [0.1, 0.3, 0.2]])

--- a/pytext/loss/__init__.py
+++ b/pytext/loss/__init__.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from .loss import AUCPRHingeLoss, BinaryCrossEntropyLoss, CrossEntropyLoss, Loss
+from .loss import (
+    AUCPRHingeLoss,
+    BinaryCrossEntropyLoss,
+    CrossEntropyLoss,
+    KLDivergenceBCELoss,
+    KLDivergenceCELoss,
+    Loss,
+    SoftHardBCELoss,
+)
 
 
-__all__ = ["Loss", "CrossEntropyLoss", "BinaryCrossEntropyLoss", "AUCPRHingeLoss"]
+__all__ = [
+    "AUCPRHingeLoss",
+    "Loss",
+    "CrossEntropyLoss",
+    "BinaryCrossEntropyLoss",
+    "KLDivergenceBCELoss",
+    "KLDivergenceCELoss",
+    "SoftHardBCELoss",
+]

--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -107,6 +107,8 @@ class MetricReporter(Component):
             return [elem.tolist() for elem in data]
         elif isinstance(data, List):
             return data
+        elif isinstance(data, tuple):
+            return data[0].tolist()
         else:
             raise NotImplementedError()
 

--- a/pytext/models/output_layers/doc_classification_output_layer.py
+++ b/pytext/models/output_layers/doc_classification_output_layer.py
@@ -7,7 +7,14 @@ import torch.nn.functional as F
 from caffe2.python import core
 from pytext.config.component import create_loss
 from pytext.fields import FieldMeta
-from pytext.loss import AUCPRHingeLoss, BinaryCrossEntropyLoss, CrossEntropyLoss
+from pytext.loss import (
+    AUCPRHingeLoss,
+    BinaryCrossEntropyLoss,
+    CrossEntropyLoss,
+    KLDivergenceBCELoss,
+    KLDivergenceCELoss,
+    SoftHardBCELoss,
+)
 from pytext.utils.cuda_utils import FloatTensor
 
 from .output_layer_base import OutputLayerBase
@@ -33,6 +40,9 @@ class ClassificationOutputLayer(OutputLayerBase):
             CrossEntropyLoss.Config,
             BinaryCrossEntropyLoss.Config,
             AUCPRHingeLoss.Config,
+            KLDivergenceBCELoss.Config,
+            KLDivergenceCELoss.Config,
+            SoftHardBCELoss.Config,
         ] = CrossEntropyLoss.Config()
 
     @classmethod

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -6,6 +6,7 @@ from pytext.common.constants import DatasetFieldName
 from pytext.config import (
     contextual_intent_slot as ContextualIntentSlot,
     doc_classification as DocClassification,
+    kd_doc_classification as KDDocClassification,
     pair_classification as PairClassification,
 )
 from pytext.config.field_config import DocLabelConfig, TargetConfigBase, WordLabelConfig
@@ -15,6 +16,7 @@ from pytext.data import (
     ContextualIntentSlotModelDataHandler,
     DocClassificationDataHandler,
     JointModelDataHandler,
+    KDDocClassificationDataHandler,
     LanguageModelDataHandler,
     PairClassificationDataHandler,
     SeqModelDataHandler,
@@ -207,3 +209,19 @@ class SemanticParsingTask(Task):
         data_handler: CompositionalDataHandler.Config = CompositionalDataHandler.Config()
         labels: Optional[WordLabelConfig] = None
         metric_reporter: CompositionalMetricReporter.Config = CompositionalMetricReporter.Config()
+
+
+class KDDocClassificationTask(Task):
+    class Config(Task.Config):
+        model: DocModel.Config = DocModel.Config()
+        trainer: Trainer.Config = Trainer.Config()
+        features: DocClassification.ModelInputConfig = (
+            DocClassification.ModelInputConfig()
+        )
+        labels: KDDocClassification.TargetConfig = KDDocClassification.TargetConfig()
+        data_handler: KDDocClassificationDataHandler.Config = (
+            KDDocClassificationDataHandler.Config()
+        )
+        metric_reporter: ClassificationMetricReporter.Config = (
+            ClassificationMetricReporter.Config()
+        )

--- a/tests/data/knowledge_distillation_test_tiny.tsv
+++ b/tests/data/knowledge_distillation_test_tiny.tsv
@@ -1,0 +1,10 @@
+Who R U ?	[-0.001166735659353435, -6.743621826171875]	["cu:other", "cu:ask_Location"]	cu:other
+You in the gym	[-1.052109956741333, -0.4391290545463562]	["cu:other", "cu:ask_Location"]	cu:ask_Location
+look at me	[-0.0476444847881794, -3.0614256858825684]	["cu:other", "cu:ask_Location"]	cu:other
+Move fast and ship love	[-0.0006301801186054945, -7.4362711906433105]	["cu:other", "cu:ask_Location"]	cu:other
+At your house?	[-1.0430370569229126, -0.4422380030155182]	["cu:other", "cu:ask_Location"]	cu:ask_Location
+Lmao	[-2.9802276912960224e-06, -12.688275337219238]	["cu:other", "cu:ask_Location"]	cu:other
+Owwww Sweet	[-0.00019667598826345056, -8.894574165344238]	["cu:other", "cu:ask_Location"]	cu:other
+You home yet lol	[-1.4669092893600464, -0.27201464772224426]	["cu:other", "cu:ask_Location"]	cu:ask_Location
+Are you home?	[-3.8916919231414795, -0.02050662972033024]	["cu:other", "cu:ask_Location"]	cu:ask_Location
+Where you at?	[-1.9239834547042847, -0.1610211282968521]	["cu:other", "cu:ask_Location"]	cu:ask_Location


### PR DESCRIPTION
Summary:
Implementation of Knowledge Distillation, follow the paper https://arxiv.org/abs/1503.02531

Now we only support distill doc classification teacher models with BinaryCrossEntropyLoss and CrossEntropyLoss, with the flexibility of whatever representation or decoder layers used in teacher model.

We create a new task called "KDDocClassificationTask", including:
1. "KDDocClassificationDataHandler" to process the probability and logit training input,
2. new KD loss functions:  "KLDivergenceBCELoss", "KLDivergenceCELoss", "SoftHardBCELoss"
3. config file for kd_doc_classification (some parts are duplicated with doc_classification)
4. unittest for data handler
5. integration test config file

This diff doesn't implement the temperature tuning mentioned in paper, but will add it in the future.

Differential Revision: D12990020
