### PR TITLE
Explicitly clarifying the Python version required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ PyText is a deep-learning based NLP modeling framework built on PyTorch. PyText 
 
 # Installing PyText
 
-### PyText requires Python 3.6 or above.
+### PyText requires Python 3.6.1 or above.
 
 *To get started on a Cloud VM, checkout [our guide](https://pytext-pytext.readthedocs-hosted.com/en/latest/installation.html#cloud-vm-setup)*
 


### PR DESCRIPTION
## Motivation and Context

Minor change as we want to make sure users use Python 3.6.1 and above.
