### PR TITLE
Adding dropout for slot-specific values

### DIFF
--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -92,6 +92,7 @@ class RNNGParser(Model, Component):
         constraints: RNNGConstraints = RNNGConstraints()
         max_open_NT: int = 10
         dropout: float = 0.1
+        slot_dropout: float = 0.0
         compositional_type: CompositionalType = CompositionalType.BLSTM
 
     @classmethod


### PR DESCRIPTION
Summary:
Sometimes, there may be overfitting on slot values. For example, in [IN:CREATE_CALL call [SL:CONTACT Mom]], the model often overfits on 'Mom' because 'Call Mom' is more common in the training data than calling other contacts.

This change applies a dropout layer to a token embedding (before concatenation with the dictionary features) if the last non-shift, non-reduction oracle (gold) action was a slot (and not an intent).

Differential Revision: D10843725
