### PR TITLE
Using existing config file for export and predict.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ By default, the model is created in `/tmp/model.pt`
 Now you can export your model as a caffe2 net:
 
 ```
-  (venv) $ pytext export < config.json
+  (venv) $ pytext export < demo/configs/docnn.json
 ```
 
 You can use the exported caffe2 model to predict the class of raw utterances like this:
 
 ```
-  (venv) $ pytext --config-file config.json predict <<< '{"raw_text": "create an alarm for 1:30 pm"}'
+  (venv) $ pytext --config-file demo/configs/docnn.json predict <<< '{"raw_text": "create an alarm for 1:30 pm"}'
 ```
 
 More examples and tutorials can be found in [Full Documentation](https://pytext-pytext.readthedocs-hosted.com)


### PR DESCRIPTION
We observed a lot of questions regarding the location of the "config.json" file for export and train steps. We expect this file to be created by the user, but for the sake of simplicity and initial trails, it's better to point users to us the existing file. This will also ease users trying the framework for the first time and support questions on both GitHub Issues and FB group.
