### PR TITLE
Adding action_p to beam state in RNNG py

### DIFF
--- a/pytext/models/semantic_parsers/rnng/rnng_data_structures.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_data_structures.py
@@ -199,6 +199,7 @@ class ParserState:
         self.num_open_NT = 0
         self.is_open_NT: List[bool] = []
         self.found_unsupported = False
+        self.action_p = torch.Tensor()
 
         # negative cumulative log prob so sort(states) is in descending order
         self.neg_prob = 0
@@ -217,6 +218,9 @@ class ParserState:
         other.is_open_NT = self.is_open_NT.copy()
         other.neg_prob = self.neg_prob
         other.found_unsupported = self.found_unsupported
+
+        # detach to avoid making copies, only called in inference to share data
+        other.action_p = self.action_p.detach()
         return other
 
     def __gt__(self, other):

--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -393,9 +393,9 @@ class RNNGParser(Model, Component):
                 if self.ablation_use_last_open_NT_feature:
                     summaries.append(last_open_NT_feature)
 
-                action_p = self.action_linear(torch.cat(summaries, dim=1))
+                state.action_p = self.action_linear(torch.cat(summaries, dim=1))
 
-                log_probs = F.log_softmax(action_p, dim=1)[0]
+                log_probs = F.log_softmax(state.action_p, dim=1)[0]
 
                 for action in self.valid_actions(state):
                     plans.append(
@@ -430,7 +430,7 @@ class RNNGParser(Model, Component):
                 ):
                     pass
                 else:
-                    state.action_scores.append(action_p)
+                    state.action_scores.append(state.action_p)
 
                 self.push_action(state, target_action_idx)
 


### PR DESCRIPTION
Summary: This diff stores action_p in ParserState. Previously, action_p was not updated to be saved for each state in the ParserState object, which may be useful in the future.

Differential Revision: D13366174
