### PR TITLE
save model as a ONNX snapshot for reuse in other languages, like java…

### DIFF
--- a/pytext/utils/onnx_utils.py
+++ b/pytext/utils/onnx_utils.py
@@ -37,6 +37,11 @@ def pytorch_to_caffe2(
         output_names=output_names,
         export_params=True,
     )
+
+    # # copy as a ONNX snapshot
+    from shutil import copyfile
+    copyfile(export_path, export_path + ".onnx")
+
     onnx_model = onnx.load(export_path)
     onnx.checker.check_model(onnx_model)
     # Convert the ONNX model to a caffe2 net


### PR DESCRIPTION
…, c++, etc.

## save ONNX model for reuse in java,c++ etc.

I have use org.bytedeco javacpp-presets in my java application to do Deep learning task in production env, and it can use onnx as a pre-trained model. So, I make this PR to copy the model as a .onnx file after it was converted from pytorch-type.

## How Has This Been Tested

my test code under JAVA applciation is as belows:

`     onnx.OpSchemaVector allSchemas = onnx.OpSchemaRegistry.get_all_schemas();
        System.out.println(allSchemas.size());

        byte[] bytes = Files.readAllBytes(Paths.get("/my/path/model.pt.onnx"));

        onnx.ModelProto model = new onnx.ModelProto();
        ParseProtoFromBytes(model, new BytePointer(bytes), bytes.length);
        check_model(model);
        InferShapes(model);
        onnx.StringVector passes = new onnx.StringVector("eliminate_nop_transpose", "eliminate_nop_pad", "fuse_consecutive_transposes", "fuse_transpose_into_gemm");
        Optimize(model, passes);
        check_model(model);
        System.out.println(model.graph().input_size());`
## Types of changes

 `# # copy as a ONNX snapshot
    from shutil import copyfile
    copyfile(export_path, export_path + ".onnx")`
