### PR TITLE
save model as a ONNX snapshot for reuse in other languages, like java…

### DIFF
--- a/pytext/utils/onnx_utils.py
+++ b/pytext/utils/onnx_utils.py
@@ -37,6 +37,11 @@ def pytorch_to_caffe2(
         output_names=output_names,
         export_params=True,
     )
+
+    # # copy as a ONNX snapshot
+    from shutil import copyfile
+    copyfile(export_path, export_path + ".onnx")
+
     onnx_model = onnx.load(export_path)
     onnx.checker.check_model(onnx_model)
     # Convert the ONNX model to a caffe2 net

--- a/pytext/utils/onnx_utils.py
+++ b/pytext/utils/onnx_utils.py
@@ -40,6 +40,7 @@ def pytorch_to_caffe2(
 
     # # copy as a ONNX snapshot
     from shutil import copyfile
+
     copyfile(export_path, export_path + ".onnx")
 
     onnx_model = onnx.load(export_path)


### PR DESCRIPTION
## Motivation and Context

I have use org.bytedeco.javacpp-presets in my JAVA application to do Deep learning task in production env, and it can use onnx as a pre-trained model. So, I make this PR to copy the model as a .onnx file after it was converted from pytorch-type model.

## How Has This Been Tested

my test code under JAVA applciation is as belows:

`
        onnx.OpSchemaVector allSchemas = onnx.OpSchemaRegistry.get_all_schemas();
        System.out.println(allSchemas.size());

        byte[] bytes = Files.readAllBytes(Paths.get("/Users/qibaoyuan/Documents/source/project/pycharm/pytext/minlpdemo/ner/model.pt.prd.2.onnx"));

        onnx.ModelProto model = new onnx.ModelProto();
        ParseProtoFromBytes(model, new BytePointer(bytes), bytes.length);

        check_model(model);

        InferShapes(model);

        onnx.StringVector passes = new onnx.StringVector("eliminate_nop_transpose", "eliminate_nop_pad", "fuse_consecutive_transposes", "fuse_transpose_into_gemm");
        Optimize(model, passes);

        check_model(model);

        ConvertVersion(model, 8);

        System.out.println(model.graph().input_size());
`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
`
    # # copy as a ONNX snapshot
    from shutil import copyfile
    copyfile(export_path, export_path + ".onnx")

`

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
