### PR TITLE
Ignore generated documentation sources in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ venv.bak/
 
 # Coverage Files
 .coverage
+
+# Generated Document Sources
+pytext/docs/source/configs/*
+pytext/docs/source/modules/*


### PR DESCRIPTION
Summary:
We generate a lot of source files as part of our documentation build process. These are generated files and should not be checked in
Test Plan:

ran `make html` and confirmed that git was not tracking the files

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
