### PR TITLE
Fix Atis Tutorial Reference in Docstring

### DIFF
--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -56,7 +56,7 @@ class Model(nn.Module, Component):
 
     Let us discuss the joint intent-slot model as a case to go over these layers.
     The model predicts intent of input utterance and the slots in the utterance.
-    (Refer to :doc:`atis_tutorial` for details about intent-slot model.)
+    (Refer to :doc:`/atis_tutorial` for details about intent-slot model.)
 
     1. :class:`~EmbeddingList` layer is tasked with representing tokens. To do so we
        can use learnable word embedding table in conjunction with learnable character


### PR DESCRIPTION
Summary:
The reference to the atis tutorial in model.py doesn't work properly and is throwing a warning. This fixes it.
Test Plan:
  make clean-all
  make html
then validated the warning went away

existing docs look like:
https://pytext-pytext.readthedocs-hosted.com/en/latest/modules/pytext.models.html (grep for atis)
new ones look like (from CI build) https://834-143080897-gh.circle-artifacts.com/0/docs/modules/pytext.models.html
as you can see, the reference is nicely expanded

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
