### PR TITLE
Reduce duplicate indices

### DIFF
--- a/pytext/docs/make_config_docs.py
+++ b/pytext/docs/make_config_docs.py
@@ -182,6 +182,7 @@ def format_config_rst(config):
         (
             f".. py:currentmodule:: {config.config.__module__}",
             f".. py:class:: {config.config.__name__}",
+            I(1) + ":noindex:",
             "",
             I(1)
             + "**Bases:** "

--- a/pytext/docs/source/conf.py
+++ b/pytext/docs/source/conf.py
@@ -16,6 +16,7 @@
 #
 import os
 import sys
+from sphinx.domains.python import PythonDomain
 
 
 # source code directory, relative to this file, for sphinx-autobuild
@@ -186,6 +187,14 @@ def run_apidoc(_):
 
     main()
 
-
+class PatchedPythonDomain(PythonDomain):
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        if 'refspecific' in node:
+            del node['refspecific']
+        return super(PatchedPythonDomain, self).resolve_xref(
+            env, fromdocname, builder, typ, target, node, contnode)
+    
 def setup(app):
+    app.override_domain(PatchedPythonDomain)
     app.connect("builder-inited", run_apidoc)
+


### PR DESCRIPTION
Summary:
our config objects are being added to the index twice, once in the modules docs, once in the config docs. This change removes the config doc verions from the index. Long term we likely want to merge these, but for now, this will do.

based on discussion here:
https://github.com/sphinx-doc/sphinx/issues/3866

Test Plan:
  make clean-all
  make html
and validated the warnings dissapeared

Before this change: 269 warnings
After: 102
## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
