### PR TITLE
Fix docstrings

### DIFF
--- a/pytext/data/disjoint_multitask_data_handler.py
+++ b/pytext/data/disjoint_multitask_data_handler.py
@@ -103,8 +103,8 @@ class DisjointMultitaskDataHandler(DataHandler):
         """Configuration class for `DisjointMultitaskDataHandler`.
 
         Attributes:
-            epoch_size (Optional[int]): Size of epoch in number of batches.  If not set,
-            do a single pass over the training data.
+            epoch_size (Optional[int]): Size of epoch in number of batches.  If not set
+                do a single pass over the training data.
 
         """
 

--- a/pytext/docs/make_config_docs.py
+++ b/pytext/docs/make_config_docs.py
@@ -145,6 +145,13 @@ def config_attrs(config):
 def I(n):
     return "  " * n
 
+def unindent_docstring(docstring):
+    lines = docstring.splitlines()
+    first = next(iter(lines), "")
+    second = next(iter([line for line in lines[1:] if line]), "")
+    indent = len(second) - len(second.lstrip())
+    return [first] + [line[indent:] for line in lines[1:]]
+
 
 def rst_big_header(s):
     return f"{s}\n{'='*len(s)}\n"
@@ -189,8 +196,12 @@ def format_config_rst(config):
             "",
             *(
                 I(1) + line
-                for line in GoogleDocstring(config.config.__doc__ or "").lines()
+                for line in GoogleDocstring(
+                   unindent_docstring(config.config.__doc__ or "")
+                ).lines()
             ),
+            "",
+            "**All Attributes (including base classes)**",
             "",
             *itertools.chain.from_iterable(
                 (

--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -75,22 +75,22 @@ class BinaryCrossEntropyLoss(Loss):
 
 class AUCPRHingeLoss(nn.Module, Loss):
     """area under the precision-recall curve loss,
-    Reference: "Scalable Learning of Non-Decomposable Objectives", Section 5
-        TensorFlow Implementation:
-        https://github.com/tensorflow/models/tree/master/research/global_objectives
+    Reference: "Scalable Learning of Non-Decomposable Objectives", Section 5 \
+    TensorFlow Implementation: \
+    https://github.com/tensorflow/models/tree/master/research/global_objectives\
     """
 
     class Config(ConfigBase):
         """
-        Configs:
-            precision_range_lower: the lower range of precision values over
+        Attributes:
+            precision_range_lower (float): the lower range of precision values over
                 which to compute AUC. Must be nonnegative, `\leq precision_range_upper`,
                 and `leq 1.0`.
-            precision_range_upper: the upper range of precision values over
+            precision_range_upper (float): the upper range of precision values over
                 which to compute AUC. Must be nonnegative, `\geq precision_range_lower`,
                 and `leq 1.0`.
-            num_classes: number of classes(aka labels)
-            num_anchors: The number of grid points used to approximate the Riemann sum.
+            num_classes (int): number of classes(aka labels)
+            num_anchors (int): The number of grid points used to approximate the Riemann sum.
         """
 
         precision_range_lower: float = 0.0

--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -214,6 +214,7 @@ class TensorBoardChannel(Channel):
         then under "tag=test" we will display "accuracy=0.7", and under
         "tag=test/scores" we will display "precision=0.8" and "recall=0.6" in
         TensorBoard.
+
         Args:
             tag (str): The tag name for the metric. If a field needs to be
                 flattened further, it will be prepended as a prefix to the field
@@ -230,6 +231,7 @@ class TensorBoardChannel(Channel):
         """
         Recursively flattens the metrics object and adds each field name and
         value as a scalar for the corresponding epoch using the summary writer.
+
         Args:
             prefix (str): The tag prefix for the metric. Each field name in the
                 metrics object will be prepended with the prefix.

--- a/pytext/models/decoders/intent_slot_model_decoder.py
+++ b/pytext/models/decoders/intent_slot_model_decoder.py
@@ -44,7 +44,7 @@ class IntentSlotModelDecoder(DecoderBase):
 
         Attributes:
             use_doc_probs_in_word (bool): Whether to use intent probabilities
-            for predicting slots.
+                for predicting slots.
         """
 
         use_doc_probs_in_word: bool = False

--- a/pytext/models/representations/pair_rep.py
+++ b/pytext/models/representations/pair_rep.py
@@ -32,14 +32,14 @@ class PairRepresentation(RepresentationBase):
     class Config(RepresentationBase.Config):
         """
         Attributes:
-            * `encode_relations`: if `false`, return the concatenation of the two
-              representations; if `true`, also concatenate their pairwise absolute
-              difference and pairwise elementwise product (à la arXiv:1705.02364).
-              Default: `true`.
-            * `subrepresentation`: the sub-representation used for the inputs. If
+            encode_relations (bool): if `false`, return the concatenation of the two
+                representations; if `true`, also concatenate their pairwise absolute
+                difference and pairwise elementwise product (à la arXiv:1705.02364).
+                Default: `true`.
+            subrepresentation (SubRepresentation): the sub-representation used for the inputs. If
               `subrepresentation_right` is not given, then this representation is
-               used for both inputs with tied weights.
-            * `subrepresentation_right`: the sub-representation used for the right
+              used for both inputs with tied weights.
+            subrepresentation_right (Optional[SubRepresentation]): the sub-representation used for the right
                input. Optional. If missing, `subrepresentation` is used with tied
                weights. Default: `None`.
         """

--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -38,9 +38,9 @@ class AblationParams(ConfigBase):
     when computing representation for the action classifier
 
     Attributes:
-    use_buffer: whether to use the buffer LSTM
-    use_stack: whether to use the stack LSTM
-    use_action: whether to use the action LSTM
+        use_buffer (bool): whether to use the buffer LSTM
+        use_stack (bool): whether to use the stack LSTM
+        use_action (bool): whether to use the action LSTM
     """
 
     use_buffer: bool = True
@@ -51,15 +51,17 @@ class AblationParams(ConfigBase):
 
 class RNNGConstraints(ConfigBase):
     """Constraints when computing valid actions.
+    
+    Attributes:
+        intent_slot_nesting (bool): for the intent slot models, the top level non-terminal
+            has to be an intent, an intent can only have slot non-terminals as
+            children and vice-versa.
 
-    intent_slot_nesting: for the intent slot models, the top level non-terminal
-    has to be an intent, an intent can only have slot non-terminals as
-    children and vice-versa.
-
-    ignore_loss_for_unsupported and no_slots_inside_unsupported:
-    if the data has "unsupported" label, that is if the label has a substring
-    "unsupported" in it, these flags control whether or not to compute loss or
-    predict slots in side the unsupported intent
+        ignore_loss_for_unsupported (bool): if the data has "unsupported" label, 
+            that is if the label has a substring "unsupported" in it, do not compute loss
+        no_slots_inside_unsupported (bool): if the data has "unsupported" label, that is
+            if the label has a substring "unsupported" in it, do not predict slots inside
+            this label.
     """
 
     intent_slot_nesting: bool = True
@@ -267,26 +269,22 @@ class RNNGParser(Model, Component):
         """RNNG forward function.
 
         Args:
-        tokens : torch.Tensor
-            list of tokens
-        seq_lens : torch.Tensor
-            list of sequence lengths
-        dict_feat : Optional[Tuple[torch.Tensor, ...]]
-            dictionary or gazetteer features for each token
-        actions : Optional[List[List[int]]]
-            Used only during training. Oracle actions for the instances.
-        beam_size : int
-            Beam size; used only during inference
-        topk : int
-            Number of top results from the method. if beam_size is 1 this is 1.
+            tokens (torch.Tensor): list of tokens
+            seq_lens (torch.Tensor): list of sequence lengths
+            dict_feat (Optional[Tuple[torch.Tensor, ...]]): dictionary or gazetteer
+                features for each token
+            actions (Optional[List[List[int]]]): Used only during training. 
+                Oracle actions for the instances.
+            beam_size (int): Beam size; used only during inference
+            topk (int) : Number of top results from the method. if beam_size is 1 this is 1.
 
 
         Returns:
-        if topk == 1
-            tuple of list of predicted actions and list of corresponding scores
-        else
+            if topk == 1
+                tuple of list of predicted actions and list of corresponding scores
+                else
             returns
-            list of tuple of list of predicted actions and list of corresponding scores
+                list of tuple of list of predicted actions and list of corresponding scores
 
 
         """
@@ -506,12 +504,10 @@ class RNNGParser(Model, Component):
         """Used for restricting the set of possible action predictions
 
         Args:
-        state : ParserState
-            The state of the stack, buffer and action
+            state (ParserState): The state of the stack, buffer and action
 
         Returns:
-        List[int]
-            indices of the valid actions
+            List[int] : indices of the valid actions
 
         """
         valid_actions: List[int] = []

--- a/pytext/models/seq_models/contextual_intent_slot.py
+++ b/pytext/models/seq_models/contextual_intent_slot.py
@@ -14,14 +14,14 @@ class ContextualIntentSlotModel(JointModel):
     Joint Model for Intent classification and slot tagging with inputs of contextual
     information (sequence of utterances) and dictionary feature of the last utterance.
 
-    Training data should includes:
-    doc_label (string): intent classification label of either the sequence of
-        utterances or just the last sentence
-    word_label (string): slot tagging label of the last utterance in the format
-        of start_idx:end_idx:slot_label, multiple slots are separated by a comma
+    Training data should include:
+    doc_label (string): intent classification label of either the sequence of \
+    utterances or just the last sentence
+    word_label (string): slot tagging label of the last utterance in the format\
+    of start_idx:end_idx:slot_label, multiple slots are separated by a comma
     text (list of string): sequence of utterances for training
-    dict_feat (dict): a dict of features that contains the feature of each word
-        in the last utterance
+    dict_feat (dict): a dict of features that contains the feature of each word\
+    in the last utterance
 
     Following is an example of raw columns from training data:
     doc_label   reply-where

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -70,10 +70,11 @@ class Trainer(TrainerBase):
         """
         Train and eval a model, the model states will be modified. This function
         iterates epochs specified in config, and for each epoch do:
-            1 Train model using training data, aggregate and report training results
-            2 Adjust learning rate if scheduler is specified
-            3 Evaluate model using evaluation data
-            4 Calculate metrics based on evaluation results and select best model
+
+            1. Train model using training data, aggregate and report training results
+            2. Adjust learning rate if scheduler is specified
+            3. Evaluate model using evaluation data
+            4. Calculate metrics based on evaluation results and select best model
 
         Args:
             train_iter (BatchIterator): batch iterator of training data

--- a/pytext/utils/documentation_helper.py
+++ b/pytext/utils/documentation_helper.py
@@ -37,6 +37,7 @@ def get_config_fields(obj):
         Return a dict of config help for this object, where:
         - key: config name
         - value: (default, type, options)
+
             - default: default value for this key if not specified
             - type: type for this config value, as a string
             - options: possible values for this config, only if type = Union

--- a/pytext/utils/loss_utils.py
+++ b/pytext/utils/loss_utils.py
@@ -7,15 +7,18 @@ from pytext.utils.cuda_utils import FloatTensor
 
 def range_to_anchors_and_delta(precision_range, num_anchors):
     """Calculates anchor points from precision range.
-      Args:
-        precision_range: an interval (a, b), where 0.0 <= a <= b <= 1.0
-        num_anchors: int, number of equally spaced anchor points.
-      Returns:
-        precision_values: A `Tensor` of [num_anchors] equally spaced values
-          in the interval precision_range.
-        delta: The spacing between the values in precision_values.
-      Raises:
-        ValueError: If precision_range is invalid.
+
+        Args:
+            precision_range: an interval (a, b), where 0.0 <= a <= b <= 1.0
+            num_anchors: int, number of equally spaced anchor points.
+
+        Returns:
+            precision_values: A `Tensor` of [num_anchors] equally spaced values
+                in the interval precision_range.
+            delta: The spacing between the values in precision_values.
+
+        Raises:
+            ValueError: If precision_range is invalid.
     """
     # Validate precision_range.
     if len(precision_range) != 2:
@@ -134,13 +137,15 @@ def weighted_hinge_loss(labels, logits, positive_weights=1.0, negative_weights=1
 def true_positives_lower_bound(labels, logits, weights):
     """
     true_positives_lower_bound defined in paper:
-        "Scalable Learning of Non-Decomposable Objectives"
+    "Scalable Learning of Non-Decomposable Objectives"
+
     Args:
         labels: A `Tensor` of shape broadcastable to logits.
         logits: A `Tensor` of shape [N, C] or [N, C, K].
             If the third dimension is present,
             the lower bound is computed on each slice [:, :, k] independently.
         weights: Per-example loss coefficients, with shape [N, 1] or [N, C]
+
     Returns:
         A `Tensor` of shape [C] or [C, K].
     """
@@ -158,7 +163,8 @@ def true_positives_lower_bound(labels, logits, weights):
 def false_postives_upper_bound(labels, logits, weights):
     """
     false_positives_upper_bound defined in paper:
-        "Scalable Learning of Non-Decomposable Objectives"
+    "Scalable Learning of Non-Decomposable Objectives"
+
     Args:
         labels: A `Tensor` of shape broadcastable to logits.
         logits: A `Tensor` of shape [N, C] or [N, C, K].
@@ -166,6 +172,7 @@ def false_postives_upper_bound(labels, logits, weights):
             the lower bound is computed on each slice [:, :, k] independently.
         weights: Per-example loss coefficients, with shape broadcast-compatible with
             that of `labels`. i.e. [N, 1] or [N, C]
+
     Returns:
         A `Tensor` of shape [C] or [C, K].
     """


### PR DESCRIPTION
Summary: Attacks issues related to indentation and formatting of docstrings. There are 3 families of issues:
1.) bad indentation of individual lines of otherwise good docstrings, these are simple fixes
2.) docstrings not following proper style, simple fixes again
3.) docstrings on config classes, which don't get parsed at all. These are being fixed via unindenting them at read time

Test Plan:
  make clean-all
  make html

and inspect the output, will add a link to the built docs on circleci after the PR is up

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
