### PR TITLE
onnx exporter for context intent slot model

### DIFF
--- a/pytext/exporters/exporter.py
+++ b/pytext/exporters/exporter.py
@@ -90,6 +90,11 @@ class ModelExporter(Component):
             torch.tensor([1, 1], dtype=torch.long)
         )  # token lengths
         input_names.append("tokens_lens")
+        if "seq_tokens_vals" in input_names:
+            dummy_model_input.append(
+                torch.tensor([1, 1], dtype=torch.long)
+            )  # seq lengths
+            input_names.append("seq_tokens_lens")
         return input_names, tuple(dummy_model_input), feature_itos_map
 
     def __init__(self, config, input_names, dummy_model_input, vocab_map, output_names):

--- a/pytext/fields/field.py
+++ b/pytext/fields/field.py
@@ -241,6 +241,8 @@ class TextFeatureField(VocabUsingField):
 
 
 class SeqFeatureField(VocabUsingNestedField):
+    dummy_model_input = torch.tensor([[[1]], [[1]]], dtype=torch.long, device="cpu")
+
     def __init__(
         self,
         pretrained_embeddings_path="",


### PR DESCRIPTION
Summary:
Implement onnx exporter for Contextual Intent Slot model:

1. refactor contextual intent slot representation layer to avoid using unsupported operator in cafe2: a. use docNN instead of BiLSTM in sequence representation because sort() is not supported in cafe2; b. use repeat() instead of expand() while concat the word_embedding and sequence embedding.
2. add seq_tokens_vals, seq_length in exporter dummy input
3. add new test for contextual intent slot exporter

Differential Revision: D13553807
