### PR TITLE
Print out utterance for tree validation errors for RNNG

### DIFF
--- a/pytext/data/compositional_data_handler.py
+++ b/pytext/data/compositional_data_handler.py
@@ -159,7 +159,7 @@ class CompositionalDataHandler(DataHandler):
         actions = ""
         # training time
         if DFColumn.SEQLOGICAL in row_data:
-            annotation = Annotation(row_data[DFColumn.SEQLOGICAL])
+            annotation = Annotation(row_data[DFColumn.SEQLOGICAL], utterance)
             actions = annotation.tree.to_actions()
 
             # Seqlogical format is required for building the tree representation of

--- a/pytext/data/data_structures/annotation.py
+++ b/pytext/data/data_structures/annotation.py
@@ -54,6 +54,7 @@ class Annotation:
     def __init__(
         self,
         annotation_string: str,
+        utterance: str = "",
         brackets: str = OPEN + CLOSE,
         combination_labels: bool = True,
         add_dict_feat: bool = False,
@@ -75,7 +76,9 @@ class Annotation:
         else:
             raise ValueError("Cannot parse annotation_string")
 
-        self.tree = Tree(self.build_tree(accept_flat_intents_slots), combination_labels)
+        self.tree = Tree(
+            self.build_tree(accept_flat_intents_slots), combination_labels, utterance
+        )
         self.root: Root = self.tree.root
 
     def build_tree(self, accept_flat_intents_slots: bool = False):
@@ -479,13 +482,18 @@ class Node_Info:
 
 
 class Tree:
-    def __init__(self, root: Root, combination_labels: bool) -> None:
+    def __init__(
+        self, root: Root, combination_labels: bool, utterance: str = ""
+    ) -> None:
         self.root = root
         self.combination_labels = combination_labels
         try:
             self.validate_tree()
         except ValueError as v:
-            raise ValueError("Tree validation failed: {}".format(v))
+            raise ValueError(
+                "Tree validation failed: {}. \n".format(v)
+                + "Utterance is: {}".format(utterance)
+            )
 
     def validate_tree(self):
         """


### PR DESCRIPTION
Summary: Print out the utterance that results in tree validation errors in the Tree class in annotation.py. This will be helpful for debugging.

Differential Revision: D13556119
