### PR TITLE
Cleanup Hogwild trainer

### DIFF
--- a/pytext/trainers/ensemble_trainer.py
+++ b/pytext/trainers/ensemble_trainer.py
@@ -42,8 +42,6 @@ class EnsembleTrainer(TrainerBase):
             most of the case only contains one optimizer
         scheduler (Optional[torch.optim.lr_scheduler]): learning rate scheduler,
             default is None
-        training_result (Optional): only meaningful for Hogwild training. default
-            is None
         rank (int): only used in distributed training, the rank of the current
             training thread, evaluation will only be done in rank 0
 

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -3,7 +3,7 @@
 
 import copy
 import sys
-from typing import List, Optional
+from typing import Any, List, Optional, Tuple
 
 import torch
 from pytext.common.constants import BatchContext, Stage
@@ -64,9 +64,8 @@ class Trainer(TrainerBase):
         train_config: PyTextConfig,
         optimizers: List[torch.optim.Optimizer],
         scheduler=None,
-        training_result=None,  # only meaningful for Hogwild training.
         rank: int = 0,
-    ):
+    ) -> Tuple[torch.nn.Module, Any]:
         """
         Train and eval a model, the model states will be modified. This function
         iterates epochs specified in config, and for each epoch do:
@@ -185,11 +184,7 @@ class Trainer(TrainerBase):
             sys.stdout.flush()
 
         model.load_state_dict(best_model_state)
-
-        if training_result is not None:
-            training_result.append((model, best_metric))
-        else:
-            return model, best_metric
+        return model, best_metric
 
     def _run_epoch(
         self,
@@ -202,7 +197,7 @@ class Trainer(TrainerBase):
         backprop=lambda loss: None,
         rank=0,
     ):
-        print(f"Rank {rank} worker: Running epoch for {stage}")
+        print(f"Rank {rank} worker: Running epoch #{epoch} for {stage}")
         report_metric = stage != Stage.TRAIN or self.config.report_train_metrics
         for batch_id, (inputs, targets, context) in enumerate(data_iter):
             pre_batch()


### PR DESCRIPTION
Summary:
Fix possible race conditions in Hogwild trainer.
We join all the parallel processes after traning every epoch, and do evaulation after joining, so that we dont encounter races during evaluation and model selection.

This implementation is similar to what sklearn is doing: https://github.com/srome/sklearn-hogwild/blob/master/hogwildsgd.py#L78

Differential Revision: D13426423
