### PR TITLE
Enabling multithreading in doc generation, fixing warning

### DIFF
--- a/pytext/docs/Makefile
+++ b/pytext/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = "-j=auto"
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyText
 SOURCEDIR     = source

--- a/pytext/docs/source/conf.py
+++ b/pytext/docs/source/conf.py
@@ -184,6 +184,8 @@ def run_apidoc(_):
 
     apidoc.main(argv)
 
+    os.remove(os.path.join(modules, "modules.rst"))
+
     from make_config_docs import main
 
     main()


### PR DESCRIPTION
This will fix 1 warning during doc generation.

