### PR TITLE
Gets rid of all doc gen warnings for Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: source .circleci/setup_circleimg.sh
       - run:
           name: install_pytorch
-          command: sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+          command: sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-linux_x86_64.whl
       - run:
           name: install docs build deps
           command: sudo pip install -r pytext/docs/requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           destination: coverage
   build_docs:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
       - run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We use isort and black to format our code, you can use the following commands to
 ```
 
 ## Updates to Docs
-The documentation only work with Python 3.7 and above. 
+The documentation build process work with Python 3.7 and above. 
  
 ## License
 By contributing to PyText, you agree that your contributions will be licensed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,7 @@ We use isort and black to format our code, you can use the following commands to
 ```
 
 ## Updates to Docs
-
-ReadTheDocs documentation changes only work with Python 3.7 and above. 
+The documentation only work with Python 3.7 and above. 
  
 ## License
 By contributing to PyText, you agree that your contributions will be licensed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ We use isort and black to format our code, you can use the following commands to
 (pytext_venv) $ isort pytext --recursive --multi-line 3 --trailing-comma --force-grid-wrap 0 --line-width 88 --lines-after-imports 2 --combine-as --section-default THIRDPARTY
 ```
 
+## Updates to Docs
+
+ReadTheDocs documentation changes only work with Python 3.7 and above. 
+ 
 ## License
 By contributing to PyText, you agree that your contributions will be licensed
 under the LICENSE file in the root directory of this source tree.

--- a/pytext/docs/Makefile
+++ b/pytext/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = "-j=auto -W"
+SPHINXOPTS    = -j=auto -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyText
 SOURCEDIR     = source

--- a/pytext/docs/Makefile
+++ b/pytext/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = "-j=auto"
+SPHINXOPTS    = "-j=auto" -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyText
 SOURCEDIR     = source

--- a/pytext/docs/Makefile
+++ b/pytext/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = "-j=auto" -W
+SPHINXOPTS    = "-j=auto -W"
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyText
 SOURCEDIR     = source

--- a/pytext/docs/make_config_docs.py
+++ b/pytext/docs/make_config_docs.py
@@ -85,7 +85,10 @@ def marked_up_type_name(arg_type):
         return f"Union[{', '.join(options)}]"
     elif hasattr(arg_type, "__args__"):
         options = [marked_up_type_name(t) for t in arg_type.__args__]
-        return f"{arg_type.__name__}[{', '.join(options)}]"
+        type_name = (
+            arg_type.__origin__.__name__ if arg_type.__origin__ else arg_type.__name__
+        )
+        return f"{type_name}[{', '.join(options)}]"
     elif arg_type is typing.Any:
         return f"Any"
     elif issubclass(arg_type, ConfigBase):

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,7 +2,7 @@ build:
   image: latest
 
 python:
-  version: 3.6
+  version: 3.7
   setup_py_install: true
   use_system_site_packages: true
 requirements_file: docs_requirements.txt


### PR DESCRIPTION


## Motivation and Context

This fixes the error that was preventing doc generation in Python 3.7. Note that doc generation will still throw a warning for 3.6, but a lot of time has been spent trying to fix that by Chris and me and moving ahead is the best approach anyway. Therefore, this commit also updates doc generation on CircleCI and ReadTheDocs to Python 3.7. Finally, enabling failures on warning for Sphinx doc gen so we lock this down for good.

## How Has This Been Tested

Tested by building docs locally without errors

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
