### PR TITLE
Removing intents as valid actions if a sibling intent exists

### DIFF
--- a/pytext/models/semantic_parsers/rnng/rnng_data_structures.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_data_structures.py
@@ -11,8 +11,10 @@ from pytext.utils.cuda_utils import xaviervar
 # token/non-terminal/sub-tree element on a stack.
 # need this value for computing valid actions
 class Element:
-    def __init__(self, node) -> None:
+    def __init__(self, node, has_child_intent=False, has_child_slot=False) -> None:
         self.node = node
+        self.has_child_intent = has_child_intent
+        self.has_child_slot = has_child_slot
 
     def __str__(self):
         return str(self.node)
@@ -173,6 +175,7 @@ class ParserState:
         other.is_open_NT = self.is_open_NT.copy()
         other.neg_prob = self.neg_prob
         other.found_unsupported = self.found_unsupported
+        other.sibling_is_intent = self.sibling_is_intent
         return other
 
     def __gt__(self, other):

--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -456,6 +456,16 @@ class RNNGParser(Model, Component):
                     ):
                         state.found_unsupported = True
 
+                    if target_action_idx in self.valid_IN_idxs:
+                        last_open_NT = None
+                        try:
+                            last_open_NT = state.stack_stackrnn.ele_from_top(
+                                state.is_open_NT[::-1].index(True)
+                            )
+                            last_open_NT.has_child_intent = True
+                        except ValueError:
+                            pass
+
                     state.is_open_NT.append(True)
                     state.num_open_NT += 1
                     state.stack_stackrnn.push(
@@ -534,7 +544,11 @@ class RNNGParser(Model, Component):
 
             if (not self.training) or self.constraints_intent_slot_nesting:
                 # if stack is empty or the last open NT is slot
-                if (not last_open_NT) or last_open_NT.node in self.valid_SL_idxs:
+                if (not last_open_NT) or (
+                    last_open_NT.node in self.valid_SL_idxs
+                    and not last_open_NT.has_child_intent
+                ):
+
                     valid_actions += self.valid_IN_idxs
                 elif last_open_NT.node in self.valid_IN_idxs:
                     if (


### PR DESCRIPTION
Summary:
Currently, there are no explicit constraints in the RNNG Python model that prevent an invalid tree with two (or more) child intents under one parent from forming.

This diff adds a constraint which prevents intents from being added as valid actions when a sibling intent has been detected.

Differential Revision: D13582124
