### PR TITLE
Select best epoch for target task

### DIFF
--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -1,14 +1,36 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import Dict, Optional
+
 from pytext.common.constants import BatchContext
 
 from .metric_reporter import MetricReporter
 
 
 class DisjointMultitaskMetricReporter(MetricReporter):
-    def __init__(self, reporters) -> None:
+    class Config(MetricReporter.Config):
+        target_task_name: Optional[str] = None  # for selecting best epoch
+
+    def __init__(
+        self, reporters: Dict[str, MetricReporter], target_task_name: Optional[str]
+    ) -> None:
+        """Short summary.
+
+        Args:
+            reporters (Dict[str, MetricReporter]):
+                Dictionary of sub-task metric-reporters.
+            target_task_name (Optional[str]):
+                Dev metric for this task will be used to select best epoch.
+
+        Returns:
+            None: Description of returned object.
+
+        """
+
         super().__init__(None)
         self.reporters = reporters
+        self.target_task_name = target_task_name or ""
+        self.target_reporter = self.reporters.get(self.target_task_name, None)
 
     def add_batch_stats(
         self, n_batches, preds, targets, scores, loss, m_input, **context
@@ -22,6 +44,12 @@ class DisjointMultitaskMetricReporter(MetricReporter):
         for reporter in self.reporters.values():
             reporter.add_channel(channel)
 
+    def compare_metric(self, new_metric, old_metric):
+        if self.target_reporter:
+            return self.target_reporter.compare_metric(new_metric, old_metric)
+        else:
+            return True
+
     def report_metric(self, stage, epoch, reset=True, print_to_channels=True):
         metrics_dict = {}
         for name, reporter in self.reporters.items():
@@ -29,7 +57,7 @@ class DisjointMultitaskMetricReporter(MetricReporter):
             metrics_dict[name] = reporter.report_metric(
                 stage, epoch, reset, print_to_channels
             )
-        return metrics_dict
-
-    def compare_metric(self, new_metric, old_metric):
-        return True
+        if self.target_reporter:
+            return metrics_dict[self.target_task_name]
+        else:
+            return metrics_dict

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -59,7 +59,8 @@ class DisjointMultitask(TaskBase):
             OrderedDict(
                 (name, create_metric_reporter(task.metric_reporter, metadata[name]))
                 for name, task in task_config.tasks.items()
-            )
+            ),
+            target_task_name=task_config.metric_reporter.target_task_name,
         )
 
         model = DisjointMultitaskModel(


### PR DESCRIPTION
Summary: Allow specifiying a target task for disjoint multitask training which will be used to select the best epoch on dev.

Differential Revision: D13406159
