### PR TITLE
gen_default_config dynamically loads custom components

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -6,11 +6,13 @@ import pprint
 import sys
 import tempfile
 from importlib import import_module
+from pydoc import locate
 
 import click
 import torch
 from pytext import create_predictor
 from pytext.config import PyTextConfig
+from pytext.config.component import register_tasks
 from pytext.config.serialize import config_from_json, config_to_json, parse_config
 from pytext.data.data_handler import CommonMetadata
 from pytext.task import load
@@ -96,9 +98,15 @@ def run_single(
 
 
 def gen_config_impl(task_name, options):
+    # import the classes required by parameters
+    requested_classes = [locate(opt) for opt in options] + [locate(task_name)]
+    register_tasks(requested_classes)
+
     task_class_set = find_config_class(task_name)
     if not task_class_set:
-        raise Exception(f"Unknown task class: {task_name}")
+        raise Exception(
+            f"Unknown task class: {task_name} " "(try fully qualified class name?)"
+        )
     elif len(task_class_set) > 1:
         raise Exception(f"Multiple tasks named {task_name}: {task_class_set}")
 

--- a/pytext/utils/documentation_helper.py
+++ b/pytext/utils/documentation_helper.py
@@ -142,13 +142,14 @@ def find_config_class(class_name):
         module_part = ".".join(m[:-1])
 
     ret = set()
-    for mod_name, mod in modules.items():
-        if not mod_name.startswith("pytext"):
+    for _, mod in list(modules.items()):
+        try:
+            for name, obj in getmembers(mod, isclass):
+                if name == class_name:
+                    if not module_part or obj.__module__ == module_part:
+                        ret.add(obj)
+        except ModuleNotFoundError:
             continue
-        for name, obj in getmembers(mod, isclass):
-            if name == class_name:
-                if not module_part or obj.__module__ == module_part:
-                    ret.add(obj)
     return ret
 
 


### PR DESCRIPTION
Summary:
Custom components are not import-ed in python main, gen_default_config
can't find them. This diff dynamically loads the classes from the fully
qualified class name.

This is a fix for github issue #145

Differential Revision: D13604448
