### PR TITLE
fix embedding loading issue of Fairseq model

### DIFF
--- a/pytext/utils/embeddings_utils.py
+++ b/pytext/utils/embeddings_utils.py
@@ -158,9 +158,17 @@ class PretrainedEmbedding(object):
         assert self.embedding_vectors is not None and self.embed_vocab is not None
         assert pretrained_embeds_weight.shape[-1] == self.embedding_vectors.shape[-1]
         unk_idx = vocab_to_idx[unk]
+        oov_count = 0
         for word, idx in vocab_to_idx.items():
             if word in self.stoi and idx != unk_idx:
                 pretrained_embeds_weight[idx] = self.embedding_vectors[self.stoi[word]]
+            else:
+                oov_count += 1
+        print(
+            "Out of pretrained embedding vocab counts: {}/{}".format(
+                oov_count, len(vocab_to_idx)
+            )
+        )
         return pretrained_embeds_weight
 
 


### PR DESCRIPTION
Summary: Currently Pytext fairseq model doesn't support add pretrained embeddings. This diff is to add pretrained embeddings and it introduces a 5 absolution point improvement in accuracy in my NLG task (see f90768868).

Differential Revision: D13475500
