### PR TITLE
load dataset shard for training

### DIFF
--- a/pytext/data/test/datahandler_test.py
+++ b/pytext/data/test/datahandler_test.py
@@ -26,7 +26,21 @@ class DataHandlerTest(unittest.TestCase):
             DFColumn.DICT_FEAT,
         ]
 
-        data = DataHandler.read_from_file(file_name, columns)
+        feat = WordFeatConfig(
+            vocab_from_all_data=True,
+            vocab_from_train_data=False,
+            vocab_from_pretrained_embeddings=False,
+        )
+        featurizer = create_featurizer(
+            SimpleFeaturizer.Config(), FeatureConfig(word_feat=feat)
+        )
+        data_handler = DocClassificationDataHandler.from_config(
+            DocClassificationDataHandler.Config(),
+            ModelInputConfig(word_feat=feat),
+            TargetConfig(),
+            featurizer=featurizer,
+        )
+        data = data_handler.read_from_file(file_name, columns)
         for col in columns:
             self.assertTrue(col in data[0], "{} must in the data".format(col))
         self.assertEqual("alarm/modify_alarm", data[0][DFColumn.DOC_LABEL])
@@ -41,7 +55,21 @@ class DataHandlerTest(unittest.TestCase):
         file_name = tests_module.test_file("train_data_tiny.tsv")
         columns = {DFColumn.DOC_LABEL: 0, DFColumn.UTTERANCE: 2}
 
-        data = DataHandler.read_from_file(file_name, columns)
+        feat = WordFeatConfig(
+            vocab_from_all_data=True,
+            vocab_from_train_data=False,
+            vocab_from_pretrained_embeddings=False,
+        )
+        featurizer = create_featurizer(
+            SimpleFeaturizer.Config(), FeatureConfig(word_feat=feat)
+        )
+        data_handler = DocClassificationDataHandler.from_config(
+            DocClassificationDataHandler.Config(),
+            ModelInputConfig(word_feat=feat),
+            TargetConfig(),
+            featurizer=featurizer,
+        )
+        data = data_handler.read_from_file(file_name, columns)
         for col in columns:
             self.assertTrue(col in data[0], "{} must in the data".format(col))
         self.assertEqual("alarm/modify_alarm", data[0][DFColumn.DOC_LABEL])

--- a/pytext/utils/dist_utils.py
+++ b/pytext/utils/dist_utils.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import copy
+import math
 import os
 import signal
+from typing import Any, List
 
 import torch
 import torch.distributed as dist_c10d
@@ -34,3 +37,43 @@ def suppress_output():
             builtin_print(*args, **kwargs)
 
     __builtin__.print = print
+
+
+def get_shard_range(data_size: int, rank: int, world_size: int):
+    """
+    Add extra 1 examples in the remainder(e.g data_size % world_size) rank,
+    For example, world_size = 8, data_size = 66
+    The shard size is [9, 9, 8, 8, 8, 8, 8, 8]
+    """
+    remainder = data_size % world_size
+    shard_len = data_size // world_size
+    if rank < remainder:
+        shard_len += 1
+
+    shard_offset = rank * shard_len + min(rank, remainder)
+    shard_end = data_size if rank == world_size - 1 else shard_offset + shard_len
+    return (shard_offset, shard_end)
+
+
+def pad_shard_data(shard_data: List[Any], data_size: int, world_size: int):
+    """
+    Because of the trailing data (dataset_size % world_size), some shard could
+    have 1 less example than the maximum shard, in this case we will pad to
+    ensure every shard have the same size.
+    The impact should be negligible when dataset_size >> world_size
+    """
+    # TODO: the workaround is that we could store max_shard_size in Dataset
+
+    max_shard_size = math.ceil(data_size / float(world_size))
+    shard_data_size = len(shard_data)
+
+    if shard_data_size == max_shard_size:
+        pass
+    elif shard_data_size == max_shard_size - 1:
+        shard_data.append(copy.deepcopy(shard_data[-1]))
+    else:
+        raise ValueError(
+            f"shard_data_size should equal or one less than max_shard_size, "
+            + f"shard_data_size is {shard_data_size} and max_shard_size "
+            + f"{max_shard_size}"
+        )


### PR DESCRIPTION
Summary:
The intention of this diff is to reduce the memory usage when each node load the sharded dataset.

The current implmentation is that every node will load the whole dataset into memory and then take the shard, which could cause OOM issue because num_gpus * dataset_size

This diff enabled that
1. each node will only load the sharded dataset into memory, which means the total memory usage should approximate same when compare multi gpus and single gpu
2. we take the shard based on [rank, rank + world_size * 1, rank + world_size * 2, ....], and we might need to pad one more example in some sharded dataset

Example
dataset = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
world_size = 3

shard_1 = [1, 4, 7, 10]
shard_2 = [2, 5, 8, 8]
shard_3 = [3, 6, 9, 9]

The benefits of this Sharding + Padding approach is that
1. It doesn't require us to know the total dataset size in advance
2. The padding guarantee that each shard have the same number of examples which means we don't need to handle potential batch different issue
3. For every single shard, the maximum pad is 1 which is negligible when dataset size is large

To be aware, the current hiveio API is not streamed, so there will still be OOM issue for hive reader even the dataset could fits in memory

Differential Revision: D13644994
