### PR TITLE
remove epoch_size to simplify configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+ - Remove epoch_size param from DisjointMultitask, use target_task (or shortest) to set epoch_size
+
 ## v0.1.0
 
 Initial version

--- a/demo/configs/multitask_sst_lm.json
+++ b/demo/configs/multitask_sst_lm.json
@@ -2,9 +2,6 @@
   "config": {
     "task": {
       "DisjointMultitask": {
-        "data_handler": {
-          "epoch_size": 2000
-        },
         "trainer": {
           "epochs": 15
         },

--- a/pytext/data/data_handler.py
+++ b/pytext/data/data_handler.py
@@ -54,7 +54,7 @@ class BatchIterator:
         include_target=True,
         include_context=True,
         is_train=True,
-        num_batches=-1,
+        num_batches=0,
     ):
         self.processor = processor
         self.batches = batches
@@ -94,8 +94,11 @@ class BatchIterator:
             if i == num_batches - 1:
                 context = deepcopy(context)
                 context.update({BatchContext.IGNORE_LOSS: True})
-                for _j in range(num_batches, self.total_num_batches):
+                for _j in range(num_batches, len(self)):
                     yield (input, target, context)
+
+    def __len__(self):
+        return self.total_num_batches
 
 
 class DataHandler(Component):

--- a/pytext/data/test/round_robin_batchiterator_test.py
+++ b/pytext/data/test/round_robin_batchiterator_test.py
@@ -10,9 +10,7 @@ class RoundRobinBatchIteratorTest(unittest.TestCase):
     def test_batch_iterator(self):
         iteratorA = [(input, None, {}) for input in [1, 2, 3, 4]]
         iteratorB = [(input, None, {}) for input in ["a", "b", "c"]]
-        round_robin_iterator = RoundRobinBatchIterator(
-            {"A": iteratorA, "B": iteratorB}, epoch_size=10
-        )
+        round_robin_iterator = RoundRobinBatchIterator({"A": iteratorA, "B": iteratorB})
         expected_output = [1, "a", 2, "b", 3, "c", 4, "a", 1, "b"]
         for actual, expected in zip(round_robin_iterator, expected_output):
             assert actual[0] == expected

--- a/pytext/docs/source/disjoint_multitask_tutorial.rst
+++ b/pytext/docs/source/disjoint_multitask_tutorial.rst
@@ -86,13 +86,6 @@ The main configuration is under `tasks`, which is a dictionary of task name to t
 You can also modify `task_weights` to weight the loss for each task.
 The sub-tasks can be configured as you would in a single task setting, with the exception of changes described in the next sections.
 
-Also configure `epoch_size` under the parent task's data handler:
-::
-
-  "data_handler": {
-    "epoch_size": 2000
-  }
-
 
 3. Specify which parameters to share
 --------------------------------------

--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -8,9 +8,6 @@ from .metric_reporter import MetricReporter
 
 
 class DisjointMultitaskMetricReporter(MetricReporter):
-    class Config(MetricReporter.Config):
-        target_task_name: Optional[str] = None  # for selecting best epoch
-
     def __init__(
         self,
         reporters: Dict[str, MetricReporter],


### PR DESCRIPTION
Summary:
The epoch_size parameter to define epochs is counterinutitive from user perspective.  One needs to know dataset size and divide by batch size to judge what the epoch_size should be.  This diff removes this parameter in favor of a binary flag, and a reasonable default epoch size.

Two parameters are added:
- upsample (in DisjointMultitaskDatahandler)
- target_task_name (moved to DisjointMultitask.Config)

If upsample = True (default):
We'll cycle over each dataset repeatedly in round-robin fashion, so that shorter datasets will see more iterations (upsampled).  Epoch is defined to be the epoch of the target task, if defined, otherwise it's set to the length of the shortest dataset.

If upsample = False:
We do a single pass over each dataset.  Datasets which are short will sit idle some of the time.  This is used for evaluation.

Differential Revision: D13678696
