### PR TITLE
default config for JointTextTask

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -123,7 +123,8 @@ def gen_config_impl(task_name, options):
         raise Exception(f"Multiple tasks named {task_name}: {task_class_set}")
 
     task_class = next(iter(task_class_set))
-    root = PyTextConfig(task=task_class.Config())
+    task_config = getattr(task_class, "example_config", task_class.Config)
+    root = PyTextConfig(task=task_config())
 
     # Use components listed in options instead of defaults
     for opt in options:

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -145,9 +145,9 @@ class WordTaggingTask(Task):
 
 class JointTextTask(Task):
     class Config(Task.Config):
+        labels: List[TargetConfigBase]
         model: JointModel.Config = JointModel.Config()
         trainer: Trainer.Config = Trainer.Config()
-        labels: List[TargetConfigBase]
         data_handler: JointModelDataHandler.Config = JointModelDataHandler.Config()
         metric_reporter: IntentSlotMetricReporter.Config = (
             IntentSlotMetricReporter.Config()
@@ -168,6 +168,10 @@ class JointTextTask(Task):
             ),
         ):
             yield {"intent": intent, "slot": slot}
+
+    @classmethod
+    def example_config(cls):
+        return cls.Config(labels=[DocLabelConfig(), WordLabelConfig()])
 
 
 class LMTask(Task):


### PR DESCRIPTION
Summary:
because fblearner is confused about types List[Union], we can't
give a default value to those Config parameters and we leave them empty.
That's a problem for gen_default_config, which relies on instanciating
components with default values. So those configs, like JointTextTask, can't
be used with gen_default_config.

This diff introduces a generic solution for Tasks like this (not for all
components, coming soon) by allowing each task to provide an optional
function "example_config" that returns a Config object with default values
suitable for gen_default_config. This default values for List[Union] should
be a list of each possible class of the union, to give a complete example
that users can edit at their convenience.

We solve the case of JointTextTask as an example. Other tasks will be solved
in following diffs.

Differential Revision: D13441705
