### PR TITLE
Fix hypothesis dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 future
-hypothesis
+hypothesis<4.0
 joblib
 numpy
 onnx


### PR DESCRIPTION
Summary:
caffe2 uses min_satisfying_examples, which was removed in v4.0 of
hypothesis. This diff makes sure we depend on an earlier version until this
is fixed upstream

Differential Revision: D13704590
