### PR TITLE
Make CosineAnnealingLR a batch-based scheduler

### DIFF
--- a/pytext/optimizer/scheduler.py
+++ b/pytext/optimizer/scheduler.py
@@ -206,7 +206,7 @@ class Scheduler(Component):
                 for optimizer in optimizers
             ]
         elif scheduler_params.type == SchedulerType.COSINE_ANNEALING_LR:
-            self.epoch_based_schedulers = [
+            self.batch_based_schedulers = [
                 CosineAnnealingLR(
                     optimizer, scheduler_params.T_max, scheduler_params.eta_min
                 )


### PR DESCRIPTION
Summary: CosineAnnealingLR treats `last_epoch` as the batch number (https://pytorch.org/docs/stable/_modules/torch/optim/lr_scheduler.html#CosineAnnealingLR), and this should be updated every training step.

Differential Revision: D13704662
