### PR TITLE
add defaults to DisjointMultitask

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -109,7 +109,8 @@ def gen_config_impl(task_name, options):
         raise Exception(f"Multiple tasks named {task_name}: {task_class_set}")
 
     task_class = next(iter(task_class_set))
-    root = PyTextConfig(task=task_class.Config())
+    task_config = getattr(task_class, "example_config", task_class.Config)
+    root = PyTextConfig(task=task_config())
 
     # Use components listed in options instead of defaults
     for opt in options:

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -20,6 +20,7 @@ from pytext.metric_reporters.disjoint_multitask_metric_reporter import (
 )
 from pytext.models.disjoint_multitask_model import DisjointMultitaskModel
 from pytext.optimizer.scheduler import Scheduler
+from pytext.task.task import ExampleTask
 from pytext.utils import cuda_utils
 
 from . import Task, TaskBase
@@ -36,6 +37,15 @@ class DisjointMultitask(TaskBase):
         target_task_name: Optional[str] = None  # for selecting best epoch
         data_handler: DisjointMultitaskDataHandler.Config = DisjointMultitaskDataHandler.Config()
         metric_reporter: DisjointMultitaskMetricReporter.Config = DisjointMultitaskMetricReporter.Config()
+
+    @classmethod
+    def example_config(cls):
+        return cls.Config(
+            tasks={
+                "first_task_name": ExampleTask.Config(),
+                "second_task_name": ExampleTask.Config(),
+            }
+        )
 
     @classmethod
     def from_config(cls, task_config, metadata=None, model_state=None):

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -224,3 +224,10 @@ class TaskBase(Component):
 
 class Task(TaskBase):
     __EXPANSIBLE__ = True
+
+
+class ExampleTask(Task):
+    "An example Task used to generate default configs"
+
+    class Config(ConfigBase):
+        info: str = "replace ExampleTask with your Task and config"

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -121,9 +121,9 @@ class WordTaggingTask(Task):
 
 class JointTextTask(Task):
     class Config(Task.Config):
+        labels: List[TargetConfigBase]
         model: JointModel.Config = JointModel.Config()
         trainer: Trainer.Config = Trainer.Config()
-        labels: List[TargetConfigBase]
         data_handler: JointModelDataHandler.Config = JointModelDataHandler.Config()
         metric_reporter: IntentSlotMetricReporter.Config = (
             IntentSlotMetricReporter.Config()
@@ -144,6 +144,10 @@ class JointTextTask(Task):
             ),
         ):
             yield {"intent": intent, "slot": slot}
+
+    @classmethod
+    def example_config(cls):
+        return cls.Config(labels=[DocLabelConfig(), WordLabelConfig()])
 
 
 class LMTask(Task):


### PR DESCRIPTION
Summary:
DisjointMultitask is a task containing tasks, so this diff introduces
ExampleTask, a dummy Task used as a placeholder in configs, only used to
generate the json.

Depends on D13441705

Differential Revision: D13441698
