### PR TITLE
Fix featurizer & memory issues for char embeddings

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -46,6 +46,8 @@ class CharFeatConfig(ConfigBase):
     cnn: CNNParams = CNNParams()
     export_input_names: List[str] = ["char_vals"]
     vocab_from_train_data: bool = True
+    max_word_length: int = 20
+    min_freq: int = 1
 
 
 class PretrainedModelEmbeddingConfig(ConfigBase):

--- a/pytext/data/doc_classification_data_handler.py
+++ b/pytext/data/doc_classification_data_handler.py
@@ -101,12 +101,19 @@ class DocClassificationDataHandler(DataHandler):
             **kwargs,
         )
 
-    def _get_tokens(self, mode_feature):
+    def _get_tokens(self, model_feature):
         if self.max_seq_len > 0:
             # truncate tokens if max_seq_len is set
-            return mode_feature.tokens[: self.max_seq_len]
+            return model_feature.tokens[: self.max_seq_len]
         else:
-            return mode_feature.tokens
+            return model_feature.tokens
+
+    def _get_chars(self, model_feature):
+        if self.max_seq_len > 0:
+            # truncate tokens if max_seq_len is set
+            return model_feature.characters[: self.max_seq_len]
+        else:
+            return model_feature.characters
 
     def preprocess_row(self, row_data: Dict[str, Any]) -> Dict[str, Any]:
         features = self.featurizer.featurize(
@@ -123,7 +130,7 @@ class DocClassificationDataHandler(DataHandler):
                 features.gazetteer_feat_weights,
                 features.gazetteer_feat_lengths,
             ),
-            ModelInput.CHAR_FEAT: features.characters,
+            ModelInput.CHAR_FEAT: self._get_chars(features),
             ModelInput.PRETRAINED_MODEL_EMBEDDING: features.pretrained_token_embedding,
             ModelInput.DENSE_FEAT: row_data.get(ModelInput.DENSE_FEAT),
             # target

--- a/pytext/data/featurizer/simple_featurizer.py
+++ b/pytext/data/featurizer/simple_featurizer.py
@@ -55,7 +55,12 @@ class SimpleFeaturizer(Featurizer):
             tokens.insert(0, self.config.sentence_markers[0])
             tokens.append(self.config.sentence_markers[1])
 
-        return OutputRecord(tokens=tokens, token_ranges=token_ranges)
+        characters = [list(tok) for tok in tokens]
+
+        # TODO: support remaining features (see OutputRecord)
+        return OutputRecord(
+            tokens=tokens, token_ranges=token_ranges, characters=characters
+        )
 
     def tokenize_batch(
         self, input_records: Sequence[InputRecord]

--- a/pytext/data/test/simple_featurizer_test.py
+++ b/pytext/data/test/simple_featurizer_test.py
@@ -14,44 +14,32 @@ class SimpleFeaturizerTest(unittest.TestCase):
         featurizer = SimpleFeaturizer.from_config(
             SimpleFeaturizer.Config(), FeatureConfig()
         )
-        tokens = featurizer.featurize(InputRecord(raw_text=self.sentence)).tokens
-        self.assertListEqual(tokens, ["order", "me", "a", "coffee"])
+        features = featurizer.featurize(InputRecord(raw_text=self.sentence))
+        expected_tokens = ["order", "me", "a", "coffee"]
+        expected_chars = [list(tok) for tok in expected_tokens]
+        self.assertListEqual(features.tokens, expected_tokens)
+        self.assertListEqual(features.characters, expected_chars)
 
     def test_tokenize_dont_lowercase(self):
         featurizer = SimpleFeaturizer.from_config(
             SimpleFeaturizer.Config(lowercase_tokens=False), FeatureConfig()
         )
-        tokens = featurizer.featurize(InputRecord(raw_text=self.sentence)).tokens
-        self.assertListEqual(tokens, ["Order", "me", "a", "coffee"])
+        features = featurizer.featurize(InputRecord(raw_text=self.sentence))
+        expected_tokens = ["Order", "me", "a", "coffee"]
+        expected_chars = [list(tok) for tok in expected_tokens]
+        self.assertListEqual(features.tokens, expected_tokens)
+        self.assertListEqual(features.characters, expected_chars)
 
     def test_convert_to_bytes(self):
         featurizer = SimpleFeaturizer.from_config(
             SimpleFeaturizer.Config(convert_to_bytes=True, lowercase_tokens=False),
             FeatureConfig(),
         )
-        tokens = featurizer.featurize(InputRecord(raw_text=self.sentence)).tokens
-        self.assertListEqual(
-            tokens,
-            [
-                "O",
-                "r",
-                "d",
-                "e",
-                "r",
-                " ",
-                "m",
-                "e",
-                " ",
-                "a",
-                " ",
-                "c",
-                "o",
-                "f",
-                "f",
-                "e",
-                "e",
-            ],
-        )
+        features = featurizer.featurize(InputRecord(raw_text=self.sentence))
+        expected_tokens = list("Order me a coffee")
+        expected_chars = [list(char) for char in expected_tokens]
+        self.assertListEqual(features.tokens, expected_tokens)
+        self.assertListEqual(features.characters, expected_chars)
 
     def test_tokenize_add_sentence_markers(self):
         featurizer = SimpleFeaturizer.from_config(

--- a/pytext/fields/test/char_field_test.py
+++ b/pytext/fields/test/char_field_test.py
@@ -18,6 +18,7 @@ class CharFieldTest(unittest.TestCase):
             pad_token=VocabMeta.PAD_TOKEN,
             unk_token=VocabMeta.UNK_TOKEN,
             batch_first=True,
+            min_freq=2,
         )
         utterances = [
             [
@@ -50,15 +51,18 @@ class CharFieldTest(unittest.TestCase):
                 "c": 1,
             }
         )
+        expected_itos = [VocabMeta.UNK_TOKEN, pad, "l", "s", "u", "b"]
         preprocessed_data = [char_field.preprocess(x) for x in utterances]
-        char_field.build_vocab(preprocessed_data)
+        char_field.build_vocab(preprocessed_data, min_freq=2)
         self.assertEqual(char_field.vocab.freqs, expected_freqs)
+        self.assertEqual(char_field.vocab.itos, expected_itos)
 
     def test_pad_and_numericalize(self):
         char_field = CharFeatureField(
             pad_token=VocabMeta.PAD_TOKEN,
             unk_token=VocabMeta.UNK_TOKEN,
             batch_first=True,
+            max_word_length=4,
         )
         utterances = [
             [
@@ -74,18 +78,18 @@ class CharFieldTest(unittest.TestCase):
         # indices are meant to help relate to the expected_stitch_index.
         expected_padded_chars = [
             [
-                ["A", "l", "l", "l", pad],
-                ["u", "r", pad, pad, pad],
-                ["b", "@", "$", "s", pad],
-                ["b", "2", pad, pad, pad],
-                ["u", "s", pad, pad, pad],
+                ["A", "l", "l", "l"],
+                ["u", "r", pad, pad],
+                ["b", "@", "$", "s"],
+                ["b", "2", pad, pad],
+                ["u", "s", pad, pad],
             ],
             [
-                ["p", "l", "a", "y", pad],
-                ["m", "u", "s", "i", "c"],
-                [pad, pad, pad, pad, pad],
-                [pad, pad, pad, pad, pad],
-                [pad, pad, pad, pad, pad],
+                ["p", "l", "a", "y"],
+                ["m", "u", "s", "i"],
+                [pad, pad, pad, pad],
+                [pad, pad, pad, pad],
+                [pad, pad, pad, pad],
             ],
         ]
 


### PR DESCRIPTION
Summary:
This diff addresses a few issues for CharacterEmbeddings:

- `YodaFeaturizer`, `YodaFeaturizerLocal`, and `SimpleFeaturizer` did not create characters that can be used by `CharFeatureField` - fix this.
- `CharFeatureField` padded all tokens (in all sentences) to the max token length of each batch, which leads to OOMs (e.g. in hate speech there is a token of length 60k). Instead, add a `max_word_length` flag in the feature (default to 20).
- There was no `min_freq` flag for characters (so every character appearing in training data would get an embedding ID). Add this flag.

Differential Revision: D13662817
