### PR TITLE
Add field to specify model_select_metric for classification

### DIFF
--- a/pytext/docs/source/create_new_task.rst
+++ b/pytext/docs/source/create_new_task.rst
@@ -253,10 +253,10 @@ results.::
 	                )
 	            ),
 	            self.label_names,
+							self.calculate_loss(),
 	        )
 
-	    @staticmethod
-	    def get_model_select_metric(metrics):
+	    def get_model_select_metric(self, metrics):
 	        return metrics.accuracy
 
 The :class:`~MetricReporter` base class already aggregates all the output from :class:`~Trainer`,

--- a/pytext/metric_reporters/classification_metric_reporter.py
+++ b/pytext/metric_reporters/classification_metric_reporter.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import List
+from enum import Enum
+from typing import List, Optional
 
 from pytext.common.constants import Stage
 from pytext.data import CommonMetadata
@@ -25,17 +26,57 @@ class IntentModelChannel(FileChannel):
             ]
 
 
+class ComparableClassificationMetric(Enum):
+    ACCURACY = "accuracy"
+    ROC_AUC = "roc_auc"
+    MCC = "mcc"
+    MACRO_F1 = "macro_f1"
+    LABEL_F1 = "label_f1"
+    LABEL_AVG_PRECISION = "label_avg_precision"
+    # use negative because the reporter's lower_is_better value is False
+    NEGATIVE_LOSS = "negative_loss"
+
+
 class ClassificationMetricReporter(MetricReporter):
-    def __init__(self, label_names: List[str], channels: List[Channel]) -> None:
+    class Config(MetricReporter.Config):
+        model_select_metric: ComparableClassificationMetric = (
+            ComparableClassificationMetric.ACCURACY
+        )
+        target_label: Optional[str] = None
+
+    def __init__(
+        self,
+        label_names: List[str],
+        channels: List[Channel],
+        model_select_metric: str,
+        target_label: Optional[str],
+    ) -> None:
         super().__init__(channels)
         self.label_names = label_names
+        self.model_select_metric = model_select_metric
+        self.target_label = target_label
 
     @classmethod
     def from_config(cls, config, meta: CommonMetadata):
         label_names = meta.target.vocab.itos
+
+        if config.model_select_metric in (
+            ComparableClassificationMetric.LABEL_F1,
+            ComparableClassificationMetric.LABEL_AVG_PRECISION,
+        ):
+            assert config.target_label is not None
+            assert config.target_label in label_names
+        if config.model_select_metric in (
+            ComparableClassificationMetric.ROC_AUC,
+            ComparableClassificationMetric.MCC,
+        ):
+            assert len(label_names) == 2
+
         return cls(
             label_names,
             [ConsoleChannel(), IntentModelChannel((Stage.TEST,), config.output_path)],
+            config.model_select_metric,
+            config.target_label,
         )
 
     def calculate_metric(self):
@@ -47,11 +88,32 @@ class ClassificationMetricReporter(MetricReporter):
                 )
             ],
             self.label_names,
+            self.calculate_loss(),
         )
 
     def get_meta(self):
         return {"label_names": self.label_names}
 
-    @staticmethod
-    def get_model_select_metric(metrics):
-        return metrics.accuracy
+    def get_model_select_metric(self, metrics):
+        if self.model_select_metric == ComparableClassificationMetric.ACCURACY:
+            metric = metrics.accuracy
+        elif self.model_select_metric == ComparableClassificationMetric.ROC_AUC:
+            metric = metrics.roc_auc
+        elif self.model_select_metric == ComparableClassificationMetric.MCC:
+            metric = metrics.mcc
+        elif self.model_select_metric == ComparableClassificationMetric.MACRO_F1:
+            metric = metrics.macro_prf1_metrics.macro_scores.f1
+        elif self.model_select_metric == ComparableClassificationMetric.LABEL_F1:
+            metric = metrics.macro_prf1_metrics.per_label_scores[self.target_label].f1
+        elif (
+            self.model_select_metric
+            == ComparableClassificationMetric.LABEL_AVG_PRECISION
+        ):
+            metric = metrics.per_label_soft_scores[self.target_label].average_precision
+        elif self.model_select_metric == ComparableClassificationMetric.NEGATIVE_LOSS:
+            metric = -metrics.loss
+        else:
+            raise ValueError(f"unknown metric: {self.model_select_metric}")
+
+        assert metric is not None
+        return metric

--- a/pytext/metric_reporters/compositional_metric_reporter.py
+++ b/pytext/metric_reporters/compositional_metric_reporter.py
@@ -83,8 +83,7 @@ class CompositionalMetricReporter(MetricReporter):
             overall_metrics=True,
         )
 
-    @staticmethod
-    def get_model_select_metric(metrics):
+    def get_model_select_metric(self, metrics):
         return metrics.frame_accuracy
 
     @staticmethod

--- a/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
+++ b/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
@@ -181,6 +181,5 @@ class IntentSlotMetricReporter(MetricReporter):
             frame_accuracy=True,
         )
 
-    @staticmethod
-    def get_model_select_metric(metrics):
+    def get_model_select_metric(self, metrics):
         return metrics.frame_accuracy

--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -47,6 +47,5 @@ class LanguageModelMetricReporter(MetricReporter):
             n_words += num_words_in_batch
         return total_loss / float(n_words)
 
-    @staticmethod
-    def get_model_select_metric(metrics) -> float:
+    def get_model_select_metric(self, metrics) -> float:
         return metrics.perplexity_per_word

--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -176,8 +176,7 @@ class MetricReporter(Component):
             self._reset()
         return metrics
 
-    @staticmethod
-    def get_model_select_metric(metrics):
+    def get_model_select_metric(self, metrics):
         """
         Return a single numeric metric value that is used for model selection, returns
         the metric itself by default, but usually metrics will be more complicated
@@ -185,8 +184,7 @@ class MetricReporter(Component):
         """
         return metrics
 
-    @classmethod
-    def compare_metric(cls, new_metric, old_metric):
+    def compare_metric(self, new_metric, old_metric):
         """
         Check if new metric indicates better model performance
 
@@ -196,8 +194,8 @@ class MetricReporter(Component):
         if not old_metric:
             return True
 
-        new = cls.get_model_select_metric(new_metric)
-        old = cls.get_model_select_metric(old_metric)
+        new = self.get_model_select_metric(new_metric)
+        old = self.get_model_select_metric(old_metric)
         if new == old:
             return False
-        return (new < old) == cls.lower_is_better
+        return (new < old) == self.lower_is_better

--- a/pytext/metric_reporters/word_tagging_metric_reporter.py
+++ b/pytext/metric_reporters/word_tagging_metric_reporter.py
@@ -80,6 +80,5 @@ class WordTaggingMetricReporter(MetricReporter):
             ]
         )[1]
 
-    @staticmethod
-    def get_model_select_metric(metrics):
+    def get_model_select_metric(self, metrics):
         return metrics.micro_scores.f1

--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -188,6 +188,7 @@ class ClassificationMetrics(NamedTuple):
         per_label_soft_scores: Per label soft metrics.
         mcc: Matthews correlation coefficient.
         roc_auc: Area under the Receiver Operating Characteristic curve.
+        loss: Training loss (only used for selecting best model, no need to print).
     """
 
     accuracy: float
@@ -195,6 +196,7 @@ class ClassificationMetrics(NamedTuple):
     per_label_soft_scores: Optional[Dict[str, SoftClassificationMetrics]]
     mcc: Optional[float]
     roc_auc: Optional[float]
+    loss: float
 
     def print_metrics(self) -> None:
         print(f"Accuracy: {self.accuracy * 100:.2f}\n")
@@ -522,6 +524,7 @@ def compute_roc_auc(predictions: Sequence[LabelPrediction]) -> Optional[float]:
 def compute_classification_metrics(
     predictions: Sequence[LabelPrediction],
     label_names: Sequence[str],
+    loss: float,
     average_precisions: bool = True,
     recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THREHOLDS,
 ) -> ClassificationMetrics:
@@ -579,4 +582,5 @@ def compute_classification_metrics(
         per_label_soft_scores=soft_metrics,
         mcc=mcc,
         roc_auc=roc_auc,
+        loss=loss,
     )

--- a/pytext/metrics/tests/basic_metrics_test.py
+++ b/pytext/metrics/tests/basic_metrics_test.py
@@ -42,7 +42,7 @@ class BasicMetricsTest(MetricsTestBase):
     def test_prf1_metrics(self) -> None:
         self.assertMetricsAlmostEqual(
             compute_classification_metrics(
-                PREDICTIONS1, LABEL_NAMES1, average_precisions=False
+                PREDICTIONS1, LABEL_NAMES1, loss=2.0, average_precisions=False
             ),
             ClassificationMetrics(
                 accuracy=0.5,
@@ -60,6 +60,7 @@ class BasicMetricsTest(MetricsTestBase):
                 per_label_soft_scores=None,
                 mcc=None,
                 roc_auc=None,
+                loss=2.0,
             ),
         )
 
@@ -81,11 +82,11 @@ class BasicMetricsTest(MetricsTestBase):
         )
 
     def test_compute_mcc(self) -> None:
-        metrics = compute_classification_metrics(PREDICTIONS2, LABEL_NAMES2)
+        metrics = compute_classification_metrics(PREDICTIONS2, LABEL_NAMES2, loss=5.0)
         self.assertAlmostEqual(metrics.mcc, 1.0 / 6)
         # Just to test the metrics print without errors
         metrics.print_metrics()
 
     def test_compute_roc_auc(self) -> None:
-        metrics = compute_classification_metrics(PREDICTIONS2, LABEL_NAMES2)
+        metrics = compute_classification_metrics(PREDICTIONS2, LABEL_NAMES2, loss=5.0)
         self.assertAlmostEqual(metrics.roc_auc, 1.0 / 6)


### PR DESCRIPTION
Summary: Currently, the `ClassificationMetricReporter` chooses the best model by accuracy on eval data (over the training epochs). Add a field to specify other metrics for selecting best model, namely roc_auc, mcc, macro_f1, f1 of a target label, avg precision of a target label, and loss.

Differential Revision: D13727079
