### PR TITLE
fix to allow scheduler in multitask training

### DIFF
--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -7,6 +7,9 @@ from pytext.common.constants import BatchContext
 from .metric_reporter import MetricReporter
 
 
+AVRG_LOSS = "_avrg_loss"
+
+
 class DisjointMultitaskMetricReporter(MetricReporter):
     def __init__(
         self,
@@ -33,9 +36,15 @@ class DisjointMultitaskMetricReporter(MetricReporter):
         self.target_reporter = self.reporters.get(self.target_task_name, None)
         self.loss_weights = loss_weights
 
+    def _reset(self):
+        self.total_loss = 0
+        self.num_batches = 0
+
     def add_batch_stats(
         self, n_batches, preds, targets, scores, loss, m_input, **context
     ):
+        self.total_loss += loss
+        self.num_batches += 1
         # losses are weighted in DisjointMultitaskModel. Here we undo the
         # weighting for proper reporting.
         if self.loss_weights[context[BatchContext.TASK_NAME]] != 0:
@@ -50,19 +59,29 @@ class DisjointMultitaskMetricReporter(MetricReporter):
             reporter.add_channel(channel)
 
     def compare_metric(self, new_metric, old_metric):
+        if old_metric is None:
+            return True
         if self.target_reporter:
             return self.target_reporter.compare_metric(new_metric, old_metric)
-        else:
-            return True
+        else:  # default to training loss
+            return new_metric[AVRG_LOSS] < old_metric[AVRG_LOSS]
 
     def report_metric(self, stage, epoch, reset=True, print_to_channels=True):
-        metrics_dict = {}
+        metrics_dict = {AVRG_LOSS: self.total_loss / self.num_batches}
         for name, reporter in self.reporters.items():
             print(f"Reporting on task: {name}")
             metrics_dict[name] = reporter.report_metric(
                 stage, epoch, reset, print_to_channels
             )
+        if reset:
+            self._reset()
         if self.target_reporter:
             return metrics_dict[self.target_task_name]
         else:
             return metrics_dict
+
+    def get_model_select_metric(self, metrics):
+        if self.target_reporter:
+            return self.target_reporter.get_model_select_metric(metrics)
+        else:  # default to training loss
+            return metrics[AVRG_LOSS]


### PR DESCRIPTION
Summary:
This was broken previously.
Also adds eval loss as default metric to pick best model, in case no target task is specified, addressing an issue that was raised before.

Differential Revision: D13739221
