### PR TITLE
Add support for Py RNNG training with pretrained model embeddings like ELMo.

### DIFF
--- a/pytext/fields/pretrained_model_embedding_field.py
+++ b/pytext/fields/pretrained_model_embedding_field.py
@@ -20,7 +20,7 @@ class PretrainedModelEmbeddingField(Field):
             unk_token=None,
             pad_token=None,
         )
-        embed_dim = kwargs.get("embed_dim")
+        embed_dim = kwargs.get("embed_dim", 0)
         num_tokens = TextFeatureField.dummy_model_input.size(0)
         self.dummy_model_input = torch.tensor(
             [[1.0] * embed_dim * num_tokens], dtype=torch.float, device="cpu"


### PR DESCRIPTION
Summary: Add support for consuming embeddings from a pretrained model (like ELMo, BERT) in RNNG for training.

Differential Revision: D13803005
