### PR TITLE
Add dense features to elmo and bert tasks

### DIFF
--- a/pytext/common/constants.py
+++ b/pytext/common/constants.py
@@ -13,6 +13,7 @@ class DatasetFieldName:
     DICT_FIELD = "dict_feat"
     RAW_DICT_FIELD = "sparsefeat"
     CHAR_FIELD = "char_feat"
+    DENSE_FIELD = "dense_feat"
     PRETRAINED_MODEL_EMBEDDING = "pretrained_model_embedding"
     DOC_WEIGHT_FIELD = "doc_weight"
     WORD_WEIGHT_FIELD = "word_weight"

--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -65,6 +65,7 @@ class FeatureConfig(ModuleConfig):  # type: ignore
     seq_word_feat: Optional[WordFeatConfig] = None
     dict_feat: Optional[DictFeatConfig] = None
     char_feat: Optional[CharFeatConfig] = None
+    dense_feat: Optional[FloatVectorConfig] = None
     pretrained_model_embedding: Optional[PretrainedModelEmbeddingConfig] = None
 
 


### PR DESCRIPTION
Summary: We want to evaluate biTransformer and BERT models on hate speech tasks that use dense features. Add support for dense features just as D13285873 did for other classification tasks.

Differential Revision: D13794908
