### PR TITLE
enable distributed for multitask

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 from importlib import import_module
 from pydoc import locate
-from typing import List, Optional
+from typing import Dict, List, Optional, Union
 
 import click
 import torch
@@ -45,10 +45,6 @@ def train_model_distributed(config, metric_channels: Optional[List[Channel]]):
     ) or config.distributed_world_size == 1, (
         "distributed training is only available for GPU training"
     )
-    assert (
-        config.distributed_world_size == 1
-        or not config.task.__class__.__name__ == "DisjointMultitask.Config"
-    ), "Distributed training currently not supported for DisjointMultitask"
     assert (
         config.distributed_world_size == 1
         or config.distributed_world_size <= torch.cuda.device_count()
@@ -91,7 +87,7 @@ def run_single(
     config_json: str,
     world_size: int,
     dist_init_method: Optional[str],
-    metadata: Optional[CommonMetadata],
+    metadata: Optional[Union[Dict[str, CommonMetadata], CommonMetadata]],
     metric_channels: Optional[List[Channel]],
 ):
     config = config_from_json(PyTextConfig, config_json)

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -59,6 +59,7 @@ class DisjointMultitask(TaskBase):
             data_handler.load_metadata(metadata)
         else:
             data_handler.init_metadata()
+
         metadata = data_handler.metadata
         exporters = {
             name: (
@@ -86,7 +87,6 @@ class DisjointMultitask(TaskBase):
             loss_weights=task_weights,
             target_task_name=task_config.target_task_name,
         )
-
         model = DisjointMultitaskModel(
             OrderedDict(
                 (name, create_model(task.model, task.features, metadata[name]))


### PR DESCRIPTION
Summary:
Stack diff implements workaround in c10d to allow null gradients.  Therefore it's now possible to run multitask in distributed.

Diff changes the way current_model is handled in DisjointMultitask model, since this should not be saved in the state_dict.  This was previously handled by overriding the state_dict function.  However, since the model is wrapped in DistributedModel, this override does not work.  Instead made current_model python list, so it doesn't get registered.

Differential Revision: D13799716
