### PR TITLE
Refactor metric_reporters

### DIFF
--- a/pytext/exporters/exporter.py
+++ b/pytext/exporters/exporter.py
@@ -218,13 +218,14 @@ class ModelExporter(Component):
         )
         return final_out_names
 
-    def export_to_tensorboard(self, model, summary_writer):
+    def export_to_metrics(self, model, metric_channels):
         """
         Exports the pytorch model to tensorboard as a graph.
 
         Args:
             model (Model): pytorch model to export
-            summary_writer (SummaryWriter): The TensorBoardX summary writer.
+            metric_channels (List[Channel]): outputs of model's execution graph
         """
-        # TensorBoardX needs an input to infer the shape of the PyTorch model graph
-        summary_writer.add_graph(model, self.dummy_model_input)
+
+        for mc in metric_channels or []:
+            mc.export(model, self.dummy_model_input)

--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -5,6 +5,7 @@ import json
 from typing import Tuple
 
 from pytext.common.constants import Stage
+from tensorboardX import SummaryWriter
 
 
 class Channel:
@@ -53,6 +54,12 @@ class Channel:
             meta (Dict[str, Any]): global metadata, such as target names
         """
         raise NotImplementedError()
+
+    def close(self):
+        pass
+
+    def export(self, model, input_to_model=None):
+        pass
 
 
 class ConsoleChannel(Channel):
@@ -152,9 +159,9 @@ class TensorBoardChannel(Channel):
             TensorBoard dashboard, defaults to "accuracy"
     """
 
-    def __init__(self, summary_writer, metric_name="accuracy"):
+    def __init__(self, summary_writer=None, metric_name="accuracy"):
         super().__init__()
-        self.summary_writer = summary_writer
+        self.summary_writer = summary_writer or SummaryWriter()
         self.metric_name = metric_name
 
     def report(
@@ -245,3 +252,9 @@ class TensorBoardChannel(Channel):
                 )
             elif hasattr(field_value, "_asdict"):
                 self.add_scalars(f"{prefix}/{field_name}", field_value, epoch)
+
+    def close(self):
+        self.summary_writer.close()
+
+    def export(self, model, input_to_model=None):
+        self.summary_writer.add_graph(model, input_to_model)

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -119,15 +119,14 @@ class DisjointMultitask(TaskBase):
         self.target_task_name = target_task_name
 
     def export(
-        self, multitask_model, export_path, summary_writer=None, export_onnx_path=None
+        self, multitask_model, export_path, metric_channels, export_onnx_path=None
     ):
         """
         Wrapper method to export PyTorch model to Caffe2 model using :class:`~Exporter`.
 
         Args:
             export_path (str): file path of exported caffe2 model
-            summary_writer: TensorBoard SummaryWriter, used to output the PyTorch
-                model's execution graph to TensorBoard, default is None.
+            metric_channels: output the PyTorch model's execution graph to
             export_onnx_path (str):file path of exported onnx model
         """
         # Make sure to put the model on CPU and disable CUDA before exporting to
@@ -136,8 +135,8 @@ class DisjointMultitask(TaskBase):
         for name, model in multitask_model.models.items():
             model = model.cpu()
             if self.exporters[name]:
-                if summary_writer is not None:
-                    self.exporters[name].export_to_tensorboard(model, summary_writer)
+                for mc in metric_channels or []:
+                    self.exporters[name].export_to_metrics(model, mc)
                 if name == self.target_task_name:
                     model_export_path = export_path
                     model_export_onnx_path = export_onnx_path

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -168,14 +168,13 @@ class TaskBase(Component):
         test_iter = self.data_handler.get_test_iter()
         return self.trainer.test(test_iter, self.model, self.metric_reporter)
 
-    def export(self, model, export_path, summary_writer=None, export_onnx_path=None):
+    def export(self, model, export_path, metric_channels, export_onnx_path=None):
         """
         Wrapper method to export PyTorch model to Caffe2 model using :class:`~Exporter`.
 
         Args:
             export_path (str): file path of exported caffe2 model
-            summary_writer: TensorBoard SummaryWriter, used to output the PyTorch
-                model's execution graph to TensorBoard, default is None.
+            metric_channels (List[Channel]): outputs of model's execution graph
             export_onnx_path (str):file path of exported onnx model
         """
         # Make sure to put the model on CPU and disable CUDA before exporting to
@@ -183,8 +182,8 @@ class TaskBase(Component):
         cuda_utils.CUDA_ENABLED = False
         model = model.cpu()
         if self.exporter:
-            if summary_writer is not None:
-                self.exporter.export_to_tensorboard(model, summary_writer)
+            print("Exporting metrics")
+            self.exporter.export_to_metrics(model, metric_channels)
             print("Saving caffe2 model to: " + export_path)
             self.exporter.export_to_caffe2(model, export_path, export_onnx_path)
 


### PR DESCRIPTION
Summary:
we're passing around SummaryWriter everywhere.  This is a
TensorBoard-specific internal parameter that should be isolated to the
TensorBoardChannel class.  This is because metric reporters channels are
actually resources that need to be closed after using them.

This implementation makes it difficult to add new metric reporter channels
that are additions to and alternatives of TensorBoard. This diff refactors
how metric reporters are passed around and improves modularity and
separation of concerns.

Differential Revision: D13829608
