### PR TITLE
Typo in docs for two CLI commands

### DIFF
--- a/pytext/docs/source/create_new_task.rst
+++ b/pytext/docs/source/create_new_task.rst
@@ -347,7 +347,7 @@ Now that we have a fully functional class:`~Task`, we can generate a default JSO
 
 .. code-block:: console
 
-	(pytext) $ pytext gen_default_config WordTaggingTask > task_config.json
+	(pytext) $ pytext gen-default-config WordTaggingTask > task_config.json
 
 Tweak the config as you like, and then train the model via
 
@@ -359,7 +359,7 @@ Run predictions using the trained PyTorch model
 
 .. code-block:: console
 
-	(pytext) $ pytext predict_py --model-file="YOUR_PY_MODEL_FILE" < test.json
+	(pytext) $ pytext predict-py --model-file="YOUR_PY_MODEL_FILE" < test.json
 
 Run predictions using the exported Caffe2 model
 


### PR DESCRIPTION
## Motivation and Context

Fixing document typo

## How Has This Been Tested

Use of CLI commands did not work and now they do as per this documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
