### PR TITLE
Add support for pretrained embedding feature export (#77)

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -53,6 +53,7 @@ class CharFeatConfig(ConfigBase):
 class PretrainedModelEmbeddingConfig(ConfigBase):
     embed_dim: int = 0
     model_paths: Optional[Dict[str, str]] = None
+    export_input_names: List[str] = ["pretrained_embeds"]
 
 
 class FloatVectorConfig(ConfigBase):

--- a/pytext/models/embeddings/pretrained_model_embedding.py
+++ b/pytext/models/embeddings/pretrained_model_embedding.py
@@ -17,9 +17,11 @@ class PretrainedModelEmbedding(EmbeddingBase):
         return cls(config.embed_dim)
 
     def forward(self, embedding: torch.Tensor) -> torch.Tensor:
-        if embedding.shape[2] != self.embedding_dim:
+        if embedding.shape[1] % self.embedding_dim != 0:
             raise ValueError(
-                f"Expected {self.embedding_dim} as dimension for pretrained "
-                + f"model embedding but got {embedding.shape[2]}."
+                f"Input embedding_dim {embedding.shape[1]} is not a"
+                + f" multiple of specified embedding_dim {self.embedding_dim}"
             )
-        return embedding
+        num_tokens = embedding.shape[1] // self.embedding_dim
+        unflattened_embedding = embedding.view(-1, num_tokens, self.embedding_dim)
+        return unflattened_embedding

--- a/pytext/models/representations/pass_through.py
+++ b/pytext/models/representations/pass_through.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import torch
+
+from .representation_base import RepresentationBase
+
+
+class PassThroughRepresentation(RepresentationBase):
+    def __init__(
+        self, config: RepresentationBase.Config, input_module_dim: int
+    ) -> None:
+        super().__init__(config)
+        self.representation_dim = input_module_dim
+
+    def forward(self, embedded_tokens: torch.Tensor, *args) -> torch.Tensor:
+        return embedded_tokens

--- a/pytext/models/word_model.py
+++ b/pytext/models/word_model.py
@@ -8,6 +8,7 @@ from pytext.models.model import Model
 from pytext.models.output_layers import CRFOutputLayer, WordTaggingOutputLayer
 from pytext.models.representations.bilstm_slot_attn import BiLSTMSlotAttention
 from pytext.models.representations.biseqcnn import BSeqCNNRepresentation
+from pytext.models.representations.pass_through import PassThroughRepresentation
 
 
 class WordTaggingModel(Model):
@@ -24,7 +25,9 @@ class WordTaggingModel(Model):
 
     class Config(Model.Config):
         representation: Union[
-            BiLSTMSlotAttention.Config, BSeqCNNRepresentation.Config
+            BiLSTMSlotAttention.Config,
+            BSeqCNNRepresentation.Config,
+            PassThroughRepresentation.Config,
         ] = BiLSTMSlotAttention.Config()
         output_layer: Union[
             WordTaggingOutputLayer.Config, CRFOutputLayer.Config


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/pytext/pull/77

Pretrained embedding features don't have support for getting exported. This diff adds the support. Point to jeep in mind is that the `PretrainedModelEmbeddingField.dummy_model_input` depends on `TextFeatureField.dummy_model_input`.

Reviewed By: hikushalhere

Differential Revision: D13421790
