### PR TITLE
add Boundary Pooling in BiLSTMDocAttention

### DIFF
--- a/pytext/models/representations/bilstm_doc_attention.py
+++ b/pytext/models/representations/bilstm_doc_attention.py
@@ -8,7 +8,7 @@ from pytext.models.decoders.mlp_decoder import MLPDecoder
 from pytext.models.module import create_module
 from pytext.models.representations.bilstm import BiLSTM
 
-from .pooling import MaxPool, MeanPool, NoPool, SelfAttention
+from .pooling import LastTimestepPool, MaxPool, MeanPool, NoPool, SelfAttention
 from .representation_base import RepresentationBase
 
 
@@ -47,7 +47,11 @@ class BiLSTMDocAttention(RepresentationBase):
         dropout: float = 0.4
         lstm: BiLSTM.Config = BiLSTM.Config()
         pooling: Union[
-            SelfAttention.Config, MaxPool.Config, MeanPool.Config, NoPool.Config
+            SelfAttention.Config,
+            MaxPool.Config,
+            MeanPool.Config,
+            NoPool.Config,
+            LastTimestepPool.Config,
         ] = SelfAttention.Config()
         mlp_decoder: Optional[MLPDecoder.Config] = None
 

--- a/pytext/models/representations/pooling.py
+++ b/pytext/models/representations/pooling.py
@@ -105,3 +105,13 @@ class BoundaryPool(Module):
             return torch.cat((inputs[:, 0, :], inputs[:, max_len - 1, :]), dim=1)
         else:
             raise Exception("Unknown configuration type {}".format(self.boundary_type))
+
+
+class LastTimestepPool(Module):
+    def __init__(self, config: Module.Config, n_input: int) -> None:
+        super().__init__(config)
+
+    def forward(self, inputs: torch.Tensor, seq_lengths: torch.Tensor) -> torch.Tensor:
+        bsz, _, dim = inputs.shape
+        idx = seq_lengths.unsqueeze(1).expand(bsz, dim).unsqueeze(1)
+        return inputs.gather(1, idx - 1).squeeze(1)


### PR DESCRIPTION
Summary:
Self attention Pooling introduce extra operator like ATEN while trying to export on-device model to C2.
add Boundary Pooling in BiLSTMDocAttention to use only the last hidden state as output

Differential Revision: D13789842
