### PR TITLE
Removing intents as valid actions if a sibling intent exists

### DIFF
--- a/pytext/models/semantic_parsers/rnng/rnng_data_structures.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_data_structures.py
@@ -14,8 +14,10 @@ class Element:
     Used to compute valid actions in the RNNG parser.
     """
 
-    def __init__(self, node: Any) -> None:
+    def __init__(self, node, has_child_intent=False, has_child_slot=False) -> None:
         self.node = node
+        self.has_child_intent = has_child_intent
+        self.has_child_slot = has_child_slot
 
     def __eq__(self, other) -> bool:
         return self.node == other.node

--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -503,7 +503,10 @@ class RNNGParser(Model, Component):
 
             if (not self.training) or self.constraints_intent_slot_nesting:
                 # if stack is empty or the last open NT is slot
-                if (not last_open_NT) or last_open_NT.node in self.valid_SL_idxs:
+                if (not last_open_NT) or (
+                    last_open_NT.node in self.valid_SL_idxs
+                    and not last_open_NT.has_child_intent
+                ):
                     valid_actions += self.valid_IN_idxs
                 elif last_open_NT.node in self.valid_IN_idxs:
                     if (
@@ -594,6 +597,16 @@ class RNNGParser(Model, Component):
                 and target_action_idx in self.ignore_subNTs_roots
             ):
                 state.found_unsupported = True
+
+            if target_action_idx in self.valid_IN_idxs:
+                last_open_NT = None
+                try:
+                    last_open_NT = state.stack_stackrnn.element_from_top(
+                        state.is_open_NT[::-1].index(True)
+                    )
+                    last_open_NT.has_child_intent = True
+                except ValueError:
+                    pass
 
             state.is_open_NT.append(True)
             state.num_open_NT += 1


### PR DESCRIPTION
Summary:
Currently, there are no explicit constraints in the RNNG Python model that prevent an invalid tree with two (or more) child intents under one parent from forming.
This diff adds a constraint which prevents intents from being added as valid actions when a sibling intent has been detected.

Differential Revision: D13857013
