### PR TITLE
Improve elmo benchmark

### DIFF
--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -119,7 +119,7 @@ class MetricReporter(Component):
         """
         Calculate the average loss for all aggregated batch
         """
-        return sum(self.all_loss) / float(len(self.all_loss))
+        return sum(self.all_loss) / float(max(1, len(self.all_loss)))
 
     def calculate_metric(self):
         """


### PR DESCRIPTION
Summary:
updates:

- report correct times in ms (previously only reported the sub-second part, i.e. 2.43 seconds was recorded as .43 seconds)
- flag to record individual token lengths and times to file, for further analysis
- flag to skip examples longer than a certain length in tokens
- time the full evaluation of each example (including preprocessing, not just model call)

Differential Revision: D13909883
