### PR TITLE
fix bug where the param name for representation layer initializer must be embed_dim

### DIFF
--- a/pytext/models/representations/pass_through.py
+++ b/pytext/models/representations/pass_through.py
@@ -7,11 +7,9 @@ from .representation_base import RepresentationBase
 
 
 class PassThroughRepresentation(RepresentationBase):
-    def __init__(
-        self, config: RepresentationBase.Config, input_module_dim: int
-    ) -> None:
+    def __init__(self, config: RepresentationBase.Config, embed_dim: int) -> None:
         super().__init__(config)
-        self.representation_dim = input_module_dim
+        self.representation_dim = embed_dim
 
     def forward(self, embedded_tokens: torch.Tensor, *args) -> torch.Tensor:
         return embedded_tokens


### PR DESCRIPTION
Summary: Previously throwing at line model.py:164

Differential Revision: D13914374
