### PR TITLE
remove unused empty embedding in RNNG py model

### DIFF
--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -267,10 +267,6 @@ class RNNGParser(Model, Component):
             lstm_dim, lstm_dim, num_layers=lstm_num_layers, dropout=dropout
         )
 
-        self.pempty_buffer_emb = nn.Parameter(torch.randn(1, lstm_dim))
-        self.empty_stack_emb = nn.Parameter(torch.randn(1, lstm_dim))
-        self.empty_action_emb = nn.Parameter(torch.randn(1, lstm_dim))
-
         self.actions_lookup = nn.Embedding(num_actions, lstm_dim)
         self.loss_func = nn.CrossEntropyLoss()
 
@@ -459,13 +455,6 @@ class RNNGParser(Model, Component):
                 )
                 for state in sorted(beam)[:top_k]
             ]
-
-    def init_lstm(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        # Batch size fixed to 1
-        return (
-            cuda_utils.FloatTensor(self.lstm_num_layers, 1, self.lstm_dim).fill_(0),
-            cuda_utils.FloatTensor(self.lstm_num_layers, 1, self.lstm_dim).fill_(0),
-        )
 
     def valid_actions(self, state: ParserState) -> List[int]:
         """Used for restricting the set of possible action predictions

--- a/pytext/models/test/rnng_test.py
+++ b/pytext/models/test/rnng_test.py
@@ -29,12 +29,8 @@ class RNNGDataStructuresTest(unittest.TestCase):
         element_node = Element("Node")
 
         lstm = nn.LSTM(lstm_dim, lstm_dim, num_layers=lstm_num_layers)
-        initial_state = (
-            torch.zeros(lstm_num_layers, 1, lstm_dim),
-            torch.zeros(lstm_num_layers, 1, lstm_dim),
-        )
         empty_embedding = torch.zeros(1, lstm_dim)
-        stackLSTM = StackLSTM(lstm, initial_state, empty_embedding)
+        stackLSTM = StackLSTM(lstm)
 
         stackLSTM.push(empty_embedding, element_node)
         self.assertEqual(len(stackLSTM), 1)


### PR DESCRIPTION
Summary: This change is required for both RNNG distributed training because these params have null grad that can't be synced, and migration to TorchScript because ParserState class need to be rewritten

Differential Revision: D13943558
