### PR TITLE
Move random_seed out of task, into PyTextConfig

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from collections import OrderedDict
 from enum import Enum
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 
 class ConfigBaseMeta(type):
@@ -81,6 +81,8 @@ class PyTextConfig(ConfigBase):
     save_module_checkpoints: bool = False
     # Whether to use TensorBoard
     use_tensorboard: bool = True
+    #: Seed value to seed torch, python, and numpy random generators.
+    random_seed: Optional[int] = None
 
     # TODO these two configs are only kept only to be backward comptible with
     # RNNG, should be removed once RNNG refactoring is done

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -91,7 +91,8 @@ def prepare_task(
 
     print("\nParameters: {}\n".format(config))
     _set_cuda(config.use_cuda_if_available, device_id, world_size)
-    set_random_seeds(config.task.random_seed)
+    if config.random_seed is not None:
+        set_random_seeds(config.random_seed)
 
     if config.load_snapshot_path and os.path.isfile(config.load_snapshot_path):
         task = load(config.load_snapshot_path)


### PR DESCRIPTION
Summary: random_seed isn't task specific and the task doesn't need or use it for anything (except the assertions, which I don't think are particularly valuable). I'm moving this to the PyTextConfig which to me is a more sensible place to put it.

Differential Revision: D13998158
