### PR TITLE
Allow query and response to have separate representations

### DIFF
--- a/pytext/models/representations/query_document_pairwise_ranking_rep.py
+++ b/pytext/models/representations/query_document_pairwise_ranking_rep.py
@@ -26,18 +26,27 @@ class QueryDocumentPairwiseRankingRep(RepresentationBase):
         subrepresentation: Union[
             BiLSTMDocAttention.Config, DocNNRepresentation.Config
         ] = BiLSTMDocAttention.Config()
+        # should the query and the response share representations?
+        shared_representations : bool = True
 
     def __init__(self, config: Config, embed_dim: Tuple[int, ...]) -> None:
         super().__init__(config)
         num_subrepresentations = 2
         assert len(embed_dim) == 1
         # TODO: allow query and response embed_dims to be different
-        self.subrepresentations = nn.ModuleList(
-            itertools.repeat(
-                create_module(config.subrepresentation, embed_dim=embed_dim[0]),
-                num_subrepresentations,
+        if config.shared_representations:
+            self.subrepresentations = nn.ModuleList(
+                itertools.repeat(
+                    create_module(config.subrepresentation, embed_dim=embed_dim[0]),
+                    num_subrepresentations,
+                )
             )
-        )
+        else:
+            self.subrepresentations = nn.ModuleList(
+                create_module(config.subrepresentation, embed_dim=embed_dim[0])
+                for x in range(num_subrepresentations)
+            )
+
         self.representation_dim = self.subrepresentations[0].representation_dim
         self.representation_dim = (num_subrepresentations, self.representation_dim)
 


### PR DESCRIPTION
Summary: Query-document pairwise ranking model has a representation layer (BiLSTM or DocNN), used to encode both the query and the document. This diff adds an option to have separate representation layers for query and document

Differential Revision: D14000202
