### PR TITLE
Expose metric channels to caller

### DIFF
--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -156,7 +156,11 @@ def test_model_from_snapshot_path(
     for mc in metric_channels or []:
         task.metric_reporter.add_channel(mc)
 
-    return (task.test(test_path), train_config.task.metric_reporter.output_path)
+    return (
+        task.test(test_path),
+        train_config.task.metric_reporter.output_path,
+        metric_channels,
+    )
 
 
 def batch_predict(model_file: str, examples: List[Dict[str, Any]]):


### PR DESCRIPTION
Summary:
test_model() also need to return the metric_channels actually used,
because some might be initialized internally. This way we can retrieve all the
metrics from outside.

Differential Revision: D14029778
