### PR TITLE
Fix pytest unit test failure

### DIFF
--- a/pytext/data/test/__init__.py
+++ b/pytext/data/test/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved


### PR DESCRIPTION
Summary:
https://github.com/pytest-dev/pytest/issues/3151

If there isn't a __init__.py file in a directory, pytest imports a test file into the global namespace. This means in a package structure not including __init__.py files, test files in separate directories with the same basename (filename not including directory) will overlap, and fortunately pytest fails with a visible error message rather than not executing the tests.

Differential Revision: D14031515
