### PR TITLE
Fix test_disjoint_multitask to not reference or set random_seed

### DIFF
--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -111,7 +111,6 @@ class DisjointMultitask(TaskBase):
             lr_scheduler=Scheduler(
                 optimizer, task_config.scheduler, metric_reporter.lower_is_better
             ),
-            random_seed=task_config.random_seed,
         )
 
     def __init__(self, target_task_name, exporters, **kwargs):


### PR DESCRIPTION
Summary:
D13998158 moved random_seed to the PyTextConfig out of Task.Config, but failed to move it in DisjointMultitask. Tests failed properly and I ignored them >.>

{gif:442tfhl1}

Differential Revision: D14031966
