### PR TITLE
make feature configs Module configs

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -14,7 +14,7 @@ class EmbedInitStrategy(Enum):
     ZERO = "zero"
 
 
-class WordFeatConfig(ConfigBase):
+class WordFeatConfig(ModuleConfig):
     embed_dim: int = 100
     freeze: bool = False  # only freezes embedding lookup, not MLP layers
     embedding_init_strategy: EmbedInitStrategy = EmbedInitStrategy.RANDOM
@@ -32,7 +32,7 @@ class WordFeatConfig(ConfigBase):
     mlp_layer_dims: Optional[List[int]] = []
 
 
-class DictFeatConfig(ConfigBase):
+class DictFeatConfig(ModuleConfig):
     embed_dim: int = 100
     sparse: bool = False
     pooling: PoolingType = PoolingType.MEAN
@@ -40,7 +40,7 @@ class DictFeatConfig(ConfigBase):
     vocab_from_train_data: bool = True
 
 
-class CharFeatConfig(ConfigBase):
+class CharFeatConfig(ModuleConfig):
     embed_dim: int = 100
     sparse: bool = False
     cnn: CNNParams = CNNParams()


### PR DESCRIPTION
Summary: Embeddings currently use feature config, which is confusing since they are used to build modules.  This will change soon, but until that time, feature configs should inherit from ModuleConfig so that they can be shared in multitask learning.

Differential Revision: D14054186
