### PR TITLE
Add a pairwise model for bert that encodes pair sentences separately

### DIFF
--- a/pytext/models/embeddings/embedding_list.py
+++ b/pytext/models/embeddings/embedding_list.py
@@ -87,7 +87,10 @@ class EmbeddingList(EmbeddingBase, ModuleList):
             emb_tensor = emb(*input)
             tensors.append(emb_tensor)
 
-        return torch.cat(tensors, 2) if self.concat else tuple(tensors)
+        if self.concat:
+            return torch.cat(tensors, 2)
+        else:
+            return tuple(tensors) if len(tensors) > 1 else tensors[0]
 
     def get_param_groups_for_optimizer(self) -> List[Dict[str, nn.Parameter]]:
         """


### PR DESCRIPTION
Summary: This diff adds a pairwise model for bert that encodes pair sentences separately. The motivation is to use this model to fine-tune bert encoder to produce sentence embeddings.

Differential Revision: D13901793
