### PR TITLE
Fix BiLSTM forward crash when input embedding is on GPU

### DIFF
--- a/pytext/models/representations/bilstm.py
+++ b/pytext/models/representations/bilstm.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 from pytext.config import ConfigBase
+from pytext.utils import cuda_utils
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 
 from .representation_base import RepresentationBase
@@ -110,6 +111,7 @@ class BiLSTM(RepresentationBase):
                 self.config.num_layers * (2 if self.config.bidirectional else 1),
                 seq_lengths.size(0),  # batch size
                 self.config.lstm_dim,
+                device=torch.cuda.current_device() if cuda_utils.CUDA_ENABLED else None,
             )
             states = (state, state)
 


### PR DESCRIPTION
Summary:
D14035841 added zero hidden state, but it allocates the tensor on CPU, which would break when the input embedding is on GPU. This borke some of our internal integration tests, which were not triggered in the original diff.

```
RuntimeError: Input and hidden tensors are not at the same device, found input tensor at cuda:0 and hidden tensor at cpu
```

Differential Revision: D14065899
