### PR TITLE
Move optimizer and lr_scheduler from task to trainer

### DIFF
--- a/pytext/config/component.py
+++ b/pytext/config/component.py
@@ -162,8 +162,10 @@ def create_featurizer(featurizer_config, *args, **kwargs):
     )
 
 
-def create_trainer(trainer_config, *args, **kwargs):
-    return create_component(ComponentType.TRAINER, trainer_config, *args, **kwargs)
+def create_trainer(trainer_config, model: torch.nn.Module, *args, **kwargs):
+    return create_component(
+        ComponentType.TRAINER, trainer_config, model, *args, **kwargs
+    )
 
 
 def create_model(model_config, *args, **kwargs):

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -119,4 +119,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 2
+LATEST_VERSION = 3

--- a/pytext/config/test/config_adapter_test.py
+++ b/pytext/config/test/config_adapter_test.py
@@ -19,6 +19,7 @@ class ConfigAdapterTest(unittest.TestCase):
         for p in glob.iglob(
             os.path.join(os.path.dirname(__file__), "json_config/*.json")
         ):
+            print("Trying to upgrade file:" + p)
             with open(p) as f:
                 test_data = json.load(f)
                 for test_case in test_data:
@@ -31,6 +32,7 @@ class ConfigAdapterTest(unittest.TestCase):
         for p in glob.iglob(
             os.path.join(os.path.dirname(__file__), "json_config/*.json")
         ):
+            print("Trying to upgrade file:" + p)
             with open(p) as f:
                 test_data = json.load(f)
                 for test_case in test_data:

--- a/pytext/config/test/json_config/v3.json
+++ b/pytext/config/test/json_config/v3.json
@@ -1,0 +1,232 @@
+[
+  {
+    "original": {
+      "task": {
+        "DocClassificationTask": {
+          "optimizer": {
+            "Adam": {
+              "lr": 0.05,
+              "weight_decay": 0.00001
+            }
+          }
+        }
+      },
+      "version": 2
+    },
+    "adapted": {
+      "task": {
+        "DocClassificationTask": {
+          "trainer": {
+            "optimizer": {
+              "Adam": {
+                "lr": 0.05,
+                "weight_decay": 0.00001
+              }
+            }
+          }
+        }
+      },
+      "version": 3
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "DocClassificationTask": {
+          "optimizer": {
+            "Adam": {
+              "lr": 0.05,
+              "weight_decay": 0.00001
+            }
+          },
+          "trainer": {
+            "epochs": 10
+          }
+        }
+      },
+      "version" : 2
+    },
+    "adapted": {
+      "task": {
+        "DocClassificationTask": {
+          "trainer": {
+            "epochs": 10,
+            "optimizer": {
+              "Adam": {
+                "lr": 0.05,
+                "weight_decay": 0.00001
+              }
+            }
+          }
+        }
+      },
+      "version": 3
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "DocClassificationTask": {
+          "scheduler": {
+            "LmFineTuning": {
+              "cut_frac": 0.1,
+              "ratio": 32,
+              "non_pretrained_param_groups": 2,
+              "lm_lr_multiplier": 1.0,
+              "lm_use_per_layer_lr": false,
+              "lm_gradual_unfreezing": true,
+              "last_epoch": -1
+            }
+          }
+        }
+      },
+      "version" : 2
+    },
+    "adapted": {
+      "task": {
+        "DocClassificationTask": {
+          "trainer" : {
+            "scheduler": {
+              "LmFineTuning": {
+                "cut_frac": 0.1,
+                "ratio": 32,
+                "non_pretrained_param_groups": 2,
+                "lm_lr_multiplier": 1.0,
+                "lm_use_per_layer_lr": false,
+                "lm_gradual_unfreezing": true,
+                "last_epoch": -1
+              }
+            }
+          }
+        }
+      },
+      "version": 3
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "DocClassificationTask": {
+          "optimizer": {
+            "Adam": {
+              "lr": 0.05,
+              "weight_decay": 0.00001
+            }
+          },
+          "scheduler": {
+            "LmFineTuning": {
+              "cut_frac": 0.1,
+              "ratio": 32,
+              "non_pretrained_param_groups": 2,
+              "lm_lr_multiplier": 1.0,
+              "lm_use_per_layer_lr": false,
+              "lm_gradual_unfreezing": true,
+              "last_epoch": -1
+            }
+          }
+        }
+      },
+      "version" : 2
+    },
+    "adapted": {
+      "task": {
+        "DocClassificationTask": {
+          "trainer" : {
+            "optimizer": {
+              "Adam": {
+                "lr": 0.05,
+                "weight_decay": 0.00001
+              }
+            },
+            "scheduler": {
+              "LmFineTuning": {
+                "cut_frac": 0.1,
+                "ratio": 32,
+                "non_pretrained_param_groups": 2,
+                "lm_lr_multiplier": 1.0,
+                "lm_use_per_layer_lr": false,
+                "lm_gradual_unfreezing": true,
+                "last_epoch": -1
+              }
+            }
+          }
+        }
+      },
+      "version": 3
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "SemanticParsingTask": {
+          "model": {
+            "ablation": {},
+            "constraints": {},
+            "lstm": {}
+          },
+          "features": {
+            "word_feat": {
+              "embed_dim": 100,
+              "min_freq": 2
+            },
+            "dict_feat": {
+              "embed_dim": 10
+            }
+          },
+          "optimizer": {
+            "Adam": {
+              "lr": 0.05,
+              "weight_decay": 0.00001
+            }
+          },
+          "trainer": {
+            "real_trainer": {
+              "epochs": 1,
+              "report_train_metrics": false
+            },
+            "num_workers": 4
+          },
+          "data_handler": {
+          }
+        }
+      },
+      "version": 2
+    },
+    "adapted": {
+      "task": {
+        "SemanticParsingTask": {
+          "model": {
+            "ablation": {},
+            "constraints": {},
+            "lstm": {}
+          },
+          "features": {
+            "word_feat": {
+              "embed_dim": 100,
+              "min_freq": 2
+            },
+            "dict_feat": {
+              "embed_dim": 10
+            }
+          },
+          "trainer": {
+            "real_trainer": {
+              "epochs": 1,
+              "report_train_metrics": false,
+              "optimizer": {
+                "Adam": {
+                  "lr": 0.05,
+                  "weight_decay": 0.00001
+                }
+              }
+            },
+            "num_workers": 4
+          },
+          "data_handler": {
+          }
+        }
+      },
+      "version": 3
+    }
+  }
+]

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -99,18 +99,13 @@ class DisjointMultitask(TaskBase):
         if cuda_utils.CUDA_ENABLED:
             model = model.cuda()
 
-        optimizer = create_optimizer(task_config.optimizer, model)
         return cls(
             target_task_name=task_config.target_task_name,
             exporters=exporters,
-            trainer=create_trainer(task_config.trainer),
+            trainer=create_trainer(task_config.trainer, model),
             data_handler=data_handler,
             model=model,
             metric_reporter=metric_reporter,
-            optimizer=optimizer,
-            lr_scheduler=Scheduler(
-                optimizer, task_config.scheduler, metric_reporter.lower_is_better
-            ),
         )
 
     def __init__(self, target_task_name, exporters, **kwargs):

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -82,8 +82,6 @@ class EnsembleTask(Task):
             self.model.models[model_id],
             self.metric_reporter,
             train_config,
-            self.optimizer,
-            self.lr_scheduler,
         )
 
     @classmethod

--- a/pytext/trainers/ensemble_trainer.py
+++ b/pytext/trainers/ensemble_trainer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import torch
 from pytext.config import ConfigBase
 from pytext.config.component import create_trainer
 
@@ -17,8 +18,8 @@ class EnsembleTrainer(TrainerBase):
         real_trainer: Trainer.Config = Trainer.Config()
 
     @classmethod
-    def from_config(cls, config: Config, *args, **kwargs):
-        return cls(create_trainer(config.real_trainer, *args, **kwargs))
+    def from_config(cls, config: Config, model: torch.nn.Module, *args, **kwargs):
+        return cls(create_trainer(config.real_trainer, model, *args, **kwargs))
 
     def __init__(self, real_trainer):
         self.real_trainer = real_trainer


### PR DESCRIPTION
Summary: The Trainer class is a better place for optimizer and learning-rate-scheduler. They both currently live in Task. Task just creates them, and passes them to the trainer in every training iteration

Differential Revision: D14094906
