### PR TITLE
Upgrade pytext char embeddings

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -44,6 +44,8 @@ class CharFeatConfig(ModuleConfig):
     embed_dim: int = 100
     sparse: bool = False
     cnn: CNNParams = CNNParams()
+    highway_layers: int = 0
+    projection_dim: Optional[int] = None
     export_input_names: List[str] = ["char_vals"]
     vocab_from_train_data: bool = True
     max_word_length: int = 20

--- a/pytext/data/joint_data_handler.py
+++ b/pytext/data/joint_data_handler.py
@@ -92,12 +92,19 @@ class JointModelDataHandler(DataHandler):
             **kwargs,
         )
 
-    def _get_tokens(self, mode_feature):
+    def _get_tokens(self, model_feature):
         if self.max_seq_len > 0:
             # truncate tokens if max_seq_len is set
-            return mode_feature.tokens[: self.max_seq_len]
+            return model_feature.tokens[: self.max_seq_len]
         else:
-            return mode_feature.tokens
+            return model_feature.tokens
+
+    def _get_chars(self, model_feature):
+        if self.max_seq_len > 0:
+            # truncate tokens if max_seq_len is set
+            return model_feature.characters[: self.max_seq_len]
+        else:
+            return model_feature.characters
 
     def featurize(self, row_data: Dict[str, Any]):
         return self.featurizer.featurize(
@@ -118,7 +125,7 @@ class JointModelDataHandler(DataHandler):
                 features.gazetteer_feat_weights,
                 features.gazetteer_feat_lengths,
             ),
-            DatasetFieldName.CHAR_FIELD: features.characters,
+            DatasetFieldName.CHAR_FIELD: self._get_chars(features),
             DatasetFieldName.PRETRAINED_MODEL_EMBEDDING: features.pretrained_token_embedding,
             # extra data
             # TODO move the logic to FloatField

--- a/pytext/data/kd_doc_classification_data_handler.py
+++ b/pytext/data/kd_doc_classification_data_handler.py
@@ -128,7 +128,7 @@ class KDDocClassificationDataHandler(DocClassificationDataHandler):
                 features.gazetteer_feat_weights,
                 features.gazetteer_feat_lengths,
             ),
-            ModelInput.CHAR_FEAT: features.characters,
+            ModelInput.CHAR_FEAT: self._get_chars(features),
             ModelInput.PRETRAINED_MODEL_EMBEDDING: features.pretrained_token_embedding,
             ModelInput.DENSE_FEAT: row_data.get(ModelInput.DENSE_FEAT),
             # target

--- a/pytext/docs/source/create_new_task.rst
+++ b/pytext/docs/source/create_new_task.rst
@@ -114,13 +114,13 @@ above, will be used later in the process.
 	      )
 	      res = {
 	          # features
-	          ModelInput.WORD_FEAT: features.tokens,
+	          ModelInput.WORD_FEAT: self._get_tokens(features),
 	          ModelInput.DICT_FEAT: (
 	              features.gazetteer_feats,
 	              features.gazetteer_feat_weights,
 	              features.gazetteer_feat_lengths,
 	          ),
-	          ModelInput.CHAR_FEAT: features.characters,
+	          ModelInput.CHAR_FEAT: self._get_chars(features),
 	          # target
 	          [Target.WORD_LABEL_FIELD] = data_utils.align_slot_labels(
 	              features.token_ranges,

--- a/pytext/models/test/embedding_list_test.py
+++ b/pytext/models/test/embedding_list_test.py
@@ -18,7 +18,12 @@ class EmbeddingListTest(unittest.TestCase):
             mlp_layer_dims=[],
         )
         char_embedding = CharacterEmbedding(
-            num_embeddings=5, embed_dim=4, out_channels=2, kernel_sizes=[1, 2]
+            num_embeddings=5,
+            embed_dim=4,
+            out_channels=2,
+            kernel_sizes=[1, 2],
+            highway_layers=1,
+            projection_dim=3,
         )
         embedding_list = EmbeddingList([word_embedding, char_embedding], concat=True)
         param_groups = embedding_list.get_param_groups_for_optimizer()


### PR DESCRIPTION
Summary:
- add highway layers (copied from fairseq)
- enforce `max_seq_len` for char features for all data handlers, to prevent OOM errors
- add `char_embed_dim` field (size of character -> embedding lookup), so that `embed_dim` is actually the output embedding dim for the token.

Differential Revision: D14068755
