### PR TITLE
handle dataset sharding on different dataset_size vs raw_data_size

### DIFF
--- a/pytext/data/bptt_lm_data_handler.py
+++ b/pytext/data/bptt_lm_data_handler.py
@@ -3,7 +3,7 @@
 
 import itertools
 import math
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
 import torch
 from pytext.common.constants import DatasetFieldName, DFColumn, VocabMeta
@@ -120,7 +120,7 @@ class BPTTLanguageModelDataHandler(DataHandler):
         """
         self.metadata.target = self.metadata.features[DatasetFieldName.TEXT_FIELD]
 
-    def preprocess(self, data: List[Dict[str, Any]]):
+    def preprocess(self, data: Iterable[Dict[str, Any]]):
         tokens = []
         for row in data:
             tokens.extend(self.preprocess_row(row))

--- a/pytext/data/test/language_model_data_handler_test.py
+++ b/pytext/data/test/language_model_data_handler_test.py
@@ -107,7 +107,7 @@ class LanguageModelDataHandlerTest(unittest.TestCase):
             assert BatchContext.IGNORE_LOSS not in b[CONTEXT_INDEX]
 
         # shard #1 took shard with input data index [1, 2, 3]
-        # shard #2 took shard with input data index [4, 5, 5]
+        # shard #2 took shard with input data index [3, 4, 5]
         # we pad shard #2 to make every shard the same size
         test_batch = batches_1[0]
         # first batch in shard #1 is row # 2 and 3 reordered by sort_key
@@ -116,9 +116,9 @@ class LanguageModelDataHandlerTest(unittest.TestCase):
         )
 
         test_batch = batches_2[0]
-        # first batch in shard #2 is row # 5 and 5 reordered by sort_key
+        # second batch in shard #2 is row # 3 and 4 reordered by sort_key
         np.testing.assert_array_equal(
-            test_batch[1], [[23, 11, 5, 10, 3], [23, 11, 5, 10, 3]]
+            test_batch[1], [[23, 11, 5, 10, 3], [24, 5, 4, 3, 1]]
         )
 
     def _init_data_handler(self):

--- a/pytext/utils/dist_utils.py
+++ b/pytext/utils/dist_utils.py
@@ -39,41 +39,32 @@ def suppress_output():
     __builtin__.print = print
 
 
-def get_shard_range(data_size: int, rank: int, world_size: int):
+def get_shard_range(dataset_size: int, rank: int, world_size: int):
     """
-    Add extra 1 examples in the remainder(e.g data_size % world_size) rank,
-    For example, world_size = 8, data_size = 66
-    The shard size is [9, 9, 8, 8, 8, 8, 8, 8]
+    In case dataset_size is not evenly divided by world_size, we need to pad
+    one extra example in each shard
+    shard_len = dataset_size // world_size + 1
+
+    Case 1 rank < remainder: each shard start position is rank * shard_len
+
+    Case 2 rank >= remainder: without padding, each shard start position is
+    rank * (shard_len - 1) + remainder = rank * shard_len - (rank - remainder)
+    But to make sure all shard have same size, we need to pad one extra example
+    when rank >= remainder, so start_position = start_position - 1
+
+    For example, dataset_size = 21, world_size = 8
+    rank 0 to 4: [0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [12, 13, 14]
+    rank 5 to 7: [14, 15, 16], [16, 17, 18], [18, 19, 20]
     """
-    remainder = data_size % world_size
-    shard_len = data_size // world_size
-    if rank < remainder:
-        shard_len += 1
+    remainder = dataset_size % world_size
+    shard_len = dataset_size // world_size
 
-    shard_offset = rank * shard_len + min(rank, remainder)
-    shard_end = data_size if rank == world_size - 1 else shard_offset + shard_len
-    return (shard_offset, shard_end)
-
-
-def pad_shard_data(shard_data: List[Any], data_size: int, world_size: int):
-    """
-    Because of the trailing data (dataset_size % world_size), some shard could
-    have 1 less example than the maximum shard, in this case we will pad to
-    ensure every shard have the same size.
-    The impact should be negligible when dataset_size >> world_size
-    """
-    # TODO: the workaround is that we could store max_shard_size in Dataset
-
-    max_shard_size = math.ceil(data_size / float(world_size))
-    shard_data_size = len(shard_data)
-
-    if shard_data_size == max_shard_size:
-        pass
-    elif shard_data_size == max_shard_size - 1:
-        shard_data.append(copy.deepcopy(shard_data[-1]))
+    if remainder == 0:
+        shard_offset = rank * shard_len
     else:
-        raise ValueError(
-            f"shard_data_size should equal or one less than max_shard_size, "
-            + f"shard_data_size is {shard_data_size} and max_shard_size "
-            + f"{max_shard_size}"
-        )
+        # take one extra when dataset_size is not evenly divided by world_size
+        shard_len += 1
+        shard_offset = rank * shard_len - max(0, rank + 1 - remainder)
+    shard_end = shard_offset + shard_len - 1
+
+    return (shard_offset, shard_end)


### PR DESCRIPTION
Summary:
The purpose of this diff is to make sure each shard have the same datasetach shard while only load the sharded data into memory.
1. Make read_from_file and read_from_hive generator
2. Take the shard range in function gen_dataset

This is replicate of D14116472 with addressing comments (I don't know why CircleCI test doesn't pick up the latest change)

Differential Revision: D14118445
