### PR TITLE
Add option of hard target to `KLDivergenceCELoss`

### DIFF
--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -272,11 +272,16 @@ class KLDivergenceBCELoss(Loss):
 class KLDivergenceCELoss(Loss):
     class Config(ConfigBase):
         temperature: float = 1.0
+        hard_weight: float = 0.0
 
     def __init__(self, config, ignore_index=-100, weight=None, *args, **kwargs):
-        self.ignore_index = ignore_index
+        # ignore_index not easily added to kl_div loss, don't support this until needed
+        assert ignore_index < 0
+        assert 0.0 <= config.hard_weight < 1.0
+
         self.weight = weight
         self.t = config.temperature
+        self.hard_weight = config.hard_weight
 
     def __call__(self, logits, targets, reduce=True):
         """
@@ -284,19 +289,32 @@ class KLDivergenceCELoss(Loss):
         probability distribution computed by CrossEntropyLoss loss
         """
         hard_targets, _, soft_targets_logits = targets
-        soft_targets = F.softmax(FloatTensor(soft_targets_logits) / self.t).clamp(
-            1e-20, 1 - 1e-20
-        )
+        soft_targets = F.softmax(FloatTensor(soft_targets_logits) / self.t, dim=1)
+        soft_targets = soft_targets.clamp(1e-10, 1 - 1e-10)
         log_probs = F.log_softmax(logits / self.t, 1)
+
         if self.weight is not None:
-            loss = F.kl_div(log_probs, soft_targets, reduction="none") * self.weight
+            soft_loss = (
+                F.kl_div(log_probs, soft_targets, reduction="none") * self.weight
+            )
             if reduce:
-                loss = loss.mean()
+                soft_loss = soft_loss.mean()
         else:
-            loss = F.kl_div(
+            soft_loss = F.kl_div(
                 log_probs, soft_targets, reduction="mean" if reduce else "none"
             )
-        return loss
+        soft_loss *= self.t ** 2  # see https://arxiv.org/pdf/1503.02531.pdf
+
+        hard_loss = 0.0
+        if self.hard_weight > 0.0:
+            hard_loss = F.cross_entropy(
+                logits,
+                hard_targets,
+                reduction="mean" if reduce else "none",
+                weight=self.weight,
+            )
+
+        return (1.0 - self.hard_weight) * soft_loss + self.hard_weight * hard_loss
 
 
 class SoftHardBCELoss(Loss):


### PR DESCRIPTION
Summary: This loss originally tries to match the model's output distribution with a target distribution. This is probably only used for knowledge distillation at the moment, and it can be helpful to also include the true target / label in the loss (according to the originl paper https://arxiv.org/abs/1503.02531). This diff adds a flag `hard_weight` that specifies the ratio of the weights for the hard target to the teacher's distribution.

Differential Revision: D14138044
