### PR TITLE
Back out "EASY [PyText] use pip 18.1 to allow circleci tests to run"

### DIFF
--- a/install_deps
+++ b/install_deps
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-pip install --upgrade pip==18.1
+pip install --upgrade pip
 pip install -e . --upgrade --no-cache-dir --progress-bar off

--- a/install_deps.bat
+++ b/install_deps.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 ::Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-python -m pip install --upgrade pip==18.1
+python -m pip install --upgrade pip
 pip install -e . --process-dependency-links --no-cache-dir --progress-bar off


### PR DESCRIPTION
Summary: Pip version is 19.1. Original commit changeset: 5f1f8e60765a

Differential Revision: D14154594
