### PR TITLE
Allow Metric Reporter To Select Metric From Config And Add Bert Word Tagging Metric Reporter

### DIFF
--- a/pytext/config/component.py
+++ b/pytext/config/component.py
@@ -195,9 +195,12 @@ def create_loss(loss_config, *args, **kwargs):
 
 
 def create_metric_reporter(module_config, *args, **kwargs):
-    return create_component(
+    metric_reporter = create_component(
         ComponentType.METRIC_REPORTER, module_config, *args, **kwargs
     )
+    if getattr(module_config, "select_metric_path", None):
+        metric_reporter.select_metric_path = module_config.select_metric_path
+    return metric_reporter
 
 
 def get_component_name(obj):

--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -146,6 +146,15 @@ class FileChannel(Channel):
             yield [preds[i], targets[i], scores[i]]
 
 
+class DetailFileChannel(FileChannel):
+    def get_title(self):
+        return ("prediction", "target", "text", "score")
+
+    def gen_content(self, metrics, loss, preds, targets, scores, contexts):
+        for i in range(len(preds)):
+            yield [preds[i], targets[i], contexts["utterance"][i], scores[i]]
+
+
 class TensorBoardChannel(Channel):
     """
     TensorBoardChannel defines how to format and report the result of a PyText

--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import torch
 from pytext.config.component import Component, ComponentType
@@ -32,10 +32,12 @@ class MetricReporter(Component):
 
     class Config(ConfigBase):
         output_path: str = "/tmp/test_out.txt"
+        select_metric_path: Optional[str] = None
 
-    def __init__(self, channels) -> None:
+    def __init__(self, channels, **kwargs) -> None:
         self._reset()
         self.channels = channels
+        self.select_metric_path = kwargs.get("select_metric_path")
 
     def _reset(self):
         self.all_preds: List = []
@@ -182,6 +184,12 @@ class MetricReporter(Component):
         the metric itself by default, but usually metrics will be more complicated
         data structures
         """
+        if self.select_metric_path:
+            try:
+                path = "metrics." + self.select_metric_path
+                return eval(path)
+            except SyntaxError:
+                return metrics
         return metrics
 
     def compare_metric(self, new_metric, old_metric):

--- a/pytext/metric_reporters/word_tagging_metric_reporter.py
+++ b/pytext/metric_reporters/word_tagging_metric_reporter.py
@@ -3,8 +3,11 @@
 from collections import Counter
 from typing import List
 
+import torch
 from pytext.common.constants import DatasetFieldName, Stage
+from pytext.config import ConfigBase
 from pytext.data import CommonMetadata
+from pytext.metrics import AllConfusions, Confusions
 from pytext.metrics.intent_slot_metrics import (
     Node,
     NodesPredictionPair,
@@ -14,7 +17,7 @@ from pytext.metrics.intent_slot_metrics import (
 from pytext.utils.data_utils import parse_slot_string
 from pytext.utils.test_utils import merge_token_labels_to_slot
 
-from .channel import Channel, ConsoleChannel, FileChannel
+from .channel import Channel, ConsoleChannel, DetailFileChannel, FileChannel
 from .metric_reporter import MetricReporter
 
 
@@ -82,3 +85,119 @@ class WordTaggingMetricReporter(MetricReporter):
 
     def get_model_select_metric(self, metrics):
         return metrics.micro_scores.f1
+
+
+class BertWordTaggingMetricReporter(MetricReporter):
+    class Config(MetricReporter.Config):
+        output_path: str = "/tmp/test_out.txt"
+        use_crf: bool = False
+
+    def __init__(
+        self,
+        use_crf: bool,
+        label_names: List[str],
+        use_bio_labels: bool,
+        channels: List[Channel],
+    ) -> None:
+        super().__init__(channels)
+        self.label_names = label_names
+        self.use_bio_labels = use_bio_labels
+        self.use_crf = use_crf
+
+    @classmethod
+    def from_config(cls, config, meta: CommonMetadata):
+        return cls(
+            config.use_crf,
+            meta.target.vocab.itos,
+            meta.target.use_bio_labels,
+            [ConsoleChannel(), DetailFileChannel((Stage.TEST,), config.output_path)],
+        )
+
+    def add_batch_stats(
+        self, n_batches, preds, targets, scores, loss, m_input, **context
+    ):
+        """
+        Aggregates a batch of output data (predictions, scores, targets/true labels
+        and loss).
+
+        Args:
+            n_batches (int): number of current batch
+            preds (torch.Tensor): predictions of current batch
+            targets (torch.Tensor): targets of current batch
+            scores (torch.Tensor): scores of current batch
+            loss (double): average loss of current batch
+            m_input (Tuple[torch.Tensor, ...]): model inputs of current batch
+            context (Dict[str, Any]): any additional context data, it could be
+                either a list of data which maps to each example, or a single value
+                for the batch
+        """
+        targets = self._strip_target(targets, scores.size()[-1])
+        preds = self._strip_preds_or_scores(preds, context)
+        scores = self._strip_preds_or_scores(scores, context)
+        super().add_batch_stats(
+            n_batches, preds, targets, scores, loss, m_input, **context
+        )
+
+    def _strip_preds_or_scores(self, new_batch, context):
+        batch_list = []
+        pad_mask = context["pad_mask"]
+        token_range = context["token_range"]
+        for i, row_tensor in enumerate(new_batch.split(1, dim=0)):
+            pred = row_tensor.squeeze()
+            if self.use_crf:
+                num_token = len(token_range[i])
+                pred = pred[:num_token]
+            else:
+                pad_mask_row = pad_mask[i, :]
+                pred = pred[pad_mask_row]
+                token_start = [r[0] for r in token_range[i]]
+                token_start_idx = torch.tensor(token_start, device=pred.device).long()
+                pred = pred.index_select(0, token_start_idx)
+            batch_list.append(pred)
+        return batch_list
+
+    def _strip_target(self, new_batch, context):
+        batch_list = []
+        for row_tensor in new_batch.split(1, dim=0):
+            row_tensor = row_tensor.squeeze()
+            row_tensor = row_tensor[row_tensor < context]
+            batch_list.append(row_tensor)
+        return batch_list
+
+    def calculate_metric(self):
+        all_confusions = AllConfusions()
+        true_positives = dict(
+            zip(self.label_names[:-1], [0] * len(self.label_names[:-1]))
+        )
+        false_positives = dict(
+            zip(self.label_names[:-1], [0] * len(self.label_names[:-1]))
+        )
+        false_negatives = dict(
+            zip(self.label_names[:-1], [0] * len(self.label_names[:-1]))
+        )
+
+        for predicted_idx_example, expected_idx_example in zip(
+            self.all_preds, self.all_targets
+        ):
+            for predicted_idx, expected_idx in zip(
+                predicted_idx_example, expected_idx_example
+            ):
+                if predicted_idx == expected_idx:
+                    true_positives[self.label_names[expected_idx]] += 1
+                else:
+                    false_negatives[self.label_names[expected_idx]] += 1
+                    false_positives[self.label_names[predicted_idx]] += 1
+        for label, count in true_positives.items():
+            all_confusions.per_label_confusions.update(label, "TP", count)
+        for label, count in false_positives.items():
+            all_confusions.per_label_confusions.update(label, "FP", count)
+        for label, count in false_negatives.items():
+            all_confusions.per_label_confusions.update(label, "FN", count)
+
+        all_confusions.confusions = Confusions(
+            TP=sum(true_positives.values()),
+            FP=sum(false_positives.values()),
+            FN=sum(false_negatives.values()),
+        )
+
+        return all_confusions.compute_metrics()

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -208,6 +208,9 @@ class Trainer(TrainerBase):
             if metric_reporter.compare_metric(eval_metric, best_metric):
                 last_best_epoch = epoch
                 best_metric = eval_metric
+                best_selection_metric = metric_reporter.get_model_select_metric(
+                    best_metric
+                )
                 # Only rank = 0 trainer saves modules.
                 if train_config.save_module_checkpoints and rank == 0:
                     model.save_modules(
@@ -215,7 +218,10 @@ class Trainer(TrainerBase):
                     )
 
                 if rank == 0:
-                    print(f"Rank {rank} worker: Found a better model!")
+                    print(
+                        f"Rank {rank} worker: Found a better model! "
+                        f"Metric for better model is {best_selection_metric}."
+                    )
                     model_state = model.state_dict()
                     # save to cpu to avoid multiple model copies in gpu memory
                     if cuda_utils.CUDA_ENABLED:


### PR DESCRIPTION
Summary: Currently, the metric reporter's metric selection criterior is bounded with the class. It's hard to change it without changing code, and it's hard to apply different one in run time. This diff adds the "select_metric_path" to the metric reporter config. It can be used to select different metric that would like to be used for model selection.

Differential Revision: D14209239
