### PR TITLE
Make RNN Configurable in PyText

### DIFF
--- a/demo/atis_joint_model/atis_joint_config.json
+++ b/demo/atis_joint_model/atis_joint_config.json
@@ -5,9 +5,10 @@
         "model": {
           "representation": {
             "BiLSTMDocSlotAttention": {
-              "lstm": {
+              "rnn": {
+                "rnn_type": "bilstm",
+                "hidden_size": 366,
                 "dropout": 0.5,
-                "lstm_dim": 366,
                 "num_layers": 2,
                 "bidirectional": true
               },

--- a/pytext/exporters/test/text_model_exporter_test.py
+++ b/pytext/exporters/test/text_model_exporter_test.py
@@ -34,8 +34,9 @@ JOINT_CONFIG = """
   "model": {
     "representation": {
       "BiLSTMDocSlotAttention": {
-        "lstm": {
-          "lstm_dim": 30,
+        "rnn": {
+          "rnn_type": "bilstm",
+          "hidden_size": 30,
           "num_layers": 1
         },
         "pooling": {

--- a/pytext/models/representations/augmented_lstm.py
+++ b/pytext/models/representations/augmented_lstm.py
@@ -326,7 +326,7 @@ class AugmentedLSTM(RepresentationBase):
         Configuration class for `AugmentedLSTM`.
 
         Attributes:
-            dropout_rate (float): Variational dropout probability to use.
+            dropout (float): Variational dropout probability to use.
                 Defaults to 0.0.
             hidden_size (int): Number of features in the hidden state of the LSTM.
                 Defaults to 32.
@@ -342,7 +342,7 @@ class AugmentedLSTM(RepresentationBase):
                 we don't.
         """
 
-        dropout_rate: float = 0.0
+        dropout: float = 0.0
         hidden_size: int = 32
         use_highway: bool = True
         bidirectional: bool = False
@@ -360,7 +360,7 @@ class AugmentedLSTM(RepresentationBase):
         self.hidden_size = self.config.hidden_size
         self.num_layers = self.config.num_layers
         self.bidirectional = self.config.bidirectional
-        self.dropout_rate = self.config.dropout_rate
+        self.dropout_rate = self.config.dropout
         self.use_highway = self.config.use_highway
         self.use_bias = self.config.use_bias
 

--- a/pytext/models/representations/bilstm.py
+++ b/pytext/models/representations/bilstm.py
@@ -43,12 +43,15 @@ class BiLSTM(RepresentationBase):
                 computing the final result. Defaults to 1.
             bidirectional (bool): If `True`, becomes a bidirectional LSTM. Defaults
                 to `True`.
+            bias (bool): If `False`, then the layer does not use bias weights
+                b_ih and b_hh. Default: True
         """
 
         dropout: float = 0.4
         lstm_dim: int = 32
         num_layers: int = 1
         bidirectional: bool = True
+        bias: bool = True
 
     def __init__(
         self, config: Config, embed_dim: int, padding_value: float = 0.0
@@ -62,6 +65,7 @@ class BiLSTM(RepresentationBase):
             config.lstm_dim,
             num_layers=config.num_layers,
             bidirectional=config.bidirectional,
+            bias=config.bias,
         )
         self.representation_dim: int = config.lstm_dim * (
             2 if config.bidirectional else 1

--- a/pytext/models/representations/bilstm_doc_slot_attention.py
+++ b/pytext/models/representations/bilstm_doc_slot_attention.py
@@ -8,9 +8,9 @@ from pytext.config import ConfigBase
 from pytext.config.module_config import SlotAttentionType
 from pytext.models.module import create_module
 
-from .bilstm import BiLSTM
 from .pooling import MaxPool, MeanPool, SelfAttention
 from .representation_base import RepresentationBase
+from .rnn_union import RNNUnion
 from .slot_attention import SlotAttention
 
 
@@ -49,7 +49,7 @@ class BiLSTMDocSlotAttention(RepresentationBase):
 
     class Config(RepresentationBase.Config, ConfigBase):
         dropout: float = 0.4
-        lstm: BiLSTM.Config = BiLSTM.Config()
+        rnn: RNNUnion.Config = RNNUnion.Config()
         pooling: Optional[
             Union[SelfAttention.Config, MaxPool.Config, MeanPool.Config]
         ] = None
@@ -67,7 +67,7 @@ class BiLSTMDocSlotAttention(RepresentationBase):
             float("-inf") if isinstance(config.pooling, MaxPool.Config) else 0.0
         )
         self.lstm = create_module(
-            config.lstm, embed_dim=embed_dim, padding_value=padding_value
+            config.rnn, input_size=embed_dim, padding_value=padding_value
         )
 
         lstm_out_dim = self.lstm.representation_dim

--- a/pytext/models/representations/rnn_union.py
+++ b/pytext/models/representations/rnn_union.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from pytext.config import ConfigBase
+
+from .augmented_lstm import AugmentedLSTM
+from .bilstm import BiLSTM
+from .representation_base import RepresentationBase
+
+
+class RNNUnion(RepresentationBase):
+    """
+    `RNNUnion` presents a union class over all the different types of RNN's within
+    PyText. This allows the user to set the rnn type as a configurable option.
+
+    Args:
+        config (Config): Configuration object of type RNNUnion.Config.
+        embed_dim (int): The number of expected features in the input.
+        padding_value (float): Value for the padded elements. Defaults to 0.0.
+
+    Attributes:
+        padding_value (float): Value for the padded elements.
+        inner_rnn (nn.Module): PyText module representing the rnn.
+        representation_dim (int): The calculated dimension of the output features
+            of RNN.
+    """
+
+    class Config(RepresentationBase.Config, ConfigBase):
+        """
+        Configuration class for `RNNUnion`.
+
+        Attributes:
+            dropout (float): Dropout probability to use. Defaults to 0.4.
+            hidden_size (int): Number of features in the hidden state of the LSTM.
+                Defaults to 32.
+            use_highway (bool): If `True` we append a highway network
+                to the outputs of the LSTM.
+            bidirectional (bool): If `True`, becomes a bidirectional LSTM. Defaults
+                to `True`.
+            num_layers (int): Number of recurrent layers. Eg. setting `num_layers=2`
+                would mean stacking two LSTMs together to form a stacked LSTM,
+                with the second LSTM taking in the outputs of the first LSTM and
+                computing the final result. Defaults to 1.
+            use_bias (bool): If `True` we use a bias in our LSTM calculations, otherwise
+                we don't.
+            rnn_type (str): The type of rnn to use. We currently support
+                (auglstm | bilistm).
+        """
+
+        dropout: float = 0.0
+        hidden_size: int = 32
+        use_highway: bool = True
+        bidirectional: bool = False
+        num_layers: int = 1
+        use_bias: bool = True
+        rnn_type: str = "auglstm"
+
+        def get_augmented_lstm_config(self) -> AugmentedLSTM.Config:
+            augmented_lstm_config = AugmentedLSTM.Config()
+            augmented_lstm_config.bidirectional = self.bidirectional
+            augmented_lstm_config.dropout = self.dropout
+            augmented_lstm_config.use_bias = self.use_bias
+            augmented_lstm_config.num_layers = self.num_layers
+            augmented_lstm_config.hidden_size = self.hidden_size
+            augmented_lstm_config.use_highway = self.use_highway
+            return augmented_lstm_config
+
+        def get_bilstm_config(self) -> BiLSTM.Config:
+            bilstm_config = BiLSTM.Config()
+            bilstm_config.dropout = self.dropout
+            bilstm_config.lstm_dim = self.hidden_size
+            bilstm_config.num_layers = self.num_layers
+            bilstm_config.bidirectional = self.bidirectional
+            bilstm_config.bias = self.use_bias
+            return bilstm_config
+
+    def __init__(self, config: Config, input_size: int, padding_value: float = 0.0):
+        super().__init__(config)
+        self.config = config
+        self.inner_rnn: nn.Module = None
+        if config.rnn_type == "auglstm":
+            self.inner_rnn = AugmentedLSTM(
+                self.config.get_augmented_lstm_config(), input_size, padding_value
+            )
+        elif config.rnn_type == "bilstm":
+            self.inner_rnn = BiLSTM(
+                self.config.get_bilstm_config(), input_size, padding_value
+            )
+        else:
+            raise ValueError(
+                f"Did not understand rnn of type {config.rnn_type}."
+                + "Please select from (auglstm | bilistm)"
+            )
+        self.representation_dim = self.inner_rnn.representation_dim
+
+    def forward(
+        self,
+        embedded_tokens: torch.Tensor,
+        seq_lengths: torch.Tensor,
+        states: Optional[Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]]:
+        """
+        Given an input batch of sequential data such as word embeddings, produces
+        a RNN representation of the sequential input and new state
+        tensors.
+
+        Args:
+            embedded_tokens (torch.Tensor): Input tensor of shape
+                (bsize x seq_len x input_dim).
+            seq_lengths (torch.Tensor): List of sequences lengths of each batch element.
+            states (Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]):
+                Tuple of tensors containing
+                the initial hidden state and possibly the cell state of each element
+                in the batch. Each of these tensors have a dimension of
+                (bsize x num_layers * num_directions x nhid). Defaults to `None`.
+
+        Returns:
+            Tuple[torch.Tensor, Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]]:
+                RNN representation of input and the state of the RNN `t = seq_len`.
+                Shape of representation is (bsize x seq_len x representation_dim).
+                Shape of each state is (bsize x num_layers * num_directions x nhid).
+
+        """
+        return self.inner_rnn(embedded_tokens, seq_lengths, states)

--- a/pytext/models/representations/test/augmented_lstm_test.py
+++ b/pytext/models/representations/test/augmented_lstm_test.py
@@ -10,7 +10,7 @@ class AugmentedLSTMTest(unittest.TestCase):
     def _test_shape(self, use_highway, variational_dropout, num_layers, bidirectional):
         config = AugmentedLSTM.Config()
         config.use_highway = use_highway
-        config.dropout_rate = variational_dropout
+        config.dropout = variational_dropout
         config.num_layers = num_layers
         config.bidirectional = bidirectional
 
@@ -21,6 +21,7 @@ class AugmentedLSTMTest(unittest.TestCase):
         input_size = 31
 
         aug_lstm = AugmentedLSTM(config, input_size)
+        aug_lstm.train()
 
         input_tensor = torch.randn(batch_size, time_step, input_size)
         input_length = torch.zeros((batch_size,)).long()
@@ -65,11 +66,12 @@ class AugmentedLSTMTest(unittest.TestCase):
             s_output, (s_hidden_state, s_cell_state) = aug_lstm(
                 input_tensor, input_length, inp_state
             )
-            if config.dropout_rate == 0.0:
+            if config.dropout == 0.0:
                 assert torch.all(
                     torch.lt(torch.abs(torch.add(s_output, -output)), 1e-12)
                 )
             else:
+                print(use_highway, variational_dropout, num_layers, bidirectional)
                 assert not torch.all(torch.eq(s_output, output))
 
     def test_augmented_lstm(self):

--- a/pytext/models/representations/test/rnn_union_test.py
+++ b/pytext/models/representations/test/rnn_union_test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import unittest
+
+import torch
+from pytext.models.representations.augmented_lstm import AugmentedLSTM
+from pytext.models.representations.bilstm import BiLSTM
+from pytext.models.representations.rnn_union import RNNUnion
+
+
+class RNNUnionTest(unittest.TestCase):
+    def test_dispatching_auglstm(self):
+        auglstm_config = RNNUnion.Config()
+        auglstm_config.rnn_type = "auglstm"
+
+        auglstm = RNNUnion(auglstm_config, 32)
+        self.assertTrue(isinstance(auglstm.inner_rnn, AugmentedLSTM))
+
+    def test_dispatching_bilstm(self):
+        bilstm_config = RNNUnion.Config()
+        bilstm_config.rnn_type = "bilstm"
+
+        bilstm = RNNUnion(bilstm_config, 32)
+        self.assertTrue(isinstance(bilstm.inner_rnn, BiLSTM))
+
+    def test_dispatching_not_supported(self):
+        with self.assertRaises(ValueError) as context:
+            broken_config = RNNUnion.Config()
+            broken_config.rnn_type = "some_rnn_cell_that_will_never_exist"
+            broken = RNNUnion(broken_config, 32)
+            # should raise error... but to get rid of error we use broken value
+            broken
+            context
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: Make choice of RNN configurable within PyText. We do this by implementing a UnionRNN which dynamically dispatches the correct model based on the configuration. Currently we have AugmentedLSTM and LSTM as choices but the typing of the introduced UnionRNN allows for other RNN's such as GRU.

Differential Revision: D14196532
