### PR TITLE
Fix potential bugs in intent-slot metrics (1st)

### DIFF
--- a/pytext/metrics/intent_slot_metrics.py
+++ b/pytext/metrics/intent_slot_metrics.py
@@ -52,7 +52,7 @@ class Node:
         self.children: Set[Node] = children or set()
 
     def __hash__(self):
-        return hash((self.label, self.span, frozenset(self.children)))
+        return hash((self.label, self.span))
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Node):

--- a/pytext/metrics/tests/intent_slot_metrics_test.py
+++ b/pytext/metrics/tests/intent_slot_metrics_test.py
@@ -346,6 +346,13 @@ FRAME_PAIRS = [
 
 
 class MetricsTest(MetricsTestBase):
+    def test_nodes_equal(self) -> None:
+        child = Node(label="slot", span=Span(1, 2))
+        node1 = Node(label="intent1", span=Span(0, 5), children={child})
+        child.children.add(Node(label="intent2", span=Span(1, 2)))
+        node2 = Node(label="intent1", span=Span(0, 5), children={child})
+        self.assertEqual(node1, node2)
+
     def test_compare_frames(self) -> None:
         i = 0
         for example in TEST_EXAMPLES:


### PR DESCRIPTION
Summary:
Thanks to Jinfeng who discovered this. `Node` class in intent slot metrics suffers from a potential bug that if its `children` are modified after creation, its hash value may not change accordingly. In this diff we modify the `__hash__()` method of the `Node` class so that it does not rely on `children`. We also add a unit test that would have exposed the bug.

Note current PyText and NLU code paths are not affected by this bug.

Differential Revision: D14196789
