### PR TITLE
Fix potential bugs in intent-slot metrics (2nd)

### DIFF
--- a/pytext/data/data_structures/node.py
+++ b/pytext/data/data_structures/node.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import AbstractSet, Any, NamedTuple, Optional
+
+
+class Span(NamedTuple):
+    """
+    Span of a node in an intent-slot tree.
+
+    Attributes:
+        start: Start position of the node.
+        end: End position of the node (exclusive).
+    """
+
+    start: int
+    end: int
+
+
+class Node:
+    """
+    Node in an intent-slot tree, representing either an intent or a slot.
+
+    Attributes:
+        label (str): Label of the node.
+        span (Span): Span of the node.
+        children (:obj:`set` of :obj:`Node`): Children of the node.
+    """
+
+    __slots__ = "label", "span", "children"
+
+    def __init__(
+        self, label: str, span: Span, children: Optional[AbstractSet["Node"]] = None
+    ) -> None:
+        object.__setattr__(self, "label", label)
+        object.__setattr__(self, "span", span)
+        object.__setattr__(
+            self, "children", children if children is not None else set()
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Node):
+            return NotImplemented
+        return (
+            self.label == other.label  # noqa
+            and self.span == other.span  # noqa
+            and self.children == other.children  # noqa
+        )
+
+    def get_depth(self) -> int:
+        return 1 + max(
+            (child.get_depth() for child in self.children), default=0  # noqa
+        )

--- a/pytext/metrics/tests/intent_slot_metrics_test.py
+++ b/pytext/metrics/tests/intent_slot_metrics_test.py
@@ -346,12 +346,10 @@ FRAME_PAIRS = [
 
 
 class MetricsTest(MetricsTestBase):
-    def test_nodes_equal(self) -> None:
-        child = Node(label="slot", span=Span(1, 2))
-        node1 = Node(label="intent1", span=Span(0, 5), children={child})
-        child.children.add(Node(label="intent2", span=Span(1, 2)))
-        node2 = Node(label="intent1", span=Span(0, 5), children={child})
-        self.assertEqual(node1, node2)
+    def test_immutable_node(self) -> None:
+        node = Node(label="", span=Span(start=0, end=5))
+        with self.assertRaises(AttributeError):
+            node.label = "intent"
 
     def test_compare_frames(self) -> None:
         i = 0


### PR DESCRIPTION
Summary: This is a followup of the previous diff. If attributes of the `Node` class can be modified after creation, comparison of sets of `Node`'s may result in unexpected behavior. In this diff we set attributes of the `Node` class to be immutable. To not affect behavior of the subclass `NLGNode`, we redefined its `__setattr__()` method.

Differential Revision: D14240249
