### PR TITLE
Data Handler Rewrite [5.5/x]: Clean up model input and some groundwork for migration

### DIFF
--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 from enum import Enum
 from typing import Dict, List, Tuple, Union
 

--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -132,4 +132,4 @@ class Data(Component):
                 name: tensorizer.create_training_tensors(batch)
                 for name, tensorizer in self.tensorizers.items()
             }
-            yield batch, tensors
+            yield tensors

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -24,10 +24,10 @@ class Tensorizer(Component):
     __EXPANSIBLE__ = True
 
     class Config(Component.Config):
-        """Make mypy happy."""
+        pass
 
     @classmethod
-    def from_config(cls, config: Component.Config):
+    def from_config(cls, config: Config):
         return cls(config.column)
 
     def __init__(self, column):
@@ -181,6 +181,18 @@ class LabelTensorizer(Tensorizer):
         """Numberize labels."""
         labels = [row[self.column] for row in batch]
         return torch.tensor(self.labels.lookup_all(labels), dtype=torch.long)
+
+
+class MetaInput(Tensorizer):
+    """A pass-through tensorizer to include raw fields from datasource in the batch.
+       Used mostly for metric reporting."""
+
+    class Config(Tensorizer.Config):
+        #: The name of the text column to parse from the data source.
+        column: str = "text"
+
+    def create_training_tensors(self, batch):
+        return [row[self.column] for row in batch]
 
 
 def initialize_tensorizers(tensorizers, data_source):

--- a/pytext/data/test/data_test.py
+++ b/pytext/data/test/data_test.py
@@ -42,27 +42,22 @@ class DataTest(unittest.TestCase):
         data = Data(self.data_source, self.tensorizers, RawBatcher(batch_size=16))
         batches = list(data.batches(Stage.TRAIN))
         self.assertEqual(1, len(batches))
-        batch, batch_tensors = next(iter(batches))
-        self.assertEqual(set(self.tensorizers), set(batch_tensors))
-        tokens, seq_lens = batch_tensors["tokens"]
+        batch = next(iter(batches))
+        self.assertEqual(set(self.tensorizers), set(batch))
+        tokens, seq_lens = batch["tokens"]
         self.assertEqual((10,), seq_lens.size())
-        self.assertEqual((10,), batch_tensors["labels"].size())
-        self.assertEqual(10, len(batch))
-        example = next(iter(batch))
-        self.assertEqual({"text", "label"}, set(example))
+        self.assertEqual((10,), batch["labels"].size())
+        self.assertEqual({"tokens", "labels"}, set(batch))
 
     def test_create_batches_different_tensorizers(self):
         tensorizers = {"tokens": WordTensorizer(column="text")}
         data = Data(self.data_source, tensorizers, RawBatcher(batch_size=16))
         batches = list(data.batches(Stage.TRAIN))
         self.assertEqual(1, len(batches))
-        batch, batch_tensors = next(iter(batches))
-        self.assertEqual({"tokens"}, set(batch_tensors))
-        tokens, seq_lens = batch_tensors["tokens"]
+        batch = next(iter(batches))
+        self.assertEqual({"tokens"}, set(batch))
+        tokens, seq_lens = batch["tokens"]
         self.assertEqual((10,), seq_lens.size())
-        self.assertEqual(10, len(batch))
-        example = next(iter(batch))
-        self.assertEqual({"text", "label"}, set(example))
 
     def test_data_initializes_tensorsizers(self):
         tensorizers = {

--- a/pytext/metric_reporters/classification_metric_reporter.py
+++ b/pytext/metric_reporters/classification_metric_reporter.py
@@ -42,11 +42,12 @@ class ComparableClassificationMetric(Enum):
 
 
 class ClassificationMetricReporter(MetricReporter):
+    UTTERANCE_COLUMN = "raw_text"
+
     class Config(MetricReporter.Config):
         model_select_metric: ComparableClassificationMetric = (
             ComparableClassificationMetric.ACCURACY
         )
-        utterance_column: str = "text"
         target_label: Optional[str] = None
 
     def __init__(
@@ -57,13 +58,11 @@ class ClassificationMetricReporter(MetricReporter):
             ComparableClassificationMetric.ACCURACY
         ),
         target_label: Optional[str] = None,
-        utterance_column: str = Config.utterance_column,
     ) -> None:
         super().__init__(channels)
         self.label_names = label_names
         self.model_select_metric = model_select_metric
         self.target_label = target_label
-        self.utterance_column = utterance_column
 
     @classmethod
     def from_config(cls, config, meta: CommonMetadata):
@@ -89,11 +88,10 @@ class ClassificationMetricReporter(MetricReporter):
             [ConsoleChannel(), IntentModelChannel((Stage.TEST,), config.output_path)],
             config.model_select_metric,
             config.target_label,
-            config.utterance_column,
         )
 
     def batch_context(self, batch):
-        return {"utterance": [row[self.utterance_column] for row in batch]}
+        return {"utterance": batch[self.UTTERANCE_COLUMN]}
 
     def calculate_metric(self):
         return compute_classification_metrics(

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -5,7 +5,12 @@ from typing import Dict, Union
 
 from pytext.config import ConfigBase
 from pytext.config.field_config import WordFeatConfig
-from pytext.data.tensorizers import LabelTensorizer, Tensorizer, WordTensorizer
+from pytext.data.tensorizers import (
+    LabelTensorizer,
+    MetaInput,
+    Tensorizer,
+    WordTensorizer,
+)
 from pytext.data.utils import UNK
 from pytext.loss import CrossEntropyLoss
 from pytext.models.decoders.mlp_decoder import MLPDecoder
@@ -47,13 +52,14 @@ class NewDocModel(NewModel, DocModel):
     for describing which inputs it expects and arranging its input tensors."""
 
     class Config(NewModel.Config, DocModel.Config):
-        embedding: WordFeatConfig = WordFeatConfig()
-
         class ModelInput(NewModel.Config.ModelInput):
             tokens: WordTensorizer.Config = WordTensorizer.Config()
             labels: LabelTensorizer.Config = LabelTensorizer.Config(allow_unknown=True)
+            # for metric reporter
+            raw_text: MetaInput.Config = MetaInput.Config(column="text")
 
         inputs: ModelInput = ModelInput()
+        embedding: WordFeatConfig = WordFeatConfig()
 
     def arrange_model_inputs(self, tensor_dict):
         tokens, seq_lens = tensor_dict["tokens"]

--- a/pytext/models/new_model.py
+++ b/pytext/models/new_model.py
@@ -3,7 +3,7 @@
 
 from typing import Dict
 
-from pytext.config.component import Component, ComponentMeta, ComponentType
+from pytext.config.component import Component, ComponentType
 from pytext.config.pytext_config import ConfigBase, ConfigBaseMeta
 from pytext.data.tensorizers import Tensorizer
 

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -53,7 +53,11 @@ def prepare_task_metadata(config: PyTextConfig) -> CommonMetadata:
     To avoid such practice, we move the operations that required loading the
     whole dataset out of spawn, and pass the context to every single process.
     """
-    return create_task(config.task).data_handler.metadata
+    return (
+        create_task(config.task).data_handler.metadata
+        if hasattr(config.task, "data_handler")
+        else {}
+    )
 
 
 def train_model(


### PR DESCRIPTION
Summary:
Diff aims to do the following:
- Create an InputConfig nested class in model Config, so that we don't have to rely on users specifying dictionary keys to be the same as hard-coded model input names, when configuring model inputs.
- Move metric reporter inputs into model input.  Data produces batches with all the required inputs, which cleans up the metric reporter integration in the trainer a bit.  MetaInput class is a tensorizer which does nothing, except pass through raw input fields into the batch so that metric reporter can use them.  (not necessarily the best design and is subject to change, but it does make it easier to migrate current models, so I think it's good for now)
- Split base pytext model to move the base functionality out and separate it from the embedding-representation-decoder architecture.

Differential Revision: D14210429
