### PR TITLE
Disable export graph to tensorboard

### DIFF
--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -257,4 +257,6 @@ class TensorBoardChannel(Channel):
         self.summary_writer.close()
 
     def export(self, model, input_to_model=None):
-        self.summary_writer.add_graph(model, input_to_model)
+        # TODO re-enable after fixing tensorboard issue t41127613
+        # self.summary_writer.add_graph(model, input_to_model)
+        pass


### PR DESCRIPTION
Summary: Disable export graph to tensorboard since it's broken now

Differential Revision: D14264050
