### PR TITLE
Back out "[PyText]Enable distributed training for c++ model (RNNG)"

### DIFF
--- a/pytext/models/distributed_model.py
+++ b/pytext/models/distributed_model.py
@@ -35,14 +35,6 @@ class DistributedModel(nn.parallel.DistributedDataParallel):
         wrapped_module = super().__getattr__("module")
         return wrapped_module.cpu()
 
-    def state_dict(self, *args, **kwargs):
-        wrapped_module = super().__getattr__("module")
-        return wrapped_module.state_dict(*args, **kwargs)
-
-    def load_state_dict(self, *args, **kwargs):
-        wrapped_module = super().__getattr__("module")
-        return wrapped_module.load_state_dict(*args, **kwargs)
-
     def train(self, mode=True):
         """
         Override to set stage


### PR DESCRIPTION
Summary: The diff caused a slight backward incompatibility - it worked E2E but gave different results for some queries. Backing out before further investigation.

Differential Revision: D14269653
