### PR TITLE
Add a test_output_path attribute to workflow.test_model()

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -115,6 +115,8 @@ class TestConfig(ConfigBase):
     use_cuda_if_available: bool = True
     # Whether to use TensorBoard
     use_tensorboard: bool = True
+    # Output path where metric reporter writes to.
+    test_out_path: str = ""
 
 
 LATEST_VERSION = 2


### PR DESCRIPTION
Summary: Add a test_output_path attribute to workflow.test_model(). This is required when testing a model that was trained by someone else and you might not have permission to write to the output path.

Differential Revision: D14276422
