### PR TITLE
Visualize model state (weights, biases) as training progresses over time

### DIFF
--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -66,12 +66,12 @@ class DisjointMultitaskMetricReporter(MetricReporter):
         else:  # default to training loss
             return new_metric[AVRG_LOSS] < old_metric[AVRG_LOSS]
 
-    def report_metric(self, stage, epoch, reset=True, print_to_channels=True):
+    def report_metric(self, model, stage, epoch, reset=True, print_to_channels=True):
         metrics_dict = {AVRG_LOSS: self.total_loss / self.num_batches}
         for name, reporter in self.reporters.items():
             print(f"Reporting on task: {name}")
             metrics_dict[name] = reporter.report_metric(
-                stage, epoch, reset, print_to_channels
+                model, stage, epoch, reset, print_to_channels
             )
         if reset:
             self._reset()

--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -141,11 +141,12 @@ class MetricReporter(Component):
         """
         return {}
 
-    def report_metric(self, stage, epoch, reset=True, print_to_channels=True):
+    def report_metric(self, model, stage, epoch, reset=True, print_to_channels=True):
         """
         Calculate metrics and average loss, report all statistic data to channels
 
         Args:
+            model (nn.Module): the PyTorch neural network model.
             stage (Stage): training, evaluation or test
             epoch (int): current epoch
             reset (bool): if all data should be reset after report, default is True
@@ -170,6 +171,7 @@ class MetricReporter(Component):
                         self.all_scores,
                         self.all_context,
                         self.get_meta(),
+                        model,
                     )
 
         if reset:

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -59,7 +59,7 @@ class NewTaskTrainer(Trainer):
         if report_metric:
             with time_utils.time("report metrics"):
                 metrics = metric_reporter.report_metric(
-                    stage, epoch, print_to_channels=(rank == 0)
+                    model, stage, epoch, print_to_channels=(rank == 0)
                 )
         else:
             metric_reporter._reset()

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -311,7 +311,7 @@ class Trainer(TrainerBase):
         if report_metric:
             with time_utils.time("report metrics"):
                 metrics = metric_reporter.report_metric(
-                    stage, epoch, print_to_channels=(rank == 0)
+                    model, stage, epoch, print_to_channels=(rank == 0)
                 )
         else:
             metric_reporter._reset()


### PR DESCRIPTION
Summary:
This adds support for visualizing inside TensorBoard the model internal state (e.g. attention weights, biases) as training progresses.
Each area graph in the z axis is one time step (one data batch), as you go to the front of the z axis, the histogram shows how the weight values change.

https://www.tensorflow.org/guide/tensorboard_histograms

Differential Revision: D14321686

Relevant to https://github.com/facebookresearch/pytext/issues/171 @silky 

![image](https://user-images.githubusercontent.com/8598682/53796608-5ff98180-3ee9-11e9-8797-223a1d3dd60f.png)