### PR TITLE
Multitask: add output view and option to use per-task model_select_metric

### DIFF
--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -86,6 +86,9 @@ class DisjointMultitask(TaskBase):
             ),
             loss_weights=task_weights,
             target_task_name=task_config.target_task_name,
+            use_subtask_select_metric=(
+                task_config.metric_reporter.use_subtask_select_metric
+            ),
         )
         model = DisjointMultitaskModel(
             OrderedDict(


### PR DESCRIPTION
Summary:
Multitask setup does not produce a flow output - to make inspecting results easier, make the flow output the set of per-task `model_select_metric`s. This is a good choice because this metric is the most important one for each task (e.g. the default for classification is accuracy), and because it's hard to show all metrics for each subtask (which can be of any type of task).

Also, enable the multitask metric reporter to select best epoch according to the sum of `model_select_metric`s as one way of determining best overall epoch.

Differential Revision: D14326176
