### PR TITLE
Shuffle task order when multitasking with no upsampling

### DIFF
--- a/pytext/data/data_handler.py
+++ b/pytext/data/data_handler.py
@@ -666,6 +666,7 @@ class DataHandler(Component):
             ),
             self._postprocess_batch,
             is_train=False,
+            num_batches=math.ceil(len(test_dataset) / float(batch_size)),
         )
 
     def get_predict_iter(

--- a/pytext/data/test/round_robin_batchiterator_test.py
+++ b/pytext/data/test/round_robin_batchiterator_test.py
@@ -8,9 +8,34 @@ from pytext.data.disjoint_multitask_data_handler import RoundRobinBatchIterator
 
 class RoundRobinBatchIteratorTest(unittest.TestCase):
     def test_batch_iterator(self):
-        iteratorA = [(input, None, {}) for input in [1, 2, 3, 4]]
+        iteratorA = [(input, None, {}) for input in ["1", "2", "3", "4", "5"]]
         iteratorB = [(input, None, {}) for input in ["a", "b", "c"]]
-        round_robin_iterator = RoundRobinBatchIterator({"A": iteratorA, "B": iteratorB})
-        expected_output = [1, "a", 2, "b", 3, "c", 4, "a", 1, "b"]
-        for actual, expected in zip(round_robin_iterator, expected_output):
-            assert actual[0] == expected
+
+        # upsample = True, no iter_to_set_epoch
+        round_robin_iterator = RoundRobinBatchIterator(
+            {"A": iteratorA, "B": iteratorB}, upsample=True
+        )
+        expected_items = ["1", "a", "2", "b", "3", "c"]
+        self._check_iterator(round_robin_iterator, expected_items)
+
+        # upsample = True, iter_to_set_epoch = "A"
+        round_robin_iterator = RoundRobinBatchIterator(
+            {"A": iteratorA, "B": iteratorB}, upsample=True, iter_to_set_epoch="A"
+        )
+        expected_items = ["1", "a", "2", "b", "3", "c", "4", "a", "5", "b"]
+        self._check_iterator(round_robin_iterator, expected_items)
+
+        # upsample = False
+        round_robin_iterator = RoundRobinBatchIterator(
+            {"A": iteratorA, "B": iteratorB}, upsample=False
+        )
+        expected_items = ["1", "2", "3", "4", "5", "a", "b", "c"]
+        self._check_iterator(round_robin_iterator, expected_items, fixed_order=False)
+
+    def _check_iterator(self, iterator, expected_items, fixed_order=True):
+        actual_items = [item for item, _, _ in iterator]
+        if not fixed_order:
+            # Order is random, just check that the sorted arrays are equal
+            actual_items = sorted(actual_items)
+            expected_items = sorted(expected_items)
+        self.assertListEqual(actual_items, expected_items)


### PR DESCRIPTION
Summary: When multitasking with no upsampling, the training schedule currently loops through all tasks equally, so smaller tasks will run out early. It'd be preferred if all batches from all tasks were shuffled randomly, so that there won't be forgetting of the smaller tasks.

Differential Revision: D14326080
