### PR TITLE
Clean up trainer 2/2 - Introduce TrainingState, pull logic into methods

### DIFF
--- a/pytext/trainers/__init__.py
+++ b/pytext/trainers/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from .ensemble_trainer import EnsembleTrainer
 from .hogwild_trainer import HogwildTrainer
-from .trainer import Trainer
+from .trainer import Trainer, TrainingState
 
 
-__all__ = ["Trainer", "EnsembleTrainer", "HogwildTrainer"]
+__all__ = ["Trainer", "TrainingState", "EnsembleTrainer", "HogwildTrainer"]

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import sys
 import time
 from typing import Any, Optional, Tuple
 
@@ -28,6 +27,25 @@ class TrainerBase(Component):
     __COMPONENT_TYPE__ = ComponentType.TRAINER
 
 
+class TrainingState:
+    model: Model
+    optimizer: Optimizer
+    scheduler: Scheduler
+    start_time: float
+    epoch: int = 0
+    rank: int = 0
+    stage: Stage = Stage.TRAIN
+    epochs_since_last_improvement: int = 0
+    best_model_state: Any = None
+    best_model_metric: Any = None
+
+    def __init__(self, **kwargs):
+        unknown_keys = kwargs.keys() - TrainingState.__annotations__.keys()
+        if unknown_keys:
+            raise TypeError(f"TrainingState unexpected attributes {unknown_keys}")
+        vars(self).update(kwargs)
+
+
 class Trainer(TrainerBase):
     """
     Base Trainer class that provide ways to
@@ -42,24 +60,24 @@ class Trainer(TrainerBase):
         max_clip_norm (Optional[float]): Clip gradient norm if set
         report_train_metrics (bool): Whether metrics on training data should be
             computed and reported.
-        target_time_limit_seconds (int): Target time limit for training in seconds. If
+        target_time_limit_seconds (float): Target time limit for training in seconds. If
             the expected time to train another epoch exceeds this limit, stop training.
     """
 
     class Config(ConfigBase):
-        # Training epochs
+        #: Training epochs
         epochs: int = 10
-        # Stop after how many epochs when the eval metric is not improving
+        #: Stop after how many epochs when the eval metric is not improving
         early_stop_after: int = 0
-        # Clip gradient norm if set
+        #: Clip gradient norm if set
         max_clip_norm: Optional[float] = None
-        # Whether metrics on training data should be computed and reported.
+        #: Whether metrics on training data should be computed and reported.
         report_train_metrics: bool = True
-        # Target time limit for training.
-        target_time_limit_seconds: int = 0
-        # Whether to do evaluation and model selection based on it.
+        #: Target time limit for training, default (None) to no time limit.
+        target_time_limit_seconds: Optional[int] = None
+        #: Whether to do evaluation and model selection based on it.
         do_eval: bool = True
-        # Number of samples for logging training progress.
+        #: Number of samples for logging training progress.
         num_samples_to_log_progress = 1000
         # config for optimizer, used in parameter update
         optimizer: Optimizer.Config = Adam.Config()
@@ -83,21 +101,145 @@ class Trainer(TrainerBase):
 
     @timing.time("Trainer.test")
     def test(self, test_iter, model, metric_reporter: MetricReporter):
+        state = TrainingState(stage=Stage.TEST, model=model, epoch=1)
         if cuda.CUDA_ENABLED:
-            model = model.cuda()
-
-        model.eval()
+            state.model.cuda()
+        state.model.eval()
         with torch.no_grad():
-            test_metric = self._run_epoch(
-                Stage.TEST, 1, test_iter, model, metric_reporter
+            return self.run_epoch(state, test_iter, metric_reporter)
+
+    @timing.time("pre-training")
+    def set_up_training(self, state: TrainingState, training_data: BatchIterator):
+        if cuda.CUDA_ENABLED:
+            state.model.cuda()
+        state.scheduler.prepare(training_data, self.config.epochs)
+
+        if cuda.DISTRIBUTED_WORLD_SIZE > 1:
+            device_id = torch.cuda.current_device()
+            state.model = DistributedModel(
+                module=state.model,
+                device_ids=[device_id],
+                output_device=device_id,
+                broadcast_buffers=False,
             )
-        return test_metric
+
+        state.optimizer = precision.wrap_optimizer(state.optimizer)
+        state.start_time = time.time()
+
+    @timing.time("zero gradients")
+    def zero_grads(self, state):
+        if state.stage != Stage.TRAIN:
+            return
+
+        if cuda.DISTRIBUTED_WORLD_SIZE > 1:
+            # replace optimizer.zero_grad() here to work with DDP
+            # in cases where some parameters don't receive grads at each step
+            # loss.backward will set grad for params in the computation graph
+            # we can thus follow which params are left out and call .backward
+            # on them manually
+            for p in state.model.parameters():
+                if p.grad is not None:
+                    p.grad.detach_()
+                    p.grad = None
+        else:
+            state.optimizer.zero_grad()
+
+    @timing.time("backprop")
+    def backprop(self, state, loss):
+        if state.stage != Stage.TRAIN:
+            return
+
+        with timing.time("loss.backward"):
+            precision.backward(state.optimizer, loss)
+            if cuda.DISTRIBUTED_WORLD_SIZE > 1:
+                # DDP fix when some parameters don't receive grads
+                for p in state.model.parameters():
+                    if p.requires_grad and p.grad is None:
+                        p.backward(torch.zeros_like(p.data))
+
+        state.scheduler.step_batch()
+
+        if self.config.max_clip_norm is not None:
+            grad_norm = torch.nn.utils.clip_grad_norm_(
+                state.model.parameters(), self.config.max_clip_norm
+            )
+        else:
+            grad_norm = None
+
+        with timing.time("optimizer.step"):
+            state.optimizer.step()
+        # grad_norm could be used to check grads sync in distributed training
+        return grad_norm
+
+    def continue_training(self, state: TrainingState) -> bool:
+        # Are we done?
+        if state.epoch >= self.config.epochs:
+            return False
+
+        # Check whether the model has improved recently enough
+        # Only do this if we're bothering to evaluate the model
+        if self.config.do_eval and state.epochs_since_last_improvement >= (
+            self.config.early_stop_after or float("inf")
+        ):
+            print(
+                f"Worker {state.rank}: Eval metric hasn't changed for "
+                + f"{state.epochs_since_last_improvement} epochs. Stopping now."
+            )
+            return False
+
+        # Check whether we think the next epoch will put us over the configured
+        # time limit.
+        epochs_run = state.epoch + 1
+        time_elapsed = time.time() - state.start_time
+        mean_epoch_time = time_elapsed / epochs_run
+        expected_next_epoch_time = time_elapsed + mean_epoch_time
+        target_time_limit = (
+            float("inf")
+            if self.config.target_time_limit_seconds is None
+            else self.config.target_time_limit_seconds
+        )
+        if expected_next_epoch_time > target_time_limit:
+            print(
+                f"Worker {state.rank}: Stopping training after {epochs_run} epochs "
+                f"and {int(time_elapsed)} seconds, due to the target max training "
+                f"time of {self.config.target_time_limit_seconds} seconds."
+            )
+            return False
+
+        return True
+
+    @timing.time("save checkpoint")
+    def save_checkpoint(self, state: TrainingState, train_config: PyTextConfig):
+        # Only one worker should save checkpoints
+        if state.rank != 0:
+            return
+
+        print(f"Found a better model!")
+        if train_config.save_module_checkpoints:
+            state.model.save_modules(
+                base_path=train_config.modules_save_dir, suffix=f"-ep{state.epoch}"
+            )
+
+        model_state = state.model.state_dict()
+        # save to cpu to avoid multiple model copies in gpu memory
+        if cuda.CUDA_ENABLED:
+            for key, parameter in model_state.items():
+                model_state[key] = parameter.cpu()
+        state.best_model_state = model_state
+
+    def load_best_model(self, state: TrainingState):
+        if cuda.CUDA_ENABLED:
+            state.model.load_state_dict(
+                {k: v.cuda() for k, v in state.best_model_state.items()}
+            )
+        else:
+            state.model.load_state_dict(state.best_model_state)
 
     @timing.time("Trainer.train")
     def train(
         self,
-        train_iter: BatchIterator,
-        eval_iter: BatchIterator,
+        training_data: BatchIterator,
+        eval_data: BatchIterator,
         model: Model,
         metric_reporter: MetricReporter,
         train_config: PyTextConfig,
@@ -127,178 +269,63 @@ class Trainer(TrainerBase):
         Returns:
             model, best_metric: the trained model together with the best metric
         """
-        with timing.time("pre-training"):
-            world_size = 1
-            if cuda.CUDA_ENABLED:
-                model = model.cuda()
-                world_size = cuda.DISTRIBUTED_WORLD_SIZE
-                if world_size > 1:
-                    device_id = torch.cuda.current_device()
-                    model = DistributedModel(
-                        module=model,
-                        device_ids=[device_id],
-                        output_device=device_id,
-                        broadcast_buffers=False,
-                    )
+        state = TrainingState(
+            model=model, optimizer=self.optimizer, scheduler=self.scheduler, rank=rank
+        )
+        self.set_up_training(state, training_data)
 
-            best_metric = None
-            last_best_epoch = 0
-            self.scheduler.prepare(train_iter, self.config.epochs)
-            self.optimizer = precision.wrap_optimizer(self.optimizer)
+        while self.continue_training(state):
+            state.epoch += 1
+            state.epochs_since_last_improvement += 1
+            print(f"Worker {state.rank} starting epoch {state.epoch}", flush=True)
+            lrs = learning_rates(state.optimizer)
+            print(f"Learning rate(s): {', '.join(map(str, lrs))}")
 
-        def training_pre_batch_callback():
-            if world_size > 1:
-                # replace optimizer.zero_grad() here to work with DDP
-                # in cases where some parameters don't receive grads at each step
-                # loss.backward will set grad for params in the computation graph
-                # we can thus follow which params are left out and call .backward
-                # on them manually
-                for p in model.parameters():
-                    if p.grad is not None:
-                        p.grad.detach_()
-                        p.grad = None
-            else:
-                self.optimizer.zero_grad()
-
-        def training_backprop(loss):
-            with timing.time("loss.backward"):
-                precision.backward(self.optimizer, loss)
-                if world_size > 1:
-                    # DDP fix when some parameters don't receive grads
-                    for p in model.parameters():
-                        if p.requires_grad and p.grad is None:
-                            p.backward(torch.zeros_like(p.data))
-
-            self.scheduler.step_batch()
-
-            if self.config.max_clip_norm is not None:
-                grad_norm = torch.nn.utils.clip_grad_norm_(
-                    model.parameters(), self.config.max_clip_norm
-                )
-            else:
-                grad_norm = None
-
-            with timing.time("optimizer.step"):
-                self.optimizer.step()
-            # grad_norm could be used to check grads sync in distributed training
-            return grad_norm
-
-        time_start = time.time()
-        best_model_state = None
-        for epoch in range(1, self.config.epochs + 1):
-            sys.stdout.flush()
-            if self.config.target_time_limit_seconds > 0 and epoch > 1:
-                time_elapsed = time.time() - time_start
-                mean_epoch_time = time_elapsed / float(epoch - 1)
-                expected_next_epoch_time = time_elapsed + mean_epoch_time
-                if expected_next_epoch_time > self.config.target_time_limit_seconds:
-                    print(
-                        f"Training stopped after {epoch - 1} epochs and "
-                        f"{int(time_elapsed)} seconds, due to the target max training "
-                        f"time of {self.config.target_time_limit_seconds} seconds."
-                    )
-                    break
-
-            print(f"Rank {rank} worker: Starting epoch #{epoch}")
-            model.train()
-            lrs = (str(lr) for lr in learning_rates(self.optimizer))
-            print(f"Learning rate(s): {', '.join(lrs)}")
-
-            with timing.time("epoch train"):
-                self._run_epoch(
-                    Stage.TRAIN,
-                    epoch,
-                    train_iter,
-                    model,
-                    metric_reporter,
-                    pre_batch=training_pre_batch_callback,
-                    backprop=training_backprop,
-                    rank=rank,
-                    num_samples_to_log_progress=self.config.num_samples_to_log_progress,
-                )
+            with timing.time("train epoch"):
+                state.stage = Stage.TRAIN
+                state.model.train()
+                self.run_epoch(state, training_data, metric_reporter)
 
             if not self.config.do_eval:
                 continue
 
-            with timing.time("epoch eval"):
+            with timing.time("eval epoch"):
+                state.stage = Stage.EVAL
                 model.eval(Stage.EVAL)
                 with torch.no_grad():
-                    eval_metric = self._run_epoch(
-                        Stage.EVAL,
-                        epoch,
-                        eval_iter,
-                        model,
-                        metric_reporter,
-                        rank=rank,
-                        num_samples_to_log_progress=(
-                            self.config.num_samples_to_log_progress
-                        ),
-                    )
+                    eval_metric = self.run_epoch(state, eval_data, metric_reporter)
 
             # Step the learning rate scheduler(s)
             assert eval_metric is not None
-            self.scheduler.step_epoch(
+            state.scheduler.step_epoch(
                 metrics=metric_reporter.get_model_select_metric(eval_metric),
-                epoch=epoch,
+                epoch=state.epoch,
             )
 
-            # choose best model.
-            if metric_reporter.compare_metric(eval_metric, best_metric):
-                with timing.time("save checkpoint model"):
-                    last_best_epoch = epoch
-                    best_metric = eval_metric
-                    # Only rank = 0 trainer saves modules.
-                    if train_config.save_module_checkpoints and rank == 0:
-                        model.save_modules(
-                            base_path=train_config.modules_save_dir,
-                            suffix=f"-ep{epoch}",
-                        )
+            # Did we train a better model?
+            if metric_reporter.compare_metric(eval_metric, state.best_model_metric):
+                state.epochs_since_last_improvement = 0
+                state.best_model_metric = eval_metric
+                self.save_checkpoint(state, train_config)
 
-                    if rank == 0:
-                        print(f"Rank {rank} worker: Found a better model!")
-                        model_state = model.state_dict()
-                        # save to cpu to avoid multiple model copies in gpu memory
-                        if cuda.CUDA_ENABLED:
-                            for key, state in model_state.items():
-                                model_state[key] = state.cpu()
-                        best_model_state = model_state
+        # Only bother loading the best model for master worker
+        if rank == 0 and state.best_model_state is not None:
+            self.load_best_model(state)
 
-            if self.config.early_stop_after > 0 and (
-                epoch - last_best_epoch == self.config.early_stop_after
-            ):
-                print(
-                    f"Rank {rank} worker: Eval metric hasn't changed for "
-                    + f"{self.config.early_stop_after} epochs. Stopping now."
-                )
-                break
-            sys.stdout.flush()
-
-        if rank == 0 and best_model_state is not None:
-            if cuda.CUDA_ENABLED:
-                for key, state in best_model_state.items():
-                    best_model_state[key] = state.cuda()
-            model.load_state_dict(best_model_state)
-
-        return model, best_metric
+        return state.model, state.best_model_metric
 
     @timing.report_snapshot
-    def _run_epoch(
-        self,
-        stage,
-        epoch,
-        data_iter,
-        model,
-        metric_reporter,
-        pre_batch=lambda: None,
-        backprop=lambda loss: None,
-        rank=0,
-        num_samples_to_log_progress=1000,
+    def run_epoch(
+        self, state: TrainingState, data: BatchIterator, metric_reporter: MetricReporter
     ):
-        print(f"Rank {rank} worker: Running epoch #{epoch} for {stage}")
-        report_metric = stage != Stage.TRAIN or self.config.report_train_metrics
+        # This method is due for some refactoring, pushing it off because it interacts
+        # with the metric reporter too much. Much of the logic here either changes in
+        # the NewTaskTrainer or should change with a better metric reporter design.
+        report_metric = state.stage != Stage.TRAIN or self.config.report_train_metrics
+        model = state.model
 
-        for batch_id, (inputs, targets, context) in enumerate(data_iter):
-            pre_batch()
+        for batch_id, (inputs, targets, context) in enumerate(data):
+            self.zero_grads(state)
             # pass context to model to use in forward call if needed
             model.contextualize(context)
             with timing.time("model.forward"):
@@ -309,29 +336,30 @@ class Trainer(TrainerBase):
                 if BatchContext.IGNORE_LOSS in context:
                     loss *= 0
 
-            with timing.time("backprop"):
-                backprop(loss)
+            self.backprop(state, loss)
 
             if report_metric:
                 with timing.time("add metrics"):
                     preds, scores = model.get_pred(
-                        logits, targets, context, stage, *inputs
+                        logits, targets, context, state.stage, *inputs
                     )
                     metric_reporter.add_batch_stats(
                         batch_id, preds, targets, scores, loss.item(), inputs, **context
                     )
 
-            if rank == 0 and (batch_id + 1) % num_samples_to_log_progress == 0:
+            if (
+                state.rank == 0
+                and batch_id % self.config.num_samples_to_log_progress == 0
+            ):
                 print(
-                    f"Epoch {epoch}: finished training {batch_id + 1} samples.",
-                    flush=True,
+                    f"Evaluating batch {batch_id} for epoch {state.epoch}", flush=True
                 )
 
         metrics = None
         if report_metric:
             with timing.time("report metrics"):
                 metrics = metric_reporter.report_metric(
-                    model, stage, epoch, print_to_channels=(rank == 0)
+                    model, state.stage, state.epoch, print_to_channels=(state.rank == 0)
                 )
         else:
             metric_reporter._reset()


### PR DESCRIPTION
Summary: Add a TrainingState object to track the various state of the train method. Simplify the API for run_epoch, and move most of the logic in train to helper functions. run_epoch is still crappy, but that's more because we have to fix the metric reporter APIs.

Differential Revision: D14295935
