### PR TITLE
Enable distributed training for RNNG c++ in backward compatible way

### DIFF
--- a/pytext/models/distributed_model.py
+++ b/pytext/models/distributed_model.py
@@ -35,6 +35,14 @@ class DistributedModel(nn.parallel.DistributedDataParallel):
         wrapped_module = super().__getattr__("module")
         return wrapped_module.cpu()
 
+    def state_dict(self, *args, **kwargs):
+        wrapped_module = super().__getattr__("module")
+        return wrapped_module.state_dict(*args, **kwargs)
+
+    def load_state_dict(self, *args, **kwargs):
+        wrapped_module = super().__getattr__("module")
+        return wrapped_module.load_state_dict(*args, **kwargs)
+
     def train(self, mode=True):
         """
         Override to set stage

--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -90,6 +90,8 @@ class RNNGParser(Model, Component):
 
         # version 0 - initial implementation
         # version 1 - beam search
+        # version 2 - use zero init state rather than random
+        # TODO change to 2
         version: int = 1
         lstm: BiLSTM.Config = BiLSTM.Config()
         ablation: AblationParams = AblationParams()


### PR DESCRIPTION
Summary: bring back D14073194 and return empty embedding for old model version to be backward compatible

Differential Revision: D14283457
