### PR TITLE
Fix exporting of pretrained embedding

### DIFF
--- a/pytext/fields/pretrained_model_embedding_field.py
+++ b/pytext/fields/pretrained_model_embedding_field.py
@@ -20,10 +20,13 @@ class PretrainedModelEmbeddingField(Field):
             unk_token=None,
             pad_token=None,
         )
+        batch_size = TextFeatureField.dummy_model_input.size(0)
+        num_tokens = TextFeatureField.dummy_model_input.size(1)
         embed_dim = kwargs.get("embed_dim", 0)
-        num_tokens = TextFeatureField.dummy_model_input.size(0)
         self.dummy_model_input = torch.tensor(
-            [[1.0] * embed_dim * num_tokens], dtype=torch.float, device="cpu"
+            [[1.0] * embed_dim * num_tokens] * batch_size,
+            dtype=torch.float,
+            device="cpu",
         )
 
     def pad(self, minibatch: List[List[List[float]]]) -> List[List[List[float]]]:

--- a/pytext/fields/test/pretrained_model_embedding_field_test.py
+++ b/pytext/fields/test/pretrained_model_embedding_field_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+import numpy as np
+from pytext.fields.pretrained_model_embedding_field import PretrainedModelEmbeddingField
+
+
+class PretrainedModelEmbeddingFieldTest(unittest.TestCase):
+    def setUp(self):
+        self.field = PretrainedModelEmbeddingField(
+            pad_token=None, unk_token=None, batch_first=True
+        )
+        self.unpadded_batch = [
+            [
+                [0.1, 0.2, 0.3, 0.4, 0.5],
+                [1.1, 1.2, 1.3, 1.4, 1.5],
+                [2.1, 2.2, 2.3, 2.4, 2.5],
+                [3.1, 3.2, 3.3, 3.4, 3.5],
+            ],
+            [
+                [0.1, 0.2, 0.3, 0.4, 0.5],
+                [1.1, 1.2, 1.3, 1.4, 1.5],
+                [2.1, 2.2, 2.3, 2.4, 2.5],
+            ],
+            [[0.1, 0.2, 0.3, 0.4, 0.5], [1.1, 1.2, 1.3, 1.4, 1.5]],
+        ]
+        self.expected_padded_batch = [
+            [
+                [0.1, 0.2, 0.3, 0.4, 0.5],
+                [1.1, 1.2, 1.3, 1.4, 1.5],
+                [2.1, 2.2, 2.3, 2.4, 2.5],
+                [3.1, 3.2, 3.3, 3.4, 3.5],
+            ],
+            [
+                [0.1, 0.2, 0.3, 0.4, 0.5],
+                [1.1, 1.2, 1.3, 1.4, 1.5],
+                [2.1, 2.2, 2.3, 2.4, 2.5],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+            ],
+            [
+                [0.1, 0.2, 0.3, 0.4, 0.5],
+                [1.1, 1.2, 1.3, 1.4, 1.5],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+            ],
+        ]
+
+    def test_pad(self):
+        padded_batch = self.field.pad(self.unpadded_batch)
+        expected_padded_batch_np = np.array(self.expected_padded_batch)
+        padded_batch_np = np.array(padded_batch)
+
+        self.assertEqual(padded_batch_np.shape, expected_padded_batch_np.shape)
+        for i in range(len(self.expected_padded_batch)):
+            for j in range(len(self.expected_padded_batch[i])):
+                for k in range(len(self.expected_padded_batch[i][j])):
+                    self.assertEqual(
+                        padded_batch[i][j][k], self.expected_padded_batch[i][j][k]
+                    )


### PR DESCRIPTION
Summary: The logic on how to use batch size to prepare `dummy_model_input` is erroneous. This worked for RNNG because the batch size used for RNNG is 1.

Differential Revision: D14373884
