### PR TITLE
Include footer when calculating column width in ascii_table.py

### DIFF
--- a/pytext/common/ascii_table.py
+++ b/pytext/common/ascii_table.py
@@ -13,9 +13,14 @@ def ascii_table(
     widths = {
         column: max(len(str(row.get(column))) for row in data) for column in columns
     }
+
     if human_column_names:
         for column, human in human_column_names.items():
             widths[column] = max(widths[column], len(human))
+
+    if footer:
+        for column, footer_value in footer.items():
+            widths[column] = max(widths[column], len(footer_value))
 
     separator = "+" + "+".join("-" * (width + 2) for width in widths.values()) + "+"
 


### PR DESCRIPTION
Summary:
Footer width was previously ignored when creating ascii tables. If the footer
was wider than other values, it would push the footer walls outside of the
bounds of the box.

Differential Revision: D14327767
