### PR TITLE
Add (Bert) regression task

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import Optional
+from typing import List, Optional
 
+import torch
 from pytext.config.component import Component, ComponentType, create_component
 
 from .utils import BOS, EOS, PAD, Tokenizer, VocabBuilder, pad_and_tensorize
@@ -247,7 +248,9 @@ class LabelTensorizer(Tensorizer):
         self.allow_unknown = allow_unknown
 
     def initialize(self):
-        """Look through the dataset for all labels and create a vocab map for them."""
+        """
+        Look through the dataset for all labels and create a vocab map for them.
+        """
         builder = VocabBuilder()
         builder.use_pad = False
         builder.use_unk = self.allow_unknown
@@ -265,6 +268,44 @@ class LabelTensorizer(Tensorizer):
 
     def tensorize(self, batch):
         return pad_and_tensorize(batch)
+
+
+class NumericLabelTensorizer(Tensorizer):
+    """Numberize numeric labels."""
+
+    class Config(Tensorizer.Config):
+        #: The name of the label column to parse from the data source.
+        column: str = "label"
+        #: If provided, the range of values the raw label can be. Will rescale the
+        #: label values to be within [0, 1].
+        rescale_range: Optional[List[float]] = None
+
+    @classmethod
+    def from_config(cls, config: Config):
+        return cls(config.column, config.rescale_range)
+
+    def __init__(
+        self,
+        column: str = Config.column,
+        rescale_range: Optional[List[float]] = Config.rescale_range,
+    ):
+        self.column = column
+        if rescale_range is not None:
+            assert len(rescale_range) == 2
+            assert rescale_range[0] < rescale_range[1]
+        self.rescale_range = rescale_range
+
+    def numberize(self, row):
+        """Numberize labels."""
+        label = float(row[self.column])
+        if self.rescale_range is not None:
+            label -= self.rescale_range[0]
+            label /= self.rescale_range[1] - self.rescale_range[0]
+            assert 0 <= label <= 1
+        return label
+
+    def tensorize(self, batch):
+        return pad_and_tensorize(batch, dtype=torch.float)
 
 
 class MetaInput(Tensorizer):

--- a/pytext/loss/__init__.py
+++ b/pytext/loss/__init__.py
@@ -6,6 +6,7 @@ from .loss import (
     KLDivergenceBCELoss,
     KLDivergenceCELoss,
     Loss,
+    MSELoss,
     PairwiseRankingLoss,
     SoftHardBCELoss,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "BinaryCrossEntropyLoss",
     "KLDivergenceBCELoss",
     "KLDivergenceCELoss",
+    "MSELoss",
     "SoftHardBCELoss",
     "PairwiseRankingLoss",
 ]

--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 import torch.nn.functional as F
 from pytext.config import ConfigBase
 from pytext.config.component import Component, ComponentType
@@ -388,3 +389,15 @@ class PairwiseRankingLoss(Loss):
         return F.margin_ranking_loss(
             pos_similarity, neg_similarity, targets_local, self.config.margin
         )
+
+
+class MSELoss(Loss):
+    """
+    Mean squared error loss, for regression tasks.
+    """
+
+    class Config(ConfigBase):
+        pass
+
+    def __call__(self, predictions, targets, reduce=True):
+        return F.mse_loss(predictions, targets, reduction="mean" if reduce else "none")

--- a/pytext/metric_reporters/__init__.py
+++ b/pytext/metric_reporters/__init__.py
@@ -8,6 +8,7 @@ from .intent_slot_detection_metric_reporter import IntentSlotMetricReporter
 from .language_model_metric_reporter import LanguageModelMetricReporter
 from .metric_reporter import MetricReporter
 from .pairwise_ranking_metric_reporter import PairwiseRankingMetricReporter
+from .regression_metric_reporter import RegressionMetricReporter
 from .word_tagging_metric_reporter import WordTaggingMetricReporter
 
 
@@ -15,6 +16,7 @@ __all__ = [
     "Channel",
     "MetricReporter",
     "ClassificationMetricReporter",
+    "RegressionMetricReporter",
     "IntentSlotMetricReporter",
     "LanguageModelMetricReporter",
     "WordTaggingMetricReporter",

--- a/pytext/metric_reporters/regression_metric_reporter.py
+++ b/pytext/metric_reporters/regression_metric_reporter.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from pytext.metrics import compute_regression_metrics
+
+from .channel import ConsoleChannel
+from .metric_reporter import MetricReporter
+
+
+class RegressionMetricReporter(MetricReporter):
+
+    lower_is_better = False
+
+    class Config(MetricReporter.Config):
+        pass
+
+    @classmethod
+    def from_config(cls, config):
+        return cls([ConsoleChannel()])
+
+    def calculate_metric(self):
+        assert len(self.all_preds) == len(self.all_targets)
+        return compute_regression_metrics(self.all_preds, self.all_targets)
+
+    def get_model_select_metric(self, metrics):
+        return metrics.pearson_correlation
+
+    def batch_context(self, batch):
+        return {}

--- a/pytext/models/output_layers/__init__.py
+++ b/pytext/models/output_layers/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .doc_classification_output_layer import ClassificationOutputLayer
+from .doc_regression_output_layer import RegressionOutputLayer
 from .output_layer_base import OutputLayerBase
 from .pairwise_ranking_output_layer import PairwiseRankingOutputLayer
 from .utils import OutputLayerUtils
@@ -12,6 +13,7 @@ __all__ = [
     "OutputLayerBase",
     "CRFOutputLayer",
     "ClassificationOutputLayer",
+    "RegressionOutputLayer",
     "WordTaggingOutputLayer",
     "PairwiseRankingOutputLayer",
     "OutputLayerUtils",

--- a/pytext/models/output_layers/doc_regression_output_layer.py
+++ b/pytext/models/output_layers/doc_regression_output_layer.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Any, Dict, Optional
+
+import torch
+from pytext.config.component import create_loss
+from pytext.loss import MSELoss
+
+from .output_layer_base import OutputLayerBase
+
+
+class RegressionOutputLayer(OutputLayerBase):
+    """
+    Output layer for doc regression models. Currently only supports Mean Squared Error
+    loss.
+
+    Args:
+        loss (MSELoss): config for MSE loss
+        clamp_to_unit_range (bool): whether to clamp the output to the range [0, 1],
+            via a sigmoid.
+    """
+
+    class Config(OutputLayerBase.Config):
+        loss: MSELoss.Config = MSELoss.Config()
+        clamp_to_unit_range: bool = False
+
+    @classmethod
+    def from_config(cls, config: Config):
+        return cls(create_loss(config.loss), config.clamp_to_unit_range)
+
+    def __init__(self, loss_fn: MSELoss, clamp_to_unit_range: bool = False) -> None:
+        super().__init__()
+        self.loss_fn = loss_fn
+        self.clamp_to_unit_range = clamp_to_unit_range
+
+    def get_loss(
+        self,
+        logit: torch.Tensor,
+        target: torch.Tensor,
+        context: Optional[Dict[str, Any]] = None,
+        reduce: bool = True,
+    ) -> torch.Tensor:
+        """
+        Compute regression loss from logits and targets.
+
+        Args:
+            logit (torch.Tensor): Logits returned :class:`~pytext.models.Model`.
+            target (torch.Tensor): True label/target to compute loss against.
+            context (Optional[Dict[str, Any]]): Context is a dictionary of items
+                that's passed as additional metadata by the
+                :class:`~pytext.data.DataHandler`. Defaults to None.
+            reduce (bool): Whether to reduce loss over the batch. Defaults to True.
+
+        Returns:
+            torch.Tensor: Model loss.
+        """
+        logit, _ = self.get_pred(logit)
+        return self.loss_fn(logit, target, reduce)
+
+    def get_pred(self, logit, *args, **kwargs):
+        """
+        Compute predictions and scores from the model (unlike in classification, where
+        prediction = "most likely class" and scores = "log probs", here these are the
+        same values). If `clamp_to_unit_range` is True, fit prediction to [0, 1] via
+        a sigmoid.
+
+        Args:
+            logit (torch.Tensor): Logits returned from the model.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: Model prediction and scores.
+        """
+        prediction = logit.squeeze(dim=1)
+        if self.clamp_to_unit_range:
+            prediction = torch.sigmoid(prediction)
+        return prediction, prediction

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -11,8 +11,15 @@ from pytext.data.data import Data
 from pytext.data.sources import DataSchema
 from pytext.data.tensorizers import Tensorizer
 from pytext.exporters import ModelExporter
-from pytext.metric_reporters import ClassificationMetricReporter, MetricReporter
-from pytext.models.doc_model import NewDocModel as DocModel
+from pytext.metric_reporters import (
+    ClassificationMetricReporter,
+    MetricReporter,
+    RegressionMetricReporter,
+)
+from pytext.models.doc_model import (
+    NewDocModel as DocModel,
+    NewDocRegressionModel as DocRegressionModel,
+)
 from pytext.models.model import BaseModel as Model
 from pytext.trainers import Trainer
 from pytext.utils import cuda, timing
@@ -186,3 +193,17 @@ class NewDocumentClassification(NewTask):
         return ClassificationMetricReporter.from_config_and_label_names(
             config.metric_reporter, list(tensorizers["labels"].labels)
         )
+
+
+class NewDocumentRegression(NewTask):
+    DATA_SCHEMA: DataSchema = {"text": data_types.Text, "label": data_types.Label}
+
+    class Config(NewTask.Config):
+        model: Model.Config = DocRegressionModel.Config()
+        metric_reporter: RegressionMetricReporter.Config = (
+            RegressionMetricReporter.Config()
+        )
+
+    @classmethod
+    def create_metric_reporter(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
+        return RegressionMetricReporter.from_config(config.metric_reporter)

--- a/tests/data/sts_tiny.tsv
+++ b/tests/data/sts_tiny.tsv
@@ -1,0 +1,16 @@
+0	main-captions	MSRvid	2012test	0001	none	none	A plane is taking off .	An air plane is taking off .	5.000
+1	main-captions	MSRvid	2012test	0004	none	none	A man is playing a large flute .	A man is playing a flute .	3.800
+2	main-captions	MSRvid	2012test	0005	none	none	A man is spreading shreded cheese on a pizza .	A man is spreading shredded cheese on an uncooked pizza .	3.800
+3	main-captions	MSRvid	2012test	0006	none	none	Three men are playing chess .	Two men are playing chess .	2.600
+4	main-captions	MSRvid	2012test	0009	none	none	A man is playing the cello .	A man seated is playing the cello .	4.250
+5	main-captions	MSRvid	2012test	0011	none	none	Some men are fighting .	Two men are fighting .	4.250
+6	main-captions	MSRvid	2012test	0012	none	none	A man is smoking .	A man is skating .	0.500
+7	main-captions	MSRvid	2012test	0013	none	none	The man is playing the piano .	The man is playing the guitar .	1.600
+8	main-captions	MSRvid	2012test	0014	none	none	A man is playing on a guitar and singing .	A woman is playing an acoustic guitar and singing .	2.200
+9	main-captions	MSRvid	2012test	0016	none	none	A person is throwing a cat on to the ceiling .	A person throws a cat on the ceiling .	5.000
+10	main-captions	MSRvid	2012test	0017	none	none	The man hit the other man with a stick .	The man spanked the other man with a stick .	4.200
+11	main-captions	MSRvid	2012test	0018	none	none	A woman picks up and holds a baby kangaroo .	A woman picks up and holds a baby kangaroo in her arms .	4.600
+12	main-captions	MSRvid	2012test	0019	none	none	A man is playing a flute .	A man is playing a bamboo flute .	3.867
+13	main-captions	MSRvid	2012test	0020	none	none	A person is folding a piece of paper .	Someone is folding a piece of paper .	4.667
+14	main-captions	MSRvid	2012test	0021	none	none	A man is running on the road .	A panda dog is running on the road .	1.667
+15	main-captions	MSRvid	2012test	0022	none	none	A dog is trying to get bacon off his back .	A dog is trying to eat the bacon on its back .	3.750


### PR DESCRIPTION
Summary: Add regression task, including new label, output layer, loss, metric, and test. The current need for this task type is to evaluate STS-B as part of the GLUE benchmarks.

Differential Revision: D14393979
