### PR TITLE
SGNN integration into PyText

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -67,6 +67,7 @@ class PretrainedModelEmbeddingConfig(ConfigBase):
 
 class FloatVectorConfig(ConfigBase):
     dim: int = 0  # Dimension of the vector in the dataset.
+    export_input_names: List[str] = ["float_vec_vals"]
 
 
 class FeatureConfig(ModuleConfig):  # type: ignore

--- a/pytext/fields/field.py
+++ b/pytext/fields/field.py
@@ -310,6 +310,9 @@ class FloatVectorField(Field):
             fix_length=dim,
             pad_token=0,  # For irregular sized vectors, pad the missing units with 0s.
         )
+        self.dummy_model_input = torch.tensor(
+            [[1.0] * dim], dtype=torch.float, device="cpu"
+        )
 
     @classmethod
     def _parse_vector(cls, s):


### PR DESCRIPTION
Summary: SGNN doesn't need Embedding and Representation components, so we pull them and pass the Featurizer output directly to Decoder.

Differential Revision: D14092870
