### PR TITLE
Add error checking to dense features

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -68,6 +68,7 @@ class PretrainedModelEmbeddingConfig(ConfigBase):
 class FloatVectorConfig(ConfigBase):
     dim: int = 0  # Dimension of the vector in the dataset.
     export_input_names: List[str] = ["float_vec_vals"]
+    dim_error_check: bool = False  # should we error check dims b/w config and data
 
 
 class FeatureConfig(ModuleConfig):  # type: ignore


### PR DESCRIPTION
Summary:
Currently, you can specify dense features along with their dimension in the config. However, we don't check that the features we read from data match specified dimensions in config. This leads to silent bugs where training data was poorly formatted, but training runs don't complain.

This diff adds (optional) error checking to dense features.

Differential Revision: D14426800
