### PR TITLE
fix unpickable, set metric_channels as empty list

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -80,7 +80,7 @@ def train_model_distributed(config, metric_channels: Optional[List[Channel]]):
                     config.distributed_world_size,
                     dist_init_method,
                     metadata,
-                    metric_channels,
+                    [],
                 ),
                 config.distributed_world_size,
             )


### PR DESCRIPTION
Summary: fix unpickable, set metric_channels as empty list

Differential Revision: D14429913
