### PR TITLE
fix distributed waiting

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -20,7 +20,7 @@ from pytext.models.doc_model import (
 )
 from pytext.models.model import BaseModel as Model
 from pytext.trainers import Trainer
-from pytext.utils import cuda, precision, timing
+from pytext.utils import cuda, distributed, precision, timing
 from torch import jit
 
 from .task import TaskBase
@@ -158,7 +158,13 @@ class NewTask(TaskBase):
         )
         self.trainer = trainer or NewTaskTrainer()
 
-    def train(self, config: PyTextConfig, rank: int = 0, unused_world_size: int = 1):
+    def train(
+        self, config: PyTextConfig, rank: int = 0, world_size: int = 1, dist_init_url=""
+    ):
+        # TODO: move dist_init back to prepare_task in pytext/workflow.py
+        # when processing time between dist_init and first loss.backward() is short
+        if dist_init_url and world_size > 1:
+            distributed.dist_init(rank, world_size, dist_init_url)
         return self.trainer.train(
             self.data.batches(Stage.TRAIN),
             self.data.batches(Stage.EVAL),

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -24,7 +24,7 @@ from pytext.loss import KLDivergenceBCELoss, KLDivergenceCELoss, SoftHardBCELoss
 from pytext.metric_reporters import MetricReporter
 from pytext.models import Model
 from pytext.trainers import Trainer
-from pytext.utils import cuda, precision
+from pytext.utils import cuda, distributed, precision
 
 
 def create_task(task_config, metadata=None, model_state=None):
@@ -129,7 +129,7 @@ class TaskBase(Component):
         self.metric_reporter: MetricReporter = metric_reporter
         self.exporter = exporter
 
-    def train(self, train_config, rank=0, world_size=1):
+    def train(self, train_config, rank=0, world_size=1, dist_init_url=""):
         """
         Wrapper method to train the model using :class:`~Trainer` object.
 
@@ -139,9 +139,14 @@ class TaskBase(Component):
             world_size (int): for distributed training only, total gpu to use, default
                 is 1
         """
+        train_iter = self.data_handler.get_train_iter(rank, world_size)
+        eval_iter = self.data_handler.get_eval_iter()
+        if dist_init_url and world_size > 1:
+            distributed.dist_init(rank, world_size, dist_init_url)
+
         result = self.trainer.train(
-            self.data_handler.get_train_iter(rank, world_size),
-            self.data_handler.get_eval_iter(),
+            train_iter,
+            eval_iter,
             self.model,
             self.metric_reporter,
             train_config,

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -99,7 +99,6 @@ def prepare_task(
 
     if dist_init_url and world_size > 1:
         assert metadata is not None
-        dist_init(rank, world_size, dist_init_url)
 
     print("\nParameters: {}\n".format(config))
     _set_cuda(config.use_cuda_if_available, device_id, world_size)


### PR DESCRIPTION
Summary:
We have noticed RuntimeError: [caffe2/caffe2/fb/distribute/lib/ZeusStoreHandler.cpp:233] Wait timeout for name(s): 0_0, caused by distributed training timeout after calling distributed_init.
Process spend some time on loading train and eval data, which might cause out of sync.
Based on Myle's suggestion, we should move distributed_init after the heavy operations

Reference: D13783815

Differential Revision: D14464248
