### PR TITLE
Console prettification

### DIFF
--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -181,7 +181,11 @@ class RootDataSource(DataSource):
                 example[name] = self.load(value, self.schema[name])
             if len(example) != len(self.schema):
                 # We might need to re-evaluate this for multi-task training
-                logging.warn("Skipping row missing values")
+                logging.warn(
+                    "Skipping row missing values: row {} -> schema {}".format(
+                        list(example.keys()), list(self.schema.keys())
+                    )
+                )
                 continue
             yield example
 

--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -115,7 +115,7 @@ class MacroPRF1Metrics(NamedTuple):
                         "f1": f"{metrics.f1:.2f}",
                         "support": metrics.true_positives + metrics.false_negatives,
                     }
-                    for label, metrics in self.per_label_scores.items()
+                    for label, metrics in sorted(self.per_label_scores.items())
                 ],
                 human_column_names={
                     "label": "Label",
@@ -130,6 +130,7 @@ class MacroPRF1Metrics(NamedTuple):
                     "recall": f"{self.macro_scores.recall:.2f}",
                     "f1": f"{self.macro_scores.f1:.2f}",
                 },
+                alignments={"label": "<"},
                 indentation=indentation,
             )
         )
@@ -209,31 +210,30 @@ class ClassificationMetrics(NamedTuple):
     def print_metrics(self) -> None:
         print(f"Accuracy: {self.accuracy * 100:.2f}\n")
         print("Macro P/R/F1 Scores:")
-        self.macro_prf1_metrics.print_metrics(indentation="\t")
+        self.macro_prf1_metrics.print_metrics()
         print("\nSoft Metrics:")
         if self.per_label_soft_scores:
             soft_scores = [
                 {
                     "label": label,
-                    "avg_pr": f"{metrics.average_precision * 100:.2f}",
-                    "roc_auc": f"{(metrics.roc_auc or 0.0) * 100:.2f}",
+                    "avg_pr": f"{metrics.average_precision:.2f}",
+                    "roc_auc": f"{(metrics.roc_auc or 0.0):.2f}",
                 }
-                for label, metrics in self.per_label_soft_scores.items()
+                for label, metrics in sorted(self.per_label_soft_scores.items())
             ]
             columns = {
                 "label": "Label",
                 "avg_pr": "Average precision",
                 "roc_auc": "ROC AUC",
             }
-            print(ascii_table(soft_scores, columns, indentation="\t"))
-
+            print(ascii_table(soft_scores, columns))
             all_thresholds = set(
                 itertools.chain.from_iterable(
                     metrics.recall_at_precision
                     for metrics in self.per_label_soft_scores.values()
                 )
             )
-            print("\n\t Precision at Recall")
+            print("\nPrecision at Recall")
             print(
                 ascii_table(
                     (
@@ -244,13 +244,13 @@ class ClassificationMetrics(NamedTuple):
                                 for p, r in metrics.recall_at_precision.items()
                             },
                         )
-                        for label, metrics in self.per_label_soft_scores.items()
+                        for label, metrics in sorted(self.per_label_soft_scores.items())
                     ),
                     dict(
                         {"label": "Label"},
                         **{str(t): f"P@R {t}" for t in all_thresholds},
                     ),
-                    indentation="\t",
+                    alignments={"label": "<"},
                 )
             )
         if self.mcc:

--- a/pytext/utils/ascii_table.py
+++ b/pytext/utils/ascii_table.py
@@ -61,4 +61,5 @@ def ascii_table_from_dict(dict, key_name, value_name, indentation=""):
         [{"key": key, "value": value} for key, value in dict.items()],
         {"key": key_name, "value": value_name},
         indentation=indentation,
+        alignments={"key": "<"},
     )

--- a/pytext/utils/precision.py
+++ b/pytext/utils/precision.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from sys import stderr
+
+from . import cuda
+
 
 _APEX_DISABLED = False
 try:
     from apex import amp
 except ImportError:
-    print("Install apex from https://github.com/NVIDIA/apex/.")
+    print("Install apex from https://github.com/NVIDIA/apex/.", file=stderr)
     _APEX_DISABLED = True
 except AttributeError as e:
     print(f"Fail to import apex: {e}")
     _APEX_DISABLED = True
-
-from . import cuda
 
 
 """


### PR DESCRIPTION
Summary:
Make the reports on the console more pretty
- remove unnecessary indentations of ascii tables to save columns, because small terminal windows wrap the tables.
- all labels are aligned to the left, so that prefixes are aligned, to easily compare results
- all labels are sorted, so that labels with similar prefixes are grouped and the results can be compared in a stable fashion
- log warnings to stderr to avoid polluting stdout, for example when printing a default config to file
- fixed rounding in timings table for minutes and seconds

Differential Revision: D14473075
