### PR TITLE
Fix model export for dense features

### DIFF
--- a/pytext/exporters/__init__.py
+++ b/pytext/exporters/__init__.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from pytext.exporters.custom_exporters import DenseFeatureExporter
 from pytext.exporters.exporter import ModelExporter
 
 
-__all__ = ["ModelExporter"]
+__all__ = ["ModelExporter", "DenseFeatureExporter"]

--- a/pytext/exporters/custom_exporters.py
+++ b/pytext/exporters/custom_exporters.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Dict
+
+from pytext.config import ConfigBase
+from pytext.config.field_config import FeatureConfig, FloatVectorConfig
+from pytext.exporters.exporter import ModelExporter
+from pytext.fields import FieldMeta
+
+
+class DenseFeatureExporter(ModelExporter):
+    """
+    Exporter for models that have DenseFeatures as input to the decoder
+    """
+
+    @classmethod
+    def get_feature_metadata(
+        cls, feature_config: FeatureConfig, feature_meta: Dict[str, FieldMeta]
+    ):
+        # add all features EXCEPT dense features. The features exported here
+        # go through the representation layer
+        (
+            input_names_rep,
+            dummy_model_input_rep,
+            feature_itos_map_rep,
+        ) = cls._get_exportable_metadata(
+            lambda x: isinstance(x, ConfigBase)
+            and not isinstance(x, FloatVectorConfig),
+            feature_config,
+            feature_meta,
+        )
+
+        # need feature lengths only for non-dense features
+        cls._add_feature_lengths(input_names_rep, dummy_model_input_rep)
+
+        # add dense features. These features don't go through the representation
+        # layer, instead they go directly to the decoder
+        (
+            input_names_dense,
+            dummy_model_input_dense,
+            feature_itos_map_dense,
+        ) = cls._get_exportable_metadata(
+            lambda x: isinstance(x, FloatVectorConfig), feature_config, feature_meta
+        )
+
+        feature_itos_map_rep.update(feature_itos_map_dense)
+        return (
+            input_names_rep + input_names_dense,
+            tuple(dummy_model_input_rep + dummy_model_input_dense),
+            feature_itos_map_rep,
+        )

--- a/pytext/fields/field.py
+++ b/pytext/fields/field.py
@@ -312,7 +312,7 @@ class FloatVectorField(Field):
         )
         self.dim_error_check = dim_error_check  # dims in data should match config
         self.dummy_model_input = torch.tensor(
-            [[1.0] * dim], dtype=torch.float, device="cpu"
+            [[1.0] * dim, [1.0] * dim], dtype=torch.float, device="cpu"
         )
 
     def _parse_vector(self, s):

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -21,6 +21,7 @@ from pytext.data import (
     QueryDocumentPairwiseRankingDataHandler,
     SeqModelDataHandler,
 )
+from pytext.exporters import DenseFeatureExporter
 from pytext.metric_reporters import (
     ClassificationMetricReporter,
     CompositionalMetricReporter,
@@ -115,6 +116,7 @@ class DocClassificationTask(Task):
         metric_reporter: ClassificationMetricReporter.Config = (
             ClassificationMetricReporter.Config()
         )
+        exporter: Optional[DenseFeatureExporter.Config] = None
 
     @classmethod
     def format_prediction(cls, predictions, scores, context, target_meta):


### PR DESCRIPTION
Summary:
DocClassificationTask supports dense features, but exporting a DocClassification model with dense features to caffe2 doesn't work. Also, exporting any model that uses both text features (word/char) and dense features together doesn't work. This diff fixes export for dense features.

There are two things that needed fixing:

- export puts model inputs in a list like this: `[features, feature lengths]`. However, dense features don't go through the representation layer - so they need to be hardcoded to be at the end of model inputs (ugh). The order of features needs to be `[features, feature lengths, dense features]`
- dummy_model_input for all other fields has two entries. dummy_model_input for dense_features has one entry

This is a blocking feature for [on-device M-suggestions](https://fb.workplace.com/groups/323789728341681/permalink/326686971385290/). A public test for that is scheduled next week.
Personalization models in M-suggestions need dense features.

Differential Revision: D14473020
