### PR TITLE
Support embedding class for seq2seq models

### DIFF
--- a/pytext/data/featurizer/featurizer.py
+++ b/pytext/data/featurizer/featurizer.py
@@ -57,3 +57,8 @@ class Featurizer(Component):
         """Featurize a batch of instances/examples.
         """
         return [self.featurize(record) for record in input_record_list]
+
+    def get_sentence_markers(self, locale=None):
+        raise NotImplementedError(
+            "Featurizer.get_sentence_markers() method must be implemented."
+        )

--- a/pytext/data/featurizer/simple_featurizer.py
+++ b/pytext/data/featurizer/simple_featurizer.py
@@ -75,3 +75,6 @@ class SimpleFeaturizer(Featurizer):
         self, input_records: Sequence[InputRecord]
     ) -> Sequence[OutputRecord]:
         return [self.featurize(in_record) for in_record in input_records]
+
+    def get_sentence_markers(self, locale=None):
+        return self.config.sentence_markers

--- a/pytext/docs/source/create_new_task.rst
+++ b/pytext/docs/source/create_new_task.rst
@@ -160,7 +160,7 @@ vectors in the forward method. We don't need to override anything in
 this example since the default behavior in base :class:`~Model` already does this::
 
 	@classmethod
-	def compose_embedding(cls, sub_embs):
+	def compose_embedding(cls, sub_embs, metadata):
 	  return EmbeddingList(sub_embs.values(), concat=True)
 
 the `sub_embs` parameter contains the embeddings we previously defined in the :class:`~ModelInputConfig`
@@ -170,7 +170,7 @@ If you're creating more complicated models, e.g PairNN, you can override this fu
 to reflect the embedding structure::
 
 	@classmethod
-	def compose_embedding(cls, sub_embs):
+	def compose_embedding(cls, sub_embs, metadata):
 	  return EmbeddingList(
 	    EmbeddingList(sub_embs["word_feat_1"], sub_embs["dict_feat_1"], concat=True),
 	    EmbeddingList(sub_embs["word_feat_2"], sub_embs["dict_feat_2"], concat=True),

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -275,7 +275,7 @@ class Model(BaseModel):
 
     @classmethod
     def compose_embedding(
-        cls, sub_emb_module_dict: Dict[str, EmbeddingBase]
+        cls, sub_emb_module_dict: Dict[str, EmbeddingBase], metadata
     ) -> EmbeddingList:
         """Default implementation is to compose an instance of
         :class:`~EmbeddingList` with all the sub-embedding modules. You should
@@ -296,7 +296,7 @@ class Model(BaseModel):
     @classmethod
     def create_embedding(cls, feat_config: FeatureConfig, metadata: CommonMetadata):
         sub_emb_module_dict = cls.create_sub_embs(feat_config, metadata)
-        emb_module = cls.compose_embedding(sub_emb_module_dict)
+        emb_module = cls.compose_embedding(sub_emb_module_dict, metadata)
         emb_module.config = feat_config
         return emb_module
 

--- a/pytext/models/pair_classification_model.py
+++ b/pytext/models/pair_classification_model.py
@@ -38,7 +38,7 @@ class PairClassificationModel(Model):
         )
 
     @classmethod
-    def compose_embedding(cls, sub_embs):
+    def compose_embedding(cls, sub_embs, metadata):
         return EmbeddingList(sub_embs.values(), concat=False)
 
     def save_modules(self, base_path: str = "", suffix: str = ""):

--- a/pytext/models/query_document_pairwise_ranking_model.py
+++ b/pytext/models/query_document_pairwise_ranking_model.py
@@ -78,7 +78,7 @@ class QueryDocumentPairwiseRankingModel(Model):
         return sub_emb_module_dict
 
     @classmethod
-    def compose_embedding(cls, sub_embs):
+    def compose_embedding(cls, sub_embs, metadata):
         return EmbeddingList(sub_embs.values(), concat=False)
 
     def forward(self, *inputs) -> List[torch.Tensor]:

--- a/pytext/models/seq_models/contextual_intent_slot.py
+++ b/pytext/models/seq_models/contextual_intent_slot.py
@@ -39,7 +39,7 @@ class ContextualIntentSlotModel(JointModel):
         representation: ContextualIntentSlotRepresentation.Config = ContextualIntentSlotRepresentation.Config()
 
     @classmethod
-    def compose_embedding(cls, sub_embs):
+    def compose_embedding(cls, sub_embs, metadata):
         """Compose embedding list for ContextualIntentSlot model training.
         The first is the word embedding of the last utterance concatenated with the
         word level dictionary feature. The second is the word embedding of a


### PR DESCRIPTION
Summary:
This diff adds support for dictionary features / contextual embeddings for seq2seq models. Below are some of the changes
- `Seq2SeqFeatureConfig` was added
- `FairseqEmbeddingList` was added
- From `pytext/fb/models/seq2seq/hybrid_transformer_rnn.py` it can be see that the translate model is built inside pytext
- `get_sentence_markers()` was add to featurizer
- `metadata` was introduced as a new argument for `compose_embedding()`

Differential Revision: D14274194
