### PR TITLE
Fix time reporting for longer timings

### DIFF
--- a/pytext/utils/tests/ascii_table_test.py
+++ b/pytext/utils/tests/ascii_table_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import unittest
 
-from pytext.common.ascii_table import ascii_table
+from pytext.utils.ascii_table import ascii_table
 
 
 class TestTables(unittest.TestCase):

--- a/pytext/utils/tests/timing_test.py
+++ b/pytext/utils/tests/timing_test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+from pytext.utils import timing
+
+
+class TimingTest(unittest.TestCase):
+    def test_format_time(self):
+        tests = (
+            (1.2473e-8, "0.0ns"),
+            (1.2473e-7, "0.1ns"),
+            (1.2473e-6, "1.2ns"),
+            (0.000_012_473, "12.5ns"),
+            (0.000_124_73, "124.7ns"),
+            (0.001_247_3, "1.2ms"),
+            (0.012_473, "12.5ms"),
+            (0.12473, "124.7ms"),
+            (1.2473, "1.2s"),
+            (12.473, "12.5s"),
+            (124.73, "2m5s"),
+            (1247.3, "20m47s"),
+            (12473.0, "3h28m"),
+            (124_730.0, "1d11h"),
+            (1_247_300.0, "14d10h"),
+        )
+        for seconds, expected in tests:
+            self.assertEqual(
+                expected, timing.format_time(seconds), f"Failed to format {seconds}"
+            )

--- a/pytext/utils/timing.py
+++ b/pytext/utils/timing.py
@@ -41,14 +41,22 @@ SECONDS_IN_DAY = 24 * SECONDS_IN_HOUR
 
 def format_time(seconds):
     if seconds > 60:
-        days, seconds = seconds // SECONDS_IN_DAY, seconds % SECONDS_IN_DAY
-        hours, seconds = seconds // SECONDS_IN_HOUR, seconds % SECONDS_IN_HOUR
-        minutes, seconds = seconds // SECONDS_IN_MINUTE, seconds % SECONDS_IN_MINUTE
+        days, seconds = int(seconds // SECONDS_IN_DAY), seconds % SECONDS_IN_DAY
+        hours, seconds = int(seconds // SECONDS_IN_HOUR), seconds % SECONDS_IN_HOUR
+        minutes, seconds = (
+            int(seconds // SECONDS_IN_MINUTE),
+            seconds % SECONDS_IN_MINUTE,
+        )
         if days:
+            if minutes >= 30:
+                hours += 1
             return f"{days}d{hours}h"
         elif hours:
+            if seconds >= 30:
+                minutes += 1
             return f"{hours}h{minutes}m"
         else:
+            seconds = int(round(seconds))
             return f"{minutes}m{seconds}s"
     elif seconds > 1:
         return f"{seconds:.1f}s"


### PR DESCRIPTION
Summary: Timings reportings that were longer than 1 minute were reporting awkwardly. Force them to ints so they look nice.

Differential Revision: D14487506
