### PR TITLE
Fix circleCI lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
               sudo pip install black isort
       - run:
           name: run black
-          command: black pytext --check
+          command: black pytext --check --diff
       - run:
           name: run isort
           command: |

--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -128,8 +128,7 @@ class Vocabulary:
            Used for replacing special strings for special tokens.
            e.g. '[UNK]' for UNK"""
         for token, replacement in replacements.items():
-            idx = self.idx[token]
-            del (self.idx[token])
+            idx = self.idx.pop(token)
             self._vocab[idx] = replacement
             self.idx[replacement] = idx
 


### PR DESCRIPTION
Summary:
Lint is failing in the following way:
https://circleci.com/gh/facebookresearch/pytext/3981?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification

I'm not sure why this isn't happening on any of our other black linters, but ¯\_(ツ)_/¯ easy fix for now

Differential Revision: D14492041
