### PR TITLE
rename RootDataSource functions

### DIFF
--- a/pytext/data/sources/tsv.py
+++ b/pytext/data/sources/tsv.py
@@ -77,13 +77,13 @@ class TSVDataSource(RootDataSource):
         self._test_tsv = make_tsv(test_file) if test_file else []
         self._eval_tsv = make_tsv(eval_file) if eval_file else []
 
-    def _iter_raw_train(self):
+    def raw_train_data_generator(self):
         return iter(self._train_tsv)
 
-    def _iter_raw_test(self):
+    def raw_test_data_generator(self):
         return iter(self._test_tsv)
 
-    def _iter_raw_eval(self):
+    def raw_eval_data_generator(self):
         return iter(self._eval_tsv)
 
 


### PR DESCRIPTION
Summary:
This diff clarifies the API of RootDataSource and renames the
functions that need to be implemented by RootDataSource users, to make it
clear that it should return a new generator each time.  Previous name can be
understood as the functions iterate on the source data set. Documentation
added or changed accordingly.

Differential Revision: D14508877
