### PR TITLE
make TSVDataSource the default

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable, Optional, Type
 from pytext.common.constants import Stage
 from pytext.config.component import Component, ComponentType, create_component
 
-from .sources import DataSource, RawExample
+from .sources import DataSource, RawExample, TSVDataSource
 from .sources.data_source import GeneratorIterator
 from .tensorizers import Tensorizer
 
@@ -132,7 +132,7 @@ class Data(Component):
     class Config(Component.Config):
         #: Specify where training/test/eval data come from. The default value
         #: will not provide any data.
-        source: DataSource.Config = DataSource.Config()
+        source: DataSource.Config = TSVDataSource.Config()
         #: How training examples are split into batches for the optimizer.
         batcher: Batcher.Config = Batcher.Config()
         sort_key: Optional[str] = None


### PR DESCRIPTION
Summary:
TSV is the most common format supported by PyText. TSVDataSource is
the only fully-implemented DataSource we provide. This diff makes it the
default, so that the user does not have to specify this option each time
they create a config. gen-default-config gives you the parameters right away.

Reviewed By: m3rlin45

Differential Revision: D14547121
