### PR TITLE
Run black --diff in circleci so we have output showing what black doesn't like if lint fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
               sudo pip install black isort
       - run:
           name: run black
-          command: black pytext --check
+          command: black pytext --check --diff
       - run:
           name: run isort
           command: |


### PR DESCRIPTION
Summary: Currently black is showing that it would reformat files on circleCI but not on local checkouts. Adding --diff so it'll show a diff dump of what it would change.

Differential Revision: D14490673
