### PR TITLE
rename MetaInput to RawString

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -338,7 +338,7 @@ class FloatListTensorizer(Tensorizer):
         return pad_and_tensorize(batch, dtype=torch.float)
 
 
-class MetaInput(Tensorizer):
+class RawString(Tensorizer):
     """A pass-through tensorizer to include raw fields from datasource in the batch.
        Used mostly for metric reporting."""
 
@@ -358,7 +358,7 @@ class MetaInput(Tensorizer):
         return row[self.column]
 
 
-class JsonMetaInput(MetaInput):
+class RawJson(RawString):
     def numberize(self, row):
         return json.loads(row[self.column])
 

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -8,8 +8,8 @@ from pytext.config.component import create_loss
 from pytext.config.field_config import WordFeatConfig
 from pytext.data.tensorizers import (
     LabelTensorizer,
-    MetaInput,
     NumericLabelTensorizer,
+    RawString,
     Tensorizer,
     TokenTensorizer,
 )
@@ -59,7 +59,7 @@ class NewDocModel(DocModel):
             tokens: TokenTensorizer.Config = TokenTensorizer.Config()
             labels: LabelTensorizer.Config = LabelTensorizer.Config(allow_unknown=True)
             # for metric reporter
-            raw_text: MetaInput.Config = MetaInput.Config(column="text")
+            raw_text: RawString.Config = RawString.Config(column="text")
 
         inputs: ModelInput = ModelInput()
         embedding: WordEmbedding.Config = WordEmbedding.Config()


### PR DESCRIPTION
Summary:
renaming MetaInput to RawString, and JsonMetaInput to RawJson.
These are pass-through Tokenizers that just copy their inputs.  The name
"MetaInput" does not mean anything, RawString and RawJson at least give you
a hint about what they're doing.

Differential Revision: D14654966
