### PR TITLE
RNNG: add tok/beam size to forward params

### DIFF
--- a/pytext/data/compositional_data_handler.py
+++ b/pytext/data/compositional_data_handler.py
@@ -146,6 +146,8 @@ class CompositionalDataHandler(DataHandler):
             if name == ACTION_FEATURE_FIELD:
                 input = input.tolist()  # Action needn't be passed as Tensor obj.
             m_inputs.append(input)
+        # beam size and topk
+        m_inputs.extend([1, 1])
         return m_inputs
 
     def _test_input_from_batch(self, batch):
@@ -156,6 +158,8 @@ class CompositionalDataHandler(DataHandler):
             getattr(batch, DatasetFieldName.DICT_FIELD, None),
             None,
             getattr(batch, DatasetFieldName.PRETRAINED_MODEL_EMBEDDING, None),
+            1,
+            1,
         ]
 
     def preprocess_row(self, row_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/pytext/models/test/rnng_test.py
+++ b/pytext/models/test/rnng_test.py
@@ -79,8 +79,6 @@ class RNNGParserTest(unittest.TestCase):
             lstm_dim=20,
             max_open_NT=10,
             dropout=0.2,
-            beam_size=3,
-            top_k=3,
             actions_vocab=actions_vocab,
             shift_idx=4,
             reduce_idx=3,
@@ -218,7 +216,9 @@ class RNNGParserTest(unittest.TestCase):
 
         # Beam Search Test
         self.parser.eval(Stage.TEST)
-        results = self.parser(tokens=tokens, seq_lens=seq_lens, dict_feat=dict_feat)
+        results = self.parser(
+            tokens=tokens, seq_lens=seq_lens, dict_feat=dict_feat, beam_size=3, top_k=3
+        )
         self.assertEqual(len(results), 3)
         for actions, scores in results:
             self.assertGreater(actions.shape[1], tokens.shape[1])


### PR DESCRIPTION
Summary:
1 add tok/beam size to forward params
2 change the way of getting input from using enum to incrementing index, because the enum way is wrong when dict feat is optional and contextual feat is given (input position changed)
3 this change is backward compatible, but not forward compatible (old model will work with this code but new model will not work with existing predictor)

Differential Revision: D14718588
