### PR TITLE
Replace dummy input index for dict feature field from 2 to 1 since 2 might not exist for data with no dictionary features

### DIFF
--- a/pytext/fields/dict_field.py
+++ b/pytext/fields/dict_field.py
@@ -13,7 +13,7 @@ from .field import VocabUsingField
 
 class DictFeatureField(VocabUsingField):
     dummy_model_input = (
-        torch.tensor([[2], [2]], dtype=torch.long, device="cpu"),
+        torch.tensor([[1], [1]], dtype=torch.long, device="cpu"),
         torch.tensor([[1.5], [2.5]], dtype=torch.float, device="cpu"),
         torch.tensor([1, 1], dtype=torch.long, device="cpu"),
     )


### PR DESCRIPTION
Summary: Motivation: model trained without dictionary feature failed to export f106767664.

Differential Revision: D14734267
