### PR TITLE
inherit RootDataSource.register_type

### DIFF
--- a/pytext/data/sources/tsv.py
+++ b/pytext/data/sources/tsv.py
@@ -85,8 +85,3 @@ class TSVDataSource(RootDataSource):
 
     def raw_eval_data_generator(self):
         return iter(self._eval_tsv)
-
-
-@TSVDataSource.register_type(str)
-def load_text(s):
-    return str(s)


### PR DESCRIPTION
Summary:
RootDataSource registered types are automatically inherited by the
subclasses and don't need to re-register common types like str.

Differential Revision: D14739237
