### PR TITLE
sharded data for PackedLM

### DIFF
--- a/pytext/data/disjoint_multitask_data.py
+++ b/pytext/data/disjoint_multitask_data.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import Dict
+from typing import Dict, Optional
 
 from pytext.common.constants import BatchContext, Stage
 from pytext.config.component import Component, ComponentType, create_component
-from pytext.data import BaseBatchSampler, Data, EvalBatchSampler, generator_iterator
+from pytext.data import BaseBatchSampler, Data, EvalBatchSampler
 
 
 class DisjointMultitaskData(Data):
@@ -25,22 +25,51 @@ class DisjointMultitaskData(Data):
     """
 
     class Config(Component.Config):
+        epoch_size: Optional[int] = None
         sampler: BaseBatchSampler.Config = EvalBatchSampler.Config()
+        test_key: Optional[str] = None
 
-    def __init__(self, config: Config, data_dict: Dict[str, Data]) -> None:
-        self.data_dict = data_dict
-        self.samplers = {
+    @classmethod
+    def from_config(
+        cls,
+        config: Config,
+        data_dict: Dict[str, Data],
+        task_key: str = BatchContext.TASK_NAME,
+        rank=0,
+        world_size=1,
+    ):
+        samplers = {
             Stage.TRAIN: create_component(ComponentType.BATCH_SAMPLER, config.sampler),
             Stage.EVAL: EvalBatchSampler(),
             Stage.TEST: EvalBatchSampler(),
         }
+        return cls(data_dict, samplers, config.epoch_size, config.test_key, task_key)
 
-    @generator_iterator
-    def batches(self, stage: Stage, rank=0, world_size=1, data_source=None):
-        all_batches = {
-            name: task.batches(stage, rank, world_size)
-            for name, task in self.data_dict.items()
-        }
-        for name, batch in self.samplers[stage].batchify(all_batches):
-            batch[BatchContext.TASK_NAME] = name
+    def __init__(
+        self,
+        data_dict: Dict[str, Data],
+        samplers: Dict[Stage, BaseBatchSampler],
+        epoch_size: Optional[int] = None,
+        test_key: str = None,
+        task_key: str = BatchContext.TASK_NAME,
+    ) -> None:
+        test_key = test_key or list(data_dict)[0]
+        # currently the way training is set up is that, the data object needs
+        # to specify a data_source which is used at test time. For multitask
+        # this is set to the data_source associated with the test_key
+        self.data_source = data_dict[test_key].data_source
+        super().__init__(self.data_source, {}, epoch_size=epoch_size)
+        self.data_dict = data_dict
+        self.samplers = samplers
+        self.task_key = task_key
+
+    def _get_batches(self, stage, data_source):
+        if not self.batch[stage]:
+            all_batches = {
+                name: task.batches(stage) for name, task in self.data_dict.items()
+            }
+            self.batch[stage] = self.samplers[stage].batchify(all_batches)
+
+        for name, batch in self.batch[stage]:
+            batch[self.task_key] = name
             yield batch

--- a/pytext/data/test/batch_sampler_test.py
+++ b/pytext/data/test/batch_sampler_test.py
@@ -32,23 +32,24 @@ class BatchSamplerTest(unittest.TestCase):
         self._check_iterator(eval_iterator, expected_items)
 
     def test_prob_batch_sampler(self):
-        sampler = RandomizedBatchSampler(
-            unnormalized_iterator_probs={"A": 1, "B": 0}, epoch_size=8
-        )
-        prob_iterator = sampler.batchify(self.iter_dict)
+        sampler = RandomizedBatchSampler(unnormalized_iterator_probs={"A": 1, "B": 0})
+
+        def truncate(items, length):
+            for _ in range(length):
+                yield next(items)
+
+        prob_iterator = truncate(iter(sampler.batchify(self.iter_dict)), 8)
         expected_items = ["1", "2", "3", "4", "5", "1", "2", "3"]
         self._check_iterator(prob_iterator, expected_items)
-        prob_iterator = sampler.batchify(self.iter_dict)
+        prob_iterator = truncate(iter(sampler.batchify(self.iter_dict)), 8)
         expected_items = ["4", "5", "1", "2", "3", "4", "5", "1"]
         self._check_iterator(prob_iterator, expected_items)
 
-        sampler = RandomizedBatchSampler(
-            unnormalized_iterator_probs={"A": 0, "B": 1}, epoch_size=5
-        )
-        prob_iterator = sampler.batchify(self.iter_dict)
+        sampler = RandomizedBatchSampler(unnormalized_iterator_probs={"A": 0, "B": 1})
+        prob_iterator = truncate(sampler.batchify(self.iter_dict), 5)
         expected_items = ["a", "b", "c", "a", "b"]
         self._check_iterator(prob_iterator, expected_items)
-        prob_iterator = sampler.batchify(self.iter_dict)
+        prob_iterator = truncate(sampler.batchify(self.iter_dict), 5)
         expected_items = ["c", "a", "b", "c", "a"]
         self._check_iterator(prob_iterator, expected_items)
 

--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -86,6 +86,18 @@ def align_target_label(
     return align_target
 
 
+def shard(rows, rank, num_workers):
+    """Only return every num_workers example for distributed training."""
+    queue = []
+    for row in rows:
+        queue.append(row)
+        # might discard remainder %num_workers rows because distributed
+        # training needs to be in sync
+        if len(queue) == num_workers:
+            yield queue[rank]
+            queue = []
+
+
 class SpecialToken(str):
     def __eq__(self, other):
         # We don't want to compare as equal to actual strings, but we want to behave

--- a/pytext/models/module.py
+++ b/pytext/models/module.py
@@ -46,7 +46,7 @@ def create_module(
     name = type(module).__name__
     if getattr(module_config, "load_path", None):
         print(f"Loading state of module {name} from {module_config.load_path} ...")
-        module.load_state_dict(torch.load(module_config.load_path))
+        module.load_state_dict(torch.load(module_config.load_path, map_location="cpu"))
     if getattr(module_config, "freeze", False):
         print(f"Freezing the parameters of module {name} ...")
         module.freeze()

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -27,12 +27,19 @@ from pytext.trainers import Trainer
 from pytext.utils import cuda, distributed, precision
 
 
-def create_task(task_config, metadata=None, model_state=None):
+def create_task(task_config, metadata=None, model_state=None, rank=0, world_size=1):
     """
     Create a task by finding task class in registry and invoking the from_config
     function of the class, see :meth:`~Task.from_config` for more details
     """
-    return create_component(ComponentType.TASK, task_config, metadata, model_state)
+    return create_component(
+        ComponentType.TASK,
+        task_config,
+        metadata,
+        model_state,
+        rank=rank,
+        world_size=world_size,
+    )
 
 
 class TaskBase(Component):
@@ -52,7 +59,9 @@ class TaskBase(Component):
         exporter: Optional[ModelExporter.Config] = None
 
     @classmethod
-    def from_config(cls, task_config, metadata=None, model_state=None):
+    def from_config(
+        cls, task_config, metadata=None, model_state=None, rank=1, world_size=0
+    ):
         """
         Create the task from config, and optionally load metadata/model_state
         This function will create components including :class:`~DataHandler`,

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -278,6 +278,7 @@ class Trainer(TrainerBase):
             state.epoch += 1
             state.epochs_since_last_improvement += 1
             print(f"\nWorker {state.rank} starting epoch {state.epoch}", flush=True)
+            print(f"Num parameters: {sum(p.numel() for p in state.model.parameters())}")
             lrs = learning_rates(state.optimizer)
             print(f"Learning rate(s): {', '.join(map(str, lrs))}")
 

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -112,7 +112,9 @@ def prepare_task(
     if config.load_snapshot_path and os.path.isfile(config.load_snapshot_path):
         task, _ = load(config.load_snapshot_path)
     else:
-        task = create_task(config.task, metadata=metadata)
+        task = create_task(
+            config.task, metadata=metadata, rank=rank, world_size=world_size
+        )
 
     for mc in metric_channels or []:
         task.metric_reporter.add_channel(mc)


### PR DESCRIPTION
Summary:
Moves sharding from Data to DataSouce, so that we can have DataSources that can shard in different ways.

- Move shard() utility to data/utils
- shard() in RootDataSource.train()
- Remove shard in Data.batches()

Introduce BlockShardingTSVDataSource, which splits (virtually) the given file into N (by byte locations using file.seek) and iterates over a single piece.  This is useful for when row order is important in the file, e.g. when rows are sentences of a long document.  Used for MaskedLM training.

Differential Revision: D14840136
