### PR TITLE
Export LSTM to InferenceLSTM when using ONNX

### DIFF
--- a/.circleci/setup_circleimg.sh
+++ b/.circleci/setup_circleimg.sh
@@ -2,5 +2,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 sudo apt-get update
 sudo apt-get install -y cmake python-pip python-dev build-essential protobuf-compiler libprotoc-dev
+sudo pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 sudo ./install_deps
 sudo pip install --progress-bar off pytest pytest-cov

--- a/pytext/models/representations/bilstm.py
+++ b/pytext/models/representations/bilstm.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.onnx
 from pytext.config import ConfigBase
 from pytext.utils import cuda
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
@@ -115,14 +116,29 @@ class BiLSTM(RepresentationBase):
             )
             states = (state, state)
 
-        rnn_input = pack_padded_sequence(embedded_tokens, seq_lengths, batch_first=True)
-        rep, new_state = self.lstm(rnn_input, states)
-        rep, _ = pad_packed_sequence(
-            rep,
-            padding_value=self.padding_value,
-            batch_first=True,
-            total_length=embedded_tokens.size(1),
-        )  # Make sure the output from LSTM is padded to input's sequence length.
+        if torch.onnx.is_in_onnx_export():
+            lstm_in = [embedded_tokens, states[0], states[1]] + [
+                param.detach() for param in self.lstm._flat_weights
+            ]
+            rep, new_state_0, new_state_1 = torch.ops._caffe2.InferenceLSTM(
+                lstm_in,
+                self.lstm.num_layers,
+                self.lstm.bias,
+                True,
+                self.lstm.bidirectional,
+            )
+            new_state = (new_state_0, new_state_1)
+        else:
+            rnn_input = pack_padded_sequence(
+                embedded_tokens, seq_lengths, batch_first=True
+            )
+            rep, new_state = self.lstm(rnn_input, states)
+            rep, _ = pad_packed_sequence(
+                rep,
+                padding_value=self.padding_value,
+                batch_first=True,
+                total_length=embedded_tokens.size(1),
+            )  # Make sure the output from LSTM is padded to input's sequence length.
 
         # convert states back to (bsz x num_layers*num_directions x nhid) to be
         # used in data parallel model

--- a/pytext/utils/onnx.py
+++ b/pytext/utils/onnx.py
@@ -38,14 +38,16 @@ def pytorch_to_caffe2(
         print(f"Saving onnx model to: {export_onnx_path}")
     else:
         export_onnx_path = export_path
-    torch.onnx.export(
-        model,
-        export_input,
-        export_onnx_path,
-        input_names=all_input_names,
-        output_names=output_names,
-        export_params=True,
-    )
+    model.eval()
+    with torch.no_grad():
+        torch.onnx.export(
+            model,
+            export_input,
+            export_onnx_path,
+            input_names=all_input_names,
+            output_names=output_names,
+            export_params=True,
+        )
     onnx_model = onnx.load(export_onnx_path)
     onnx.checker.check_model(onnx_model)
     # Convert the ONNX model to a caffe2 net


### PR DESCRIPTION
Summary: We have added a new InferenceLSTM layer in caffe2 that is compact and resembles PyTorch's LSTM implementation. Adding the export support to the new layer in PyText bilstm representation.

Differential Revision: D14795595
