### PR TITLE
Fixed 25 issues of type: PYTHON_F401 throughout 17 files in repo.

### DIFF
--- a/pytext/data/bptt_lm_data_handler.py
+++ b/pytext/data/bptt_lm_data_handler.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import itertools
 import math
 from typing import Any, Dict, Iterable, List
 

--- a/pytext/data/seq_data_handler.py
+++ b/pytext/data/seq_data_handler.py
@@ -4,7 +4,6 @@
 from typing import Any, Dict, List
 
 from pytext.common.constants import DatasetFieldName, DFColumn
-from pytext.config import ConfigBase
 from pytext.config.field_config import DocLabelConfig, FeatureConfig
 from pytext.data.featurizer import InputRecord
 from pytext.fields import DocLabelField, Field, RawField, SeqFeatureField

--- a/pytext/data/test/datahandler_test.py
+++ b/pytext/data/test/datahandler_test.py
@@ -7,7 +7,6 @@ from pytext.common.constants import DFColumn, VocabMeta
 from pytext.config.component import create_featurizer
 from pytext.config.doc_classification import ModelInput, ModelInputConfig, TargetConfig
 from pytext.config.field_config import FeatureConfig, WordFeatConfig
-from pytext.data.data_handler import DataHandler
 from pytext.data.doc_classification_data_handler import DocClassificationDataHandler
 from pytext.data.featurizer import SimpleFeaturizer
 from pytext.utils.test import import_tests_module

--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 import numpy as np
-from pytext.utils.ascii_table import ascii_table, ascii_table_from_dict
+from pytext.utils.ascii_table import ascii_table
 
 
 RECALL_AT_PRECISION_THREHOLDS = [0.2, 0.4, 0.6, 0.8, 0.9]

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -5,7 +5,6 @@ from typing import Dict, Union
 
 from pytext.config import ConfigBase
 from pytext.config.component import create_loss
-from pytext.config.field_config import WordFeatConfig
 from pytext.data.tensorizers import (
     LabelTensorizer,
     NumericLabelTensorizer,

--- a/pytext/models/representations/biseqcnn.py
+++ b/pytext/models/representations/biseqcnn.py
@@ -3,7 +3,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pytext.config import ConfigBase
 from pytext.config.module_config import CNNParams
 from pytext.utils import cuda
 

--- a/pytext/models/representations/contextual_intent_slot_rep.py
+++ b/pytext/models/representations/contextual_intent_slot_rep.py
@@ -4,7 +4,6 @@
 from typing import List, Tuple, Union
 
 import torch
-from pytext.config import ConfigBase
 from pytext.models.module import create_module
 
 from .bilstm_doc_slot_attention import BiLSTMDocSlotAttention

--- a/pytext/models/representations/docnn.py
+++ b/pytext/models/representations/docnn.py
@@ -4,7 +4,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pytext.config import ConfigBase
 from pytext.config.module_config import CNNParams
 
 from .representation_base import RepresentationBase

--- a/pytext/models/representations/jointcnn_rep.py
+++ b/pytext/models/representations/jointcnn_rep.py
@@ -4,7 +4,6 @@
 from typing import List
 
 import torch
-from pytext.config import ConfigBase
 
 from .biseqcnn import BSeqCNNRepresentation
 from .docnn import DocNNRepresentation

--- a/pytext/models/representations/pure_doc_attention.py
+++ b/pytext/models/representations/pure_doc_attention.py
@@ -4,7 +4,6 @@ from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
-from pytext.config import ConfigBase
 from pytext.models.decoders.mlp_decoder import MLPDecoder
 from pytext.models.module import create_module
 

--- a/pytext/models/representations/seq_rep.py
+++ b/pytext/models/representations/seq_rep.py
@@ -4,7 +4,6 @@
 from typing import Union
 
 import torch
-from pytext.config import ConfigBase
 from pytext.models.module import create_module
 
 from .bilstm_doc_attention import BiLSTMDocAttention

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -19,7 +19,6 @@ from pytext.metric_reporters.disjoint_multitask_metric_reporter import (
     DisjointMultitaskMetricReporter,
 )
 from pytext.models.disjoint_multitask_model import DisjointMultitaskModel
-from pytext.optimizer.scheduler import Scheduler
 from pytext.utils import cuda
 
 from . import Task, TaskBase

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from pprint import pprint
 from typing import List, Optional
 
 from pytext.common.constants import BatchContext
-from pytext.config import ConfigBase, config_to_json
+from pytext.config import ConfigBase
 from pytext.config.component import (
     Component,
     ComponentType,

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -37,7 +37,6 @@ from pytext.models.doc_model import DocModel
 from pytext.models.ensembles import BaggingDocEnsemble, BaggingIntentSlotEnsemble
 from pytext.models.joint_model import JointModel
 from pytext.models.language_models.lmlstm import LMLSTM
-from pytext.models.model import Model
 from pytext.models.pair_classification_model import PairClassificationModel
 from pytext.models.query_document_pairwise_ranking_model import (
     QueryDocumentPairwiseRankingModel,

--- a/pytext/utils/documentation.py
+++ b/pytext/utils/documentation.py
@@ -7,7 +7,6 @@ from sys import modules, stderr
 from typing import Union
 
 from pytext.config.component import Component, get_component_name
-from pytext.config.pytext_config import ConfigBase
 from pytext.models.module import Module
 
 


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        