### PR TITLE
multi forward/backward single step

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 from pytext.common.constants import Stage
 from pytext.config import ConfigBase, PyTextConfig
@@ -28,34 +28,39 @@ class NewTaskTrainer(Trainer):
     class Config(Trainer.Config):
         """Make mypy happy"""
 
-    @timing.time("train epoch")
-    def run_epoch(self, state: TrainingState, data, metric_reporter: MetricReporter):
-        """Our run_epoch is a bit different, because we're wrapping the model forward
-        call with model.train_batch, which arranges tensors and gets loss, etc."""
-        report_metric = state.stage != Stage.TRAIN or self.config.report_train_metrics
-        model = state.model
+    @timing.time("run_step")
+    def run_step(
+        self,
+        samples: List[Any],
+        state: TrainingState,
+        metric_reporter: MetricReporter,
+        report_metric: bool,
+    ):
+        assert len(samples) <= self.config.grads_update_freq
 
-        for batch_id, batch in enumerate(data):
-            self.zero_grads(state)
+        model = state.model
+        self.zero_grads(state)
+        for i, (batch_id, batch) in enumerate(samples):
+            # Whenever *samples* contains more than one mini-batch, we
+            # want to accumulate gradients locally and only call
+            # all-reduce in the last backwards pass.
+            if state.stage == Stage.TRAIN and cuda.DISTRIBUTED_WORLD_SIZE > 1:
+                # kick off all-reduction in the last sample
+                model.accumulate_grads = i != len(samples) - 1
+
             with timing.time("model.train_batch"):
                 loss, metric_data = model.train_batch(batch)
             self.backprop(state, loss)
+
             if report_metric:
                 with timing.time("add metrics"):
                     metric_reporter.add_batch_stats(
                         batch_id, *metric_data, **metric_reporter.batch_context(batch)
                     )
+            self.report_step(state, batch_id)
 
-        metrics = None
-        if report_metric:
-            with timing.time("report metrics"):
-                metrics = metric_reporter.report_metric(
-                    model, state.stage, state.epoch, print_to_channels=(state.rank == 0)
-                )
-        else:
-            metric_reporter._reset()
-
-        return metrics
+        # update gradients after len(samples) forward & backward
+        self.optimizer_step(state, len(samples))
 
     def _prepare_scheduler(self, training_batches, scheduler=None):
         """Batch based schedulers require knowing the number of batches in


### PR DESCRIPTION
Summary: For big model training, even 32G gpu memory could only fits batch_size=4, to take advantage of larger batch training, we want to accumulate gradients locally with multiple forward&backward before sync gradients (e.g all-reduce)

Differential Revision: D14947425

