### PR TITLE
Add eval results to trainer

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -98,6 +98,8 @@ class PyTextConfig(ConfigBase):
     use_tensorboard: bool = True
     #: Seed value to seed torch, python, and numpy random generators.
     random_seed: Optional[int] = None
+    # Run eval set after model has been trained - for hyperparameter search
+    report_eval_results: bool = False
     # config version
     version: int
 


### PR DESCRIPTION
Summary:
Hyperparameter sweeps are the biggest reason for having eval(dev) datasets
However, PyText's fblearner workflow only exports test results. So eval results cannot be used in choosing hyperparameters.

This diff adds support to (optionally) generate results from the eval dataset and export them - so they can be used in choosing hyperparameter

Differential Revision: D14976643

