### PR TITLE
Add error checking to dense features

### DIFF
--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -141,7 +141,7 @@ class TensorizersTest(unittest.TestCase):
             tensor = next(tensors)
 
     def test_create_float_list_tensor(self):
-        tensorizer = FloatListTensorizer(column="dense")
+        tensorizer = FloatListTensorizer(column="dense", dim=2, error_check=True)
         rows = [
             {"dense": "[0.1,0.2]"},  # comma
             {"dense": "[0.1, 0.2]"},  # comma with single space


### PR DESCRIPTION
Summary:
Dense Features in pytext require a dimension. This diff adds (optional) error checking that dimensions match actual data.

This will prevent silent 'failures' where the data has fewer (or more) dense features than what was expected in the config.

Differential Revision: D14991184

