### PR TITLE
ModelInputMeta compatible with Union

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -130,7 +130,7 @@ class NewDocModel(DocModel):
 
     @classmethod
     def create_embedding(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        return create_module(config, None, tensorizers["tokens"])
+        return create_module(config.embedding, tensorizer=tensorizers["tokens"])
 
     @classmethod
     def create_decoder(cls, config: Config, representation_dim: int, num_labels: int):
@@ -141,7 +141,7 @@ class NewDocModel(DocModel):
     @classmethod
     def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
         labels = tensorizers["labels"].labels
-        embedding = cls.create_embedding(config.embedding, tensorizers)
+        embedding = cls.create_embedding(config, tensorizers)
         representation = create_module(
             config.representation, embed_dim=embedding.embedding_dim
         )

--- a/pytext/models/embeddings/char_embedding.py
+++ b/pytext/models/embeddings/char_embedding.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from pytext.config.field_config import CharFeatConfig
+from pytext.data.utils import Vocabulary
 from pytext.fields import FieldMeta
 
 from .embedding_base import EmbeddingBase
@@ -42,7 +43,12 @@ class CharacterEmbedding(EmbeddingBase):
     Config = CharFeatConfig
 
     @classmethod
-    def from_config(cls, config: CharFeatConfig, metadata: FieldMeta):
+    def from_config(
+        cls,
+        config: CharFeatConfig,
+        metadata: Optional[FieldMeta] = None,
+        labels: Optional[Vocabulary] = None,
+    ):
         """Factory method to construct an instance of CharacterEmbedding from
         the module's config object and the field's metadata object.
 
@@ -55,8 +61,9 @@ class CharacterEmbedding(EmbeddingBase):
             type: An instance of CharacterEmbedding.
 
         """
+        vocab_size = len(labels) if labels is not None else metadata.vocab_size
         return cls(
-            metadata.vocab_size,
+            vocab_size,
             config.embed_dim,
             config.cnn.kernel_num,
             config.cnn.kernel_sizes,

--- a/pytext/models/embeddings/dict_embedding.py
+++ b/pytext/models/embeddings/dict_embedding.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import Optional
 
 import torch
 import torch.nn as nn
 import torch.onnx.operators
 from pytext.config.field_config import DictFeatConfig
 from pytext.config.module_config import PoolingType
+from pytext.data.utils import Vocabulary
 from pytext.fields import FieldMeta
 
 from .embedding_base import EmbeddingBase
@@ -46,7 +48,12 @@ class DictEmbedding(EmbeddingBase, nn.Embedding):
     Config = DictFeatConfig
 
     @classmethod
-    def from_config(cls, config: DictFeatConfig, metadata: FieldMeta):
+    def from_config(
+        cls,
+        config: DictFeatConfig,
+        metadata: Optional[FieldMeta] = None,
+        labels: Optional[Vocabulary] = None,
+    ):
         """Factory method to construct an instance of DictEmbedding from
         the module's config object and the field's metadata object.
 
@@ -59,7 +66,12 @@ class DictEmbedding(EmbeddingBase, nn.Embedding):
             type: An instance of DictEmbedding.
 
         """
-        return cls(metadata.vocab_size, config.embed_dim, config.pooling)
+        vocab_size = len(labels) if labels is not None else metadata.vocab_size
+        return cls(
+            num_embeddings=vocab_size,
+            embed_dim=config.embed_dim,
+            pooling_type=config.pooling,
+        )
 
     def __init__(
         self,

--- a/pytext/models/embeddings/embedding_base.py
+++ b/pytext/models/embeddings/embedding_base.py
@@ -19,6 +19,8 @@ class EmbeddingBase(Module):
 
     """
 
+    __EXPANSIBLE__ = True
+
     def __init__(self, embedding_dim: int):
         super().__init__()
         # By default has 1 embedding which is itself, for EmbeddingList, this num

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -39,7 +39,10 @@ class WordEmbedding(EmbeddingBase):
 
     @classmethod
     def from_config(
-        cls, config: WordFeatConfig, metadata: FieldMeta, tensorizer: Tensorizer = None
+        cls,
+        config: WordFeatConfig,
+        metadata: Optional[FieldMeta] = None,
+        tensorizer: Optional[Tensorizer] = None,
     ):
         """Factory method to construct an instance of WordEmbedding from
         the module's config object and the field's metadata object.
@@ -53,12 +56,7 @@ class WordEmbedding(EmbeddingBase):
             type: An instance of WordEmbedding.
 
         """
-        # Backward compatiblity until we do away with metadata
-        if metadata is not None:
-            num_embeddings = metadata.vocab_size
-            embeddings_weight = metadata.pretrained_embeds_weight
-            unk_token_idx = metadata.unk_token_idx
-        elif tensorizer is not None:
+        if tensorizer is not None:
             embeddings_weight = None
             if config.pretrained_embeddings_path:
                 pretrained_embedding = PretrainedEmbedding(
@@ -79,10 +77,9 @@ class WordEmbedding(EmbeddingBase):
             num_embeddings = len(tensorizer.vocab)
             unk_token_idx = tensorizer.vocab.idx[UNK]
         else:  # This else condition should go away after metadata goes away.
-            raise ValueError(
-                "metadata and tensorizer objects both are None. "
-                "WordEmbedding cannot be initalized."
-            )
+            num_embeddings = metadata.vocab_size
+            embeddings_weight = metadata.pretrained_embeds_weight
+            unk_token_idx = metadata.unk_token_idx
 
         return cls(
             num_embeddings=num_embeddings,

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -91,7 +91,7 @@ class BaseModel(nn.Module, Component):
     def save_modules(self, base_path: str = "", suffix: str = ""):
         """Save each sub-module in separate files for reusing later."""
         for module in self.module_list:
-            if getattr(module.config, "save_path", None):
+            if module and getattr(module.config, "save_path", None):
                 path = module.config.save_path + suffix
                 if base_path:
                     path = os.path.join(base_path, path)

--- a/pytext/models/output_layers/doc_classification_output_layer.py
+++ b/pytext/models/output_layers/doc_classification_output_layer.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import torch
 import torch.nn.functional as F
 from caffe2.python import core
 from pytext.config.component import create_loss
+from pytext.data.utils import Vocabulary
 from pytext.fields import FieldMeta
 from pytext.loss import (
     AUCPRHingeLoss,
@@ -47,11 +48,16 @@ class ClassificationOutputLayer(OutputLayerBase):
         ] = CrossEntropyLoss.Config()
 
     @classmethod
-    def from_config(cls, config: Config, metadata: FieldMeta = None, labels=None):
+    def from_config(
+        cls,
+        config: Config,
+        metadata: Optional[FieldMeta] = None,
+        labels: Optional[Vocabulary] = None,
+    ):
         label_weights = getattr(metadata, "label_weights", None)
         if label_weights is not None:
             label_weights = FloatTensor(label_weights)
-        vocab = metadata.vocab.itos if metadata else labels
+        vocab = list(labels) if labels is not None else metadata.vocab.itos
         loss = create_loss(config.loss, weight=label_weights)
         cls = (
             BinaryClassificationOutputLayer

--- a/pytext/models/word_model.py
+++ b/pytext/models/word_model.py
@@ -90,8 +90,7 @@ class NewWordTaggingModel(Model):
             in_dim=representation.representation_dim,
             out_dim=len(labels),
         )
-        # TODO after migration: create_module(config.output_layer, tensorizers=tensorizers)
-        output_layer = WordTaggingOutputLayer(labels, CrossEntropyLoss(None))
+        output_layer = create_module(config.output_layer, labels=labels)
         return cls(embedding, representation, decoder, output_layer)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Summary:
ModelInput should be composed of Tensorizers only. ModelInputMeta is
a metaclass ensuring this is always the case. However, the current
implementation breaks with Unions, which is a problem mainly when specifying
Optional[Tensorizer] (actually Union[Tensorizer, NoneType]). This diff fixes
this.

Differential Revision: D15019753

