### PR TITLE
Deprecate DocModel

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -21,6 +21,14 @@ def register_adapter(from_version):
     return decorator
 
 
+def find_dicts_containing_key(json_config, key):
+    if key in json_config:
+        yield json_config
+    for _, v in json_config.items():
+        if isinstance(v, dict):
+            yield from find_dicts_containing_key(v, key)
+
+
 @register_adapter(from_version=0)
 def v0_to_v1(json_config):
     # migrate optimizer and random_seed params
@@ -170,6 +178,17 @@ def v3_to_v4(json_config):
                 section.pop(old_key)
 
     json_config["version"] = 4
+    return json_config
+
+
+@register_adapter(from_version=4)
+def doc_model_deprecated(json_config):
+    """
+    Rename DocModel to DocModel_Deprecated
+    """
+    for section in find_dicts_containing_key(json_config, "DocModel"):
+        section["DocModel_Deprecated"] = section.pop("DocModel")
+
     return json_config
 
 

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -126,4 +126,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 4
+LATEST_VERSION = 5

--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -130,9 +130,15 @@ def config_from_json(cls, json_obj, ignore_fields=()):
     parsed_dict = {}
     if not hasattr(cls, "_fields"):
         raise IncorrectTypeError(f"{cls} is not a valid config class")
-    unknown_fields = set(json_obj) - {f[0] for f in cls.__annotations__.items()}
+    cls_name = getattr(cls, "__name__", cls)
+    # Non-EXPANSIBLE classes can be found in configs
+    cls_name_wo_config = cls_name.split(".")[0]
+    unknown_fields = (
+        set(json_obj)
+        - {f[0] for f in cls.__annotations__.items()}
+        - {cls_name_wo_config}
+    )
     if unknown_fields:
-        cls_name = getattr(cls, "__name__", cls)
         cls_fields = {f[0] for f in cls.__annotations__.items()}
         raise ConfigParseError(
             f"Unknown fields for class {cls_name} with fields {cls_fields} \
@@ -158,7 +164,6 @@ def config_from_json(cls, json_obj, ignore_fields=()):
                 ) from e
         # validate value
         if value is None and not is_optional:
-            cls_name = getattr(cls, "__name__", cls)
             raise MissingValueError(
                 f"missing value for {field} in class {cls_name} with json {json_obj}"
             )

--- a/pytext/config/test/json_config/v5.json
+++ b/pytext/config/test/json_config/v5.json
@@ -1,0 +1,42 @@
+[
+  {
+    "original": {
+      "task": {
+        "DocClassificationTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          },
+          "model": {
+            "DocModel": {
+              "representation": {
+                "DocNNRepresentation": {}
+              }
+            }
+          }
+        }
+      },
+      "version": 4
+    },
+    "adapted": {
+      "task": {
+        "DocClassificationTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          },
+          "model": {
+            "DocModel_Deprecated": {
+              "representation": {
+                "DocNNRepresentation": {}
+              }
+            }
+          }
+        }
+      },
+      "version": 5
+    }
+  }
+]

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -32,7 +32,7 @@ from pytext.utils.torch import Vocabulary, list_max
 from torch import jit
 
 
-class DocModel(Model):
+class DocModel_Deprecated(Model):
     """
     An n-ary document classification model. It can be used for all text
     classification scenarios. It supports :class:`~PureDocAttention`,
@@ -41,6 +41,8 @@ class DocModel(Model):
     for projecting the document representation into label/target space.
 
     It can be instantiated just like any other :class:`~Model`.
+
+    DEPRECATED: Use NewDocModel instead
     """
 
     class Config(ConfigBase):
@@ -55,13 +57,13 @@ class DocModel(Model):
         )
 
 
-class NewDocModel(DocModel):
+class NewDocModel(DocModel_Deprecated):
     """DocModel that's compatible with the new Model abstraction, which is responsible
     for describing which inputs it expects and arranging its input tensors."""
 
     __EXPANSIBLE__ = True
 
-    class Config(DocModel.Config):
+    class Config(DocModel_Deprecated.Config):
         class ModelInput(Model.Config.ModelInput):
             tokens: TokenTensorizer.Config = TokenTensorizer.Config()
             labels: LabelTensorizer.Config = LabelTensorizer.Config(allow_unknown=True)

--- a/pytext/models/ensembles/bagging_doc_ensemble.py
+++ b/pytext/models/ensembles/bagging_doc_ensemble.py
@@ -3,7 +3,7 @@
 from typing import List
 
 import torch
-from pytext.models.doc_model import DocModel
+from pytext.models.doc_model import DocModel_Deprecated as DocModel
 
 from .ensemble import Ensemble
 

--- a/pytext/models/test/module_test.py
+++ b/pytext/models/test/module_test.py
@@ -7,7 +7,7 @@ from pytext.config.component import create_model
 from pytext.config.field_config import DictFeatConfig, FeatureConfig, WordFeatConfig
 from pytext.data import CommonMetadata
 from pytext.fields import FieldMeta
-from pytext.models.doc_model import DocModel
+from pytext.models.doc_model import DocModel_Deprecated as DocModel
 
 
 class VocabStub:

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -33,7 +33,7 @@ from pytext.metric_reporters import (
     SimpleWordTaggingMetricReporter,
     WordTaggingMetricReporter,
 )
-from pytext.models.doc_model import DocModel
+from pytext.models.doc_model import DocModel_Deprecated as DocModel
 from pytext.models.ensembles import BaggingDocEnsemble, BaggingIntentSlotEnsemble
 from pytext.models.joint_model import JointModel
 from pytext.models.language_models.lmlstm import LMLSTM

--- a/tests/module_load_save_test.py
+++ b/tests/module_load_save_test.py
@@ -12,7 +12,7 @@ from pytext.config.field_config import FeatureConfig
 from pytext.data import CommonMetadata
 from pytext.fields import FieldMeta
 from pytext.models.decoders.mlp_decoder import MLPDecoder
-from pytext.models.doc_model import DocModel
+from pytext.models.doc_model import DocModel_Deprecated as DocModel
 from pytext.models.representations.bilstm_doc_attention import BiLSTMDocAttention
 
 


### PR DESCRIPTION
Summary:
Deprecate DocModel in preparation of the introduction of the new
BaseClassificationModel. This is simply renaming DocModel to
DocModel_Deprecated to be able to reuse the class name DocModel.

Differential Revision: D15019759

