### PR TITLE
Better dense feature parsing

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -332,7 +332,14 @@ class FloatListTensorizer(Tensorizer):
         assert not self.error_check or self.dim is not None, "Error check requires dim"
 
     def numberize(self, row):
-        res = json.loads(re.sub(r",? +", ",", row[self.column]))
+        try:
+            # strip spaces after [
+            stripped = re.sub(r"\[ +", "[", row[self.column])
+            # strip spaces before ]
+            stripped = re.sub(r" +\]", "]", stripped)
+            res = json.loads(re.sub(r",? +", ",", stripped))
+        except json.decoder.JSONDecodeError as e:
+            raise Exception("Unable to parse dense feature:" + str(row.column)) from e
         if type(res) is not list:
             raise ValueError(f"{res} is not a valid float list")
         if self.error_check:

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -148,6 +148,8 @@ class TensorizersTest(unittest.TestCase):
             {"dense": "[0.1,  0.2]"},  # comma with multiple spaces
             {"dense": "[0.1 0.2]"},  # space
             {"dense": "[0.1  0.2]"},  # multiple spaces
+            {"dense": "[ 0.1  0.2]"},  # space after [
+            {"dense": "[0.1  0.2 ]"},  # space before ]
         ]
 
         tensors = (tensorizer.numberize(row) for row in rows)


### PR DESCRIPTION
Summary:
New dense feature parsing is not robust to spaces after '[' and spaces before ']'
Existing dense feature parsing was robust to extra spaces, so existing training data has extra spaces that break in the new model.

Differential Revision: D15022396

