### PR TITLE
Multitask in new data design

### DIFF
--- a/pytext/builtin_task.py
+++ b/pytext/builtin_task.py
@@ -7,7 +7,7 @@ import inspect
 import os
 
 from pytext.config.component import register_tasks
-from pytext.task.disjoint_multitask import DisjointMultitask
+from pytext.task.disjoint_multitask import DisjointMultitask, NewDisjointMultitask
 from pytext.task.new_task import NewTask
 from pytext.task.task import Task
 from pytext.task.tasks import (
@@ -67,5 +67,6 @@ def register_builtin_tasks():
             ContextualIntentSlotTask,
             SemanticParsingTask,
             DisjointMultitask,
+            NewDisjointMultitask,
         )
     )

--- a/pytext/data/__init__.py
+++ b/pytext/data/__init__.py
@@ -4,7 +4,7 @@
 from .batch_sampler import (
     BaseBatchSampler,
     EvalBatchSampler,
-    ProbabalisticBatchSampler,
+    RandomizedBatchSampler,
     RoundRobinBatchSampler,
 )
 from .bptt_lm_data_handler import BPTTLanguageModelDataHandler
@@ -12,6 +12,7 @@ from .compositional_data_handler import CompositionalDataHandler
 from .contextual_intent_slot_data_handler import ContextualIntentSlotModelDataHandler
 from .data import Batcher, Data, PoolingBatcher, generator_iterator
 from .data_handler import BatchIterator, CommonMetadata, DataHandler
+from .disjoint_multitask_data import DisjointMultitaskData
 from .disjoint_multitask_data_handler import DisjointMultitaskDataHandler
 from .doc_classification_data_handler import DocClassificationDataHandler, RawData
 from .joint_data_handler import JointModelDataHandler
@@ -33,6 +34,7 @@ __all__ = [
     "ContextualIntentSlotModelDataHandler",
     "Data",
     "DataHandler",
+    "DisjointMultitaskData",
     "DisjointMultitaskDataHandler",
     "DocClassificationDataHandler",
     "EvalBatchSampler",
@@ -41,7 +43,7 @@ __all__ = [
     "LanguageModelDataHandler",
     "PairClassificationDataHandler",
     "PoolingBatcher",
-    "ProbabalisticBatchSampler",
+    "RandomizedBatchSampler",
     "QueryDocumentPairwiseRankingDataHandler",
     "RawData",
     "RoundRobinBatchSampler",

--- a/pytext/data/disjoint_multitask_data.py
+++ b/pytext/data/disjoint_multitask_data.py
@@ -3,7 +3,7 @@
 from typing import Dict
 
 from pytext.common.constants import BatchContext, Stage
-from pytext.config.component import create_component
+from pytext.config.component import Component, ComponentType, create_component
 from pytext.data import BaseBatchSampler, Data, EvalBatchSampler, generator_iterator
 
 
@@ -24,14 +24,16 @@ class DisjointMultitaskData(Data):
 
     """
 
-    class Config(Data.Config):
+    class Config(Component.Config):
         sampler: BaseBatchSampler.Config = EvalBatchSampler.Config()
 
-    def __init__(
-        self, config: Config, data_dict: Dict[str, Data], *args, **kwargs
-    ) -> None:
+    def __init__(self, config: Config, data_dict: Dict[str, Data]) -> None:
         self.data_dict = data_dict
-        self.sampler_config = config.sampler
+        self.samplers = {
+            Stage.TRAIN: create_component(ComponentType.BATCH_SAMPLER, config.sampler),
+            Stage.EVAL: EvalBatchSampler(),
+            Stage.TEST: EvalBatchSampler(),
+        }
 
     @generator_iterator
     def batches(self, stage: Stage, rank=0, world_size=1, data_source=None):
@@ -39,11 +41,6 @@ class DisjointMultitaskData(Data):
             name: task.batches(stage, rank, world_size)
             for name, task in self.data_dict.items()
         }
-        if stage == Stage.TRAIN:
-            sampler = create_component(self.sampler_config, iterators=all_batches)
-        else:
-            sampler = EvalBatchSampler(all_batches)
-
-        for name, batch in sampler.batchify(all_batches):
+        for name, batch in self.samplers[stage].batchify(all_batches):
             batch[BatchContext.TASK_NAME] = name
             yield batch

--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -47,6 +47,12 @@ class DisjointMultitaskMetricReporter(MetricReporter):
         self.total_loss = 0
         self.num_batches = 0
 
+    def batch_context(self, batch):
+        context = {BatchContext.TASK_NAME: batch[BatchContext.TASK_NAME]}
+        for reporter in self.reporters.values():
+            context.update(reporter.batch_context(batch))
+        return context
+
     def add_batch_stats(
         self, n_batches, preds, targets, scores, loss, m_input, **context
     ):

--- a/pytext/models/disjoint_multitask_model.py
+++ b/pytext/models/disjoint_multitask_model.py
@@ -45,7 +45,7 @@ class DisjointMultitaskModel(Model):
             logits, targets, context
         )
 
-    def get_pred(self, logits, targets, context, *args):
+    def get_pred(self, logits, targets=None, context=None, *args):
         return self.current_model.get_pred(logits, targets, context, *args)
 
     def forward(self, *inputs) -> List[torch.Tensor]:
@@ -54,3 +54,15 @@ class DisjointMultitaskModel(Model):
     def save_modules(self, base_path, suffix=""):
         for name, model in self.models.items():
             model.save_modules(base_path, f"-{name}{suffix}")
+
+
+class NewDisjointMultitaskModel(DisjointMultitaskModel):
+    def arrange_model_inputs(self, tensor_dict):
+        self.contextualize(tensor_dict)
+        return self.current_model.arrange_model_inputs(tensor_dict)
+
+    def arrange_targets(self, tensor_dict):
+        return self.current_model.arrange_targets(tensor_dict)
+
+    def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
+        pass

--- a/pytext/task/__init__.py
+++ b/pytext/task/__init__.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from .new_task import NewDocumentClassification, NewTask
+from .new_task import NewDocumentClassification, NewTask, _NewTask
 from .serialize import load, save
 from .task import Task, TaskBase, create_task
 
 
 __all__ = [
+    "_NewTask",
     "NewTask",
     "NewDocumentClassification",
     "Task",

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -66,7 +66,7 @@ class NewTaskTrainer(Trainer):
         return scheduler
 
 
-class NewTask(TaskBase):
+class _NewTask(TaskBase):
     """This task abstraction separates the concerns into three main components,
     `pytext.data.Data`, `pytext.models.new_model.NewModel` (names and paths
     will change as these become the primary abstractions), and `pytext.trainers.Trainer`
@@ -93,11 +93,8 @@ class NewTask(TaskBase):
     running `loss.backward()` and `optimizer.step()`, and managing the scheduler.
     """
 
-    __EXPANSIBLE__ = True
-
     class Config(ConfigBase):
         data: Data.Config = Data.Config()
-        model: Model.Config
         trainer: NewTaskTrainer.Config = NewTaskTrainer.Config()
 
     @classmethod
@@ -217,6 +214,13 @@ class NewTask(TaskBase):
         inputs = model.arrange_model_inputs(batch)
         trace = jit.trace(model, inputs)
         trace.save(export_path)
+
+
+class NewTask(_NewTask):
+    __EXPANSIBLE__ = True
+
+    class Config(_NewTask.Config):
+        model: Model.Config
 
 
 class NewDocumentClassification(NewTask):


### PR DESCRIPTION
Summary:
Migrate multitask to the new data design. Specifically, this involves creating a `NewDisjointMultitask` and `NewDisjointMultitaskModel`, and making sure the task context is set in each batch for the model and metric reporter.

Also update `ProbabilisticBatchSampler` to persist data iterators across epochs, so data reading won't restart from the beginning of a file in a new epoch.

Have not added exporting or multi-gpu training for this task yet.

Differential Revision: D14992525

