### PR TITLE
Fix DDP unused params

### DIFF
--- a/pytext/models/__init__.py
+++ b/pytext/models/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from .model import Model
+from .model import BaseModel, Model
 
 
-__all__ = ["Model"]
+__all__ = ["Model", "BaseModel"]

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -62,6 +62,7 @@ class BaseModel(nn.Module, Component):
         nn.Module.__init__(self)
         self.stage = stage
         self.module_list: List[nn.Module] = []
+        self.find_unused_parameters = True
 
     def train(self, mode=True):
         """Override to explicitly maintain the stage (train, eval, test)."""

--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -11,9 +11,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 from pytext.common.constants import Stage
 from pytext.config import ConfigBase
-from pytext.config.component import Component, ComponentType
+from pytext.config.component import ComponentType
 from pytext.data import CommonMetadata
-from pytext.models import Model
+from pytext.models import BaseModel, Model
 from pytext.models.embeddings import EmbeddingList
 from pytext.models.representations.bilstm import BiLSTM
 from pytext.models.semantic_parsers.rnng.rnng_data_structures import (
@@ -25,7 +25,7 @@ from pytext.models.semantic_parsers.rnng.rnng_data_structures import (
 )
 
 
-class RNNGParser(Model, Component):
+class RNNGParser(BaseModel):
     """
     The Recurrent Neural Network Grammar (RNNG) parser from
     Dyer et al.: https://arxiv.org/abs/1602.07776 and
@@ -202,7 +202,7 @@ class RNNGParser(Model, Component):
 
         """
 
-        nn.Module.__init__(self)
+        super().__init__()
 
         self.embedding = embedding
         # self.embedding.config: FeatureConfig object cannot be pickled but,


### PR DESCRIPTION
Summary:
1 DDP assumes all used params are in model.forward, however in CRF model, there's params used outside of forward, which will casue issue. This diff fixed this by setting find_unused_parameters to False

2 DDP can detect unused params now, so removing the previous hack in PyText

Differential Revision: D15027698

