### PR TITLE
fix bytes lstm test

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -45,8 +45,8 @@ class Batcher(Component):
         self.test_batch_size = test_batch_size
         self._batch_sizes = {
             Stage.TRAIN: self.train_batch_size,
-            Stage.TEST: self.eval_batch_size,
-            Stage.EVAL: self.test_batch_size,
+            Stage.TEST: self.test_batch_size,
+            Stage.EVAL: self.eval_batch_size,
         }
 
     def batchify(


### PR DESCRIPTION
Summary: The new InferenceLSTM doesn't owner padding, so set the test batch_size to 1

Differential Revision: D15022747

