### PR TITLE
Upgrade PyText config to v4

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -153,6 +153,26 @@ def v2_to_v3(json_config):
     return json_config
 
 
+@register_adapter(from_version=3)
+def v3_to_v4(json_config):
+    """Key for provding the path for contextual token embedding has changed from
+    `pretrained_model_embedding` to `contextual_token_embedding. This affects the
+    `features` section of the config.
+    """
+    [task] = json_config["task"].values()
+    old_key = "pretrained_model_embedding"
+    new_key = "contextual_token_embedding"
+    for section_str in ["features", "labels"]:
+        if section_str in task:
+            section = task[section_str]
+            if old_key in section:
+                section[new_key] = section[old_key]
+                section.pop(old_key)
+
+    json_config["version"] = 4
+    return json_config
+
+
 def upgrade_one_version(json_config):
     current_version = json_config.get("version", 0)
     adapter = ADAPTERS.get(current_version)

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -124,4 +124,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 3
+LATEST_VERSION = 4

--- a/pytext/config/test/json_config/v4.json
+++ b/pytext/config/test/json_config/v4.json
@@ -1,0 +1,34 @@
+[
+  {
+    "original": {
+      "task": {
+        "DocClassificationTask": {
+          "features": {
+            "pretrained_model_embedding": {
+              "model_paths": {
+                "en_XX": "/mnt/vol/pytext/nlu/tests/nets/dummy_elmo_net.predictor"
+              },
+              "embed_dim": 128
+            }
+          }
+        }
+      },
+      "version": 3
+    },
+    "adapted": {
+      "task": {
+        "DocClassificationTask": {
+          "features": {
+            "contextual_token_embedding": {
+              "model_paths": {
+                "en_XX": "/mnt/vol/pytext/nlu/tests/nets/dummy_elmo_net.predictor"
+              },
+              "embed_dim": 128
+            }
+          }
+        }
+      },
+      "version": 4
+    }
+  }
+]


### PR DESCRIPTION
Summary: Key for provding the path for contextual token embedding has changed from `pretrained_model_embedding` to `contextual_token_embedding. This affects the `features` section of the config.

Differential Revision: D15036115

