### PR TITLE
TorchScript export for document classification

### DIFF
--- a/demo/configs/new_docnn.json
+++ b/demo/configs/new_docnn.json
@@ -19,5 +19,6 @@
         }
       }
     }
-  }
+  },
+  "export_torchscript_path": "/tmp/new_docnn.pt1"
 }

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -87,9 +87,11 @@ class PyTextConfig(ConfigBase):
     # Where to save the trained pytorch model
     save_snapshot_path: str = "/tmp/model.pt"
     # Exported caffe model will be stored here
-    export_caffe2_path: str = "/tmp/model.caffe2.predictor"
+    export_caffe2_path: Optional[str] = "/tmp/model.caffe2.predictor"
     # Exported onnx model will be stored here
     export_onnx_path: str = "/tmp/model.onnx"
+    # Exported torchscript model will be stored here
+    export_torchscript_path: Optional[str] = None
     # Base directory where modules are saved
     modules_save_dir: str = ""
     # Whether to save intermediate checkpoints for modules
@@ -113,7 +115,7 @@ class TestConfig(ConfigBase):
     # Snapshot of a trained model to test
     load_snapshot_path: str
     # Test data path
-    test_path: str = "test.tsv"
+    test_path: Optional[str] = "test.tsv"
     #: Field names for the TSV. If this is not set, the first line of each file
     #: will be assumed to be a header containing the field names.
     field_names: Optional[List[str]] = None

--- a/pytext/models/test/module_test.py
+++ b/pytext/models/test/module_test.py
@@ -40,7 +40,7 @@ class ModuleTest(unittest.TestCase):
         # word embedding
         for param in model.embedding[0].word_embedding.parameters():
             self.assertFalse(param.requires_grad)
-        for param in model.embedding[0].mlp_layers.parameters():
+        for param in model.embedding[0].mlp.parameters():
             self.assertTrue(param.requires_grad)
 
         # dict feat embedding

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -213,6 +213,9 @@ class _NewTask(TaskBase):
         batch = next(iter(self.data.batches(Stage.TEST)))
         inputs = model.arrange_model_inputs(batch)
         trace = jit.trace(model, inputs)
+        if hasattr(model, "torchscriptify"):
+            trace = model.torchscriptify(self.data.tensorizers, trace)
+        print(f"Saving torchscript model to: {export_path}")
         trace.save(export_path)
 
 

--- a/pytext/utils/tests/torch_test.py
+++ b/pytext/utils/tests/torch_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import unittest
+
+from pytext.utils.torch import Vocabulary
+from torch import jit
+
+
+class VocabTest(unittest.TestCase):
+    def setUp(self):
+        vocab_list = ["UNK", "a", "b", "c", "d"]
+        self.vocab = Vocabulary(vocab_list)
+
+    def test_vocab_lookup(self):
+        # There are bugs with just making this a script, eventually these can be simpler
+        class LookupWord(jit.ScriptModule):
+            def __init__(self, vocab):
+                super().__init__()
+                self.vocab = vocab
+
+            @jit.script_method
+            def forward(self, word: str):
+                return self.vocab.idx[word]
+
+        lookup_word = LookupWord(self.vocab)
+
+        self.assertEqual(1, lookup_word("a"))
+        self.assertEqual(3, lookup_word("c"))
+        with self.assertRaises(Exception):
+            lookup_word("notaword")
+
+    def test_vocab_idx_lookup(self):
+        # There are bugs with just making this a script, eventually these can be simpler
+        class LookupIndex(jit.ScriptModule):
+            def __init__(self, vocab):
+                super().__init__()
+                self.vocab = vocab
+
+            @jit.script_method
+            def forward(self, i: int):
+                return self.vocab.vocab[i]
+
+        lookup_idx = LookupIndex(self.vocab)
+
+        self.assertEqual("UNK", lookup_idx(0))
+        self.assertEqual("b", lookup_idx(2))
+        with self.assertRaises(Exception):
+            lookup_idx(20)
+
+    def test_lookup_1d(self):
+        self.assertEqual(
+            [1, 0, 3, 4], self.vocab.lookup_indices_1d(["a", "e", "c", "d"])
+        )
+        self.assertEqual([], self.vocab.lookup_indices_1d([]))
+
+    def test_lookup_2d(self):
+        self.assertEqual(
+            [[1, 0, 3, 4], [], [2]],
+            self.vocab.lookup_indices_2d([["a", "e", "c", "d"], [], ["b"]]),
+        )
+        self.assertEqual([], self.vocab.lookup_indices_2d([]))
+
+    def test_custom_unk(self):
+        vocab_list = ["a", "UNK", "b", "c", "d"]
+        vocab = Vocabulary(vocab_list, unk_idx=1)
+        self.assertEqual([0, 1, 3, 4], vocab.lookup_indices_1d(["a", "e", "c", "d"]))

--- a/pytext/utils/torch.py
+++ b/pytext/utils/torch.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Dict, List
+
+from torch import jit
+
+
+@jit.script
+def list_max(l: List[int]):
+    max_value = l[0]  # fine to throw if empty
+    for i in range(len(l) - 1):  # don't forget the +1
+        max_value = max(max_value, l[i + 1])
+    return max_value
+
+
+class Vocabulary(jit.ScriptModule):
+    def __init__(self, vocab_list, unk_idx: int = 0):
+        super().__init__()
+        self.vocab = jit.Attribute(vocab_list, List[str])
+        self.unk_idx = jit.Attribute(unk_idx, int)
+        self.idx = jit.Attribute(
+            {word: i for i, word in enumerate(vocab_list)}, Dict[str, int]
+        )
+
+    @jit.script_method
+    def lookup_indices_1d(self, values: List[str]) -> List[int]:
+        result = jit.annotate(List[int], [])
+        for value in values:
+            result.append(self.idx.get(value, self.unk_idx))
+        return result
+
+    @jit.script_method
+    def lookup_indices_2d(self, values: List[List[str]]) -> List[List[int]]:
+        result = jit.annotate(List[List[int]], [])
+        for value in values:
+            result.append(self.lookup_indices_1d(value))
+        return result

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -128,9 +128,15 @@ def save_and_export(
     if hasattr(task, "data_handler"):
         meta = task.data_handler.metadata_to_save()
     save(config, task.model, meta)
-    task.export(
-        task.model, config.export_caffe2_path, metric_channels, config.export_onnx_path
-    )
+    if config.export_caffe2_path:
+        task.export(
+            task.model,
+            config.export_caffe2_path,
+            metric_channels,
+            config.export_onnx_path,
+        )
+    if config.export_torchscript_path:
+        task.torchscript_export(task.model, config.export_torchscript_path)
 
 
 def export_saved_model_to_caffe2(


### PR DESCRIPTION
Summary:
Full torchscript export for doc classification.

For now we are not going the route of including the vocab lookup, etc. as part of the model at train time. There's some convenience aspects here, for instance not having to worry about getting logits out of the model at train time and predictions at inference time, but mainly it's a consequence of List/str not being supported by torch tracing. Since we can't trace them and we need them as the inputs to the primary forward function for the model, we're locked in to ScriptModules for every single module in the model graph, which isn't feasible (we don't even control all of the implementations, even if it was already possible to implement everything we want in Script, which it definitely isn't).

As such, we train the model as normal, trace it via jit.trace, and then inject it into a ScriptModule wrapper which implements the vocab lookup and predictions. This module is then saved and exported.

This ends up looking a lot like ONNX/caffe2 wrapping, but thankfully less painful.

Differential Revision: D14966825

