### PR TITLE
eval data should not take the shard

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -174,7 +174,7 @@ class _NewTask(TaskBase):
 
         return self.trainer.train(
             self.data.batches(Stage.TRAIN, rank, world_size),
-            self.data.batches(Stage.EVAL, rank, world_size),
+            self.data.batches(Stage.EVAL),
             self.model,
             self.metric_reporter,
             config,


### PR DESCRIPTION
Summary: We rely on rank0 to calcualte the eval metric, so eval data should not take the shard

Differential Revision: D15083642

