### PR TITLE
BaseClassificationModel

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -405,6 +405,10 @@ class FloatListTensorizer(Tensorizer):
         return pad_and_tensorize(batch, dtype=torch.float)
 
 
+class DictTensorizer(Tensorizer):
+    """TODO"""
+
+
 NO_LABEL = SpecialToken("NO_LABEL")
 
 

--- a/pytext/exporters/exporter.py
+++ b/pytext/exporters/exporter.py
@@ -175,7 +175,8 @@ class ModelExporter(Component):
         """
         c2_prepared = onnx.pytorch_to_caffe2(
             model,
-            self.dummy_model_input,
+            # self.dummy_model_input,
+            tuple(i for i in self.dummy_model_input if i is not None),
             self.input_names,
             self.output_names,
             export_path,

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -1,25 +1,13 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import Dict, List, Union
+from typing import Union
 
 import torch
 from pytext.config import ConfigBase
-from pytext.config.component import create_loss
-from pytext.data.tensorizers import (
-    LabelTensorizer,
-    NumericLabelTensorizer,
-    RawString,
-    Tensorizer,
-    TokenTensorizer,
-)
-from pytext.data.utils import PAD, UNK
-from pytext.exporters.exporter import ModelExporter
-from pytext.loss import BinaryCrossEntropyLoss
+from pytext.data.tensorizers import NumericLabelTensorizer
 from pytext.models.decoders.mlp_decoder import MLPDecoder
-from pytext.models.embeddings import WordEmbedding
-from pytext.models.model import Model
-from pytext.models.module import create_module
+from pytext.models.model import Model, SimpleTokenModel
 from pytext.models.output_layers import ClassificationOutputLayer, RegressionOutputLayer
 from pytext.models.output_layers.doc_classification_output_layer import (
     BinaryClassificationOutputLayer,
@@ -28,8 +16,6 @@ from pytext.models.output_layers.doc_classification_output_layer import (
 from pytext.models.representations.bilstm_doc_attention import BiLSTMDocAttention
 from pytext.models.representations.docnn import DocNNRepresentation
 from pytext.models.representations.pure_doc_attention import PureDocAttention
-from pytext.utils.torch import Vocabulary, list_max
-from torch import jit
 
 
 class DocModel_Deprecated(Model):
@@ -57,108 +43,27 @@ class DocModel_Deprecated(Model):
         )
 
 
-class NewDocModel(DocModel_Deprecated):
-    """DocModel that's compatible with the new Model abstraction, which is responsible
-    for describing which inputs it expects and arranging its input tensors."""
+class NewDocModel(SimpleTokenModel):
+    """
+    An n-ary document classification model. It can be used for all text
+    classification scenarios. It supports :class:`~PureDocAttention`,
+    :class:`~BiLSTMDocAttention` and :class:`~DocNNRepresentation` as the ways
+    to represent the document followed by multi-layer perceptron (:class:`~MLPDecoder`)
+    for projecting the document representation into label/target space.
 
-    __EXPANSIBLE__ = True
+    It can be instantiated just like any other :class:`~Model`.
+    """
 
-    class Config(DocModel_Deprecated.Config):
-        class ModelInput(Model.Config.ModelInput):
-            tokens: TokenTensorizer.Config = TokenTensorizer.Config()
-            labels: LabelTensorizer.Config = LabelTensorizer.Config(allow_unknown=True)
-            # for metric reporter
-            raw_text: RawString.Config = RawString.Config(column="text")
-
-        inputs: ModelInput = ModelInput()
-        embedding: WordEmbedding.Config = WordEmbedding.Config()
-
-    def arrange_model_inputs(self, tensor_dict):
-        tokens, seq_lens = tensor_dict["tokens"]
-        return (tokens, seq_lens)
-
-    def arrange_targets(self, tensor_dict):
-        return tensor_dict["labels"]
-
-    def get_export_input_names(self, tensorizers):
-        return ["tokens", "tokens_lens"]
-
-    def get_export_output_names(self, tensorizers):
-        return ["scores"]
-
-    def vocab_to_export(self, tensorizers):
-        return {"tokens": list(tensorizers["tokens"].vocab)}
-
-    def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
-        exporter = ModelExporter(
-            ModelExporter.Config(),
-            self.get_export_input_names(tensorizers),
-            self.arrange_model_inputs(tensor_dict),
-            self.vocab_to_export(tensorizers),
-            self.get_export_output_names(tensorizers),
+    class Config(SimpleTokenModel.Config):
+        representation: Union[
+            PureDocAttention.Config,
+            BiLSTMDocAttention.Config,
+            DocNNRepresentation.Config,
+        ] = BiLSTMDocAttention.Config()
+        decoder: MLPDecoder.Config = MLPDecoder.Config()
+        output_layer: ClassificationOutputLayer.Config = (
+            ClassificationOutputLayer.Config()
         )
-        return exporter.export_to_caffe2(self, path, export_onnx_path=export_onnx_path)
-
-    def torchscriptify(self, tensorizers, traced_model):
-        output_layer = self.output_layer.torchscript_predictions()
-
-        input_vocab = tensorizers["tokens"].vocab
-
-        class Model(jit.ScriptModule):
-            def __init__(self):
-                super().__init__()
-                self.vocab = Vocabulary(input_vocab, unk_idx=input_vocab.idx[UNK])
-                self.model = traced_model
-                self.output_layer = output_layer
-                self.pad_idx = jit.Attribute(input_vocab.idx[PAD], int)
-
-            @jit.script_method
-            def forward(self, tokens: List[List[str]]):
-                word_ids = self.vocab.lookup_indices_2d(tokens)
-
-                seq_lens = jit.annotate(List[int], [])
-
-                for sentence in word_ids:
-                    seq_lens.append(len(sentence))
-                pad_to_length = list_max(seq_lens)
-                for sentence in word_ids:
-                    for _ in range(pad_to_length - len(sentence)):
-                        sentence.append(self.pad_idx)
-
-                logits = self.model(torch.tensor(word_ids), torch.tensor(seq_lens))
-                return self.output_layer(logits)
-
-        return Model()
-
-    @classmethod
-    def create_embedding(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        return create_module(config, tensorizer=tensorizers["tokens"])
-
-    @classmethod
-    def create_decoder(cls, config: Config, representation_dim: int, num_labels: int):
-        return create_module(
-            config.decoder, in_dim=representation_dim, out_dim=num_labels
-        )
-
-    @classmethod
-    def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        labels = tensorizers["labels"].vocab
-        embedding = cls.create_embedding(config.embedding, tensorizers)
-        representation = create_module(
-            config.representation, embed_dim=embedding.embedding_dim
-        )
-        decoder = cls.create_decoder(
-            config, representation.representation_dim, len(labels)
-        )
-        # TODO change from_config function of ClassificationOutputLayer after migriting to new design
-        loss = create_loss(config.output_layer.loss)
-        output_layer_cls = (
-            BinaryClassificationOutputLayer
-            if isinstance(loss, BinaryCrossEntropyLoss)
-            else MulticlassOutputLayer
-        )
-        output_layer = output_layer_cls(list(labels), loss)
-        return cls(embedding, representation, decoder, output_layer)
 
 
 class NewDocRegressionModel(NewDocModel):
@@ -168,21 +73,8 @@ class NewDocRegressionModel(NewDocModel):
     """
 
     class Config(NewDocModel.Config):
-        class RegressionModelInput(Model.Config.ModelInput):
-            tokens: TokenTensorizer.Config = TokenTensorizer.Config()
+        class RegressionModelInput(SimpleTokenModel.Config.ModelInput):
             labels: NumericLabelTensorizer.Config = NumericLabelTensorizer.Config()
 
         inputs: RegressionModelInput = RegressionModelInput()
         output_layer: RegressionOutputLayer.Config = RegressionOutputLayer.Config()
-
-    @classmethod
-    def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        embedding = cls.create_embedding(config.embedding, tensorizers)
-        representation = create_module(
-            config.representation, embed_dim=embedding.embedding_dim
-        )
-        decoder = create_module(
-            config.decoder, in_dim=representation.representation_dim, out_dim=1
-        )
-        output_layer = RegressionOutputLayer.from_config(config.output_layer)
-        return cls(embedding, representation, decoder, output_layer)

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -137,7 +137,7 @@ class WordEmbedding(EmbeddingBase):
             return self.word_embedding.weight
         return super().__getattr__(name)
 
-    def forward(self, input):
+    def forward(self, input: torch.Tensor):
         return self.mlp(self.word_embedding(input))
 
     def freeze(self):


### PR DESCRIPTION
Summary:
(From Barlas's original diff)

Original pytext base model is a three layer architecture: embedding,
representation, decoder. Supported inputs can be word features, character
features, gazetteer features and dense features.

This diff introduces BaseClassificationModel as a replacement with similar
capabilities, so that most models can be migrated easily by inheriting from
it. We support up to 3 token level features (which could be word,
char-word, gazetteer, elmo, etc).  It also supports one doc level feature,
which is the dense features.

Basic doc level and word level models should be able to migrate to this with
very little code change.  Things like seqnn, pairnn and joint models will
need to have their own models.

Embedding classes need a tensorizer input to their from_config function to
replace metadata input.  This is done for WordEmbedding and will need to be
replicated for other embedding modules.

Differential Revision: D15069871

