### PR TITLE
fix sort key

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -232,6 +232,9 @@ class CharacterTokenTensorizer(TokenTensorizer):
         characters, lengths = zip(*batch)
         return (pad_and_tensorize(characters), pad_and_tensorize(lengths))
 
+    def sort_key(self, row):
+        return len(row[0])
+
 
 class LabelTensorizer(Tensorizer):
     """Numberize labels."""


### PR DESCRIPTION
Summary: Sort key should return num_tokens.  Fixing this for the relevant tensorizers: BERTTensorizer, CharacterTensorizer, XLMTensorizer

Differential Revision: D15096378

