### PR TITLE
Fix test no attribute 'embedding'

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -130,7 +130,7 @@ class NewDocModel(DocModel):
 
     @classmethod
     def create_embedding(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        return create_module(config.embedding, None, tensorizers["tokens"])
+        return create_module(config, None, tensorizers["tokens"])
 
     @classmethod
     def create_decoder(cls, config: Config, representation_dim: int, num_labels: int):


### PR DESCRIPTION
Summary: fix test AttributeError: 'WordEmbedding.Config' object has no attribute 'embedding'

Reviewed By: seayoung1112

Differential Revision: D15104211

