### PR TITLE
fix eval and test batch size

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -264,5 +264,6 @@ class Data(Component):
             )
             if self.sort_key
             else None,
+            stage=stage,
         )
         return pad_and_tensorize_batches(self.tensorizers, batches)


### PR DESCRIPTION
Summary:
Batch size is never passed to batchify, so we always default to
train batch size. This diff fixes that

Differential Revision: D15106788

