### PR TITLE
Export contextual intent slot model

### DIFF
--- a/pytext/models/representations/contextual_intent_slot_rep.py
+++ b/pytext/models/representations/contextual_intent_slot_rep.py
@@ -4,13 +4,12 @@
 from typing import List, Tuple, Union
 
 import torch
-from pytext.config import ConfigBase
 from pytext.models.module import create_module
 
 from .bilstm_doc_slot_attention import BiLSTMDocSlotAttention
+from .docnn import DocNNRepresentation
 from .jointcnn_rep import JointCNNRepresentation
 from .representation_base import RepresentationBase
-from .seq_rep import SeqRepresentation
 
 
 class ContextualIntentSlotRepresentation(RepresentationBase):
@@ -35,7 +34,8 @@ class ContextualIntentSlotRepresentation(RepresentationBase):
     """
 
     class Config(RepresentationBase.Config):
-        seq_representation: SeqRepresentation.Config = SeqRepresentation.Config()
+        sen_representation: DocNNRepresentation.Config = DocNNRepresentation.Config()
+        seq_representation: DocNNRepresentation.Config = DocNNRepresentation.Config()
         joint_representation: Union[
             BiLSTMDocSlotAttention.Config, JointCNNRepresentation.Config
         ] = BiLSTMDocSlotAttention.Config()
@@ -43,7 +43,12 @@ class ContextualIntentSlotRepresentation(RepresentationBase):
     def __init__(self, config: Config, embed_dim: Tuple[int, ...]) -> None:
         super().__init__(config)
         assert len(embed_dim) == 2
-        self.seq_rep = create_module(config.seq_representation, embed_dim=embed_dim[1])
+        self.sen_rep = create_module(config.sen_representation, embed_dim=embed_dim[1])
+        self.sen_representation_dim = self.sen_rep.representation_dim
+
+        self.seq_rep = create_module(
+            config.seq_representation, embed_dim=self.sen_representation_dim
+        )
         self.seq_representation_dim = self.seq_rep.representation_dim
         self.joint_rep = create_module(
             config.joint_representation,
@@ -59,21 +64,15 @@ class ContextualIntentSlotRepresentation(RepresentationBase):
         seq_lengths: torch.Tensor,
         *args,
     ) -> List[torch.Tensor]:
-        # Every batch is sorted by in descending or of word_lengths.
-        # We need to sort seq_lengths and seq_embed first before passing
-        # to seq_rep, then unsort the output of seq_rep so it aligns with batch order
+
         (word_embed, seq_embed) = word_seq_embed
-        # sort seq_lengths and seq_embed
-        seq_lengths, sort_idx = torch.sort(seq_lengths, descending=True)
-        _, unsort_idx = torch.sort(sort_idx)
-        seq_embed = seq_embed[sort_idx]
 
-        seq_rep = self.seq_rep(embedded_seqs=seq_embed, seq_lengths=seq_lengths)
-
-        # unsort seq_out
-        seq_out = seq_rep[0][unsort_idx]
+        (bsz, max_num_sen, max_seq_len, dim) = seq_embed.size()
+        rep = self.sen_rep(seq_embed.view(bsz * max_num_sen, max_seq_len, dim))
+        sentence_reps = rep.view(bsz, max_num_sen, self.sen_representation_dim)
+        seq_out = self.seq_rep(embedded_tokens=sentence_reps)
 
         bsz, max_seq_len, dim = word_embed.size()
-        seq_rep_expand = seq_out.view(bsz, 1, -1).expand(-1, max_seq_len, -1)
+        seq_rep_expand = seq_out.view(bsz, 1, -1).repeat(1, max_seq_len, 1)
         new_embed = torch.cat([seq_rep_expand, word_embed], 2)
         return self.joint_rep(new_embed, word_lengths)

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -259,6 +259,7 @@ class ContextualIntentSlotTask(Task):
         metric_reporter: IntentSlotMetricReporter.Config = (
             IntentSlotMetricReporter.Config()
         )
+        exporter: Optional[DenseFeatureExporter.Config] = None
 
     @classmethod
     def example_config(cls):


### PR DESCRIPTION
Summary:
This diff basically implemented D13553807

Refactor contextual intent slot representation layer to avoid using unsupported operator in cafe2: a. use docNN instead of BiLSTM in sequence representation because sort() is not supported in cafe2; b. use repeat() instead of expand() while concat the word_embedding and sequence embedding.

Differential Revision: D15124843

