### PR TITLE
accumulate gradients locally based on update_grads_freq

### DIFF
--- a/pytext/models/distributed_model.py
+++ b/pytext/models/distributed_model.py
@@ -24,6 +24,7 @@ class DistributedModel(nn.parallel.DistributedDataParallel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.accumulate_grads = False
 
     def __getattr__(self, name):
         wrapped_module = super().__getattr__("module")
@@ -63,3 +64,13 @@ class DistributedModel(nn.parallel.DistributedDataParallel):
         wrapped_module = super().__getattr__("module")
         if hasattr(wrapped_module, "stage"):
             wrapped_module.stage = stage
+
+    def accumulate_gradients(self, enable):
+        self.accumulate_grads = enable
+
+    def forward(self, *inputs, **kwargs):
+        # support accumulate gradients in PyText
+        if self.accumulate_grads:
+            return self.module(*inputs, **kwargs)
+        else:
+            return super().forward(*inputs, **kwargs)

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -15,6 +15,7 @@ from pytext.config.serialize import _is_optional
 from pytext.data import CommonMetadata
 from pytext.data.tensorizers import Tensorizer
 from pytext.models.module import create_module
+from pytext.utils.precision import maybe_float
 
 from .decoders import DecoderBase
 from .embeddings import EmbeddingBase, EmbeddingList
@@ -89,7 +90,7 @@ class BaseModel(nn.Module, Component):
         self.context = context
 
     def get_loss(self, logit, target, context):
-        return self.output_layer.get_loss(logit, target, context)
+        return maybe_float(self.output_layer.get_loss(logit, target, context))
 
     def get_pred(self, logit, target=None, context=None, *args):
         return self.output_layer.get_pred(logit, target, context)


### PR DESCRIPTION
Summary:
For large model training or improve distributed training efficiency, we could increase the update gradients frequency (e.g model accumulate gradients locally for multiple forward & backward) before update.

The benefits
1. Increase distributed training speed, the major factor is caused by network latency.
2. Increase batch size for large model training (e.g bound by memory)

Differential Revision: D15124863

