### PR TITLE
Fix Squad data source for v1.1

### DIFF
--- a/pytext/data/sources/squad.py
+++ b/pytext/data/sources/squad.py
@@ -16,7 +16,7 @@ def unflatten(fname, ignore_impossible):
         for paragraph in article["paragraphs"]:
             doc = paragraph["context"]
             for question in paragraph["qas"]:
-                has_answer = not question["is_impossible"]
+                has_answer = not question.get("is_impossible", False)
                 if has_answer or not ignore_impossible:
                     answers = (
                         question["answers"]


### PR DESCRIPTION
Summary: Squad data source breaks for v1.1 because it doesn't have any json field with key `is_impossible`.

Differential Revision: D15125430

