### PR TITLE
Fix Torch Nightly and ONNX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,10 @@
+_run:
+  install_pytorch: &install_pytorch
+    name: install_pytorch
+    command: |
+      sudo pip uninstall -y torch
+      sudo pip install --progress-bar off torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+
 version: 2
 jobs:
   build_Py3.6:
@@ -8,9 +15,7 @@ jobs:
       - run:
           name: setup
           command: source .circleci/setup_circleimg.sh
-      - run:
-          name: install_pytorch
-          command: sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+      - run: *install_pytorch
       - run:
           name: run tests and gather coverage
           command: pytest --junitxml=test-reports/junit.xml --cov=pytext --cov-report=html:htmlcov
@@ -29,9 +34,7 @@ jobs:
       - run:
           name: setup
           command: source .circleci/setup_circleimg.sh
-      - run:
-          name: install_pytorch
-          command: sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-linux_x86_64.whl
+      - run: *install_pytorch
       - run:
           name: run tests and gather coverage
           command: pytest --junitxml=test-reports/junit.xml --cov=pytext --cov-report=html:htmlcov
@@ -50,9 +53,7 @@ jobs:
       - run:
           name: setup
           command: source .circleci/setup_circleimg.sh
-      - run:
-          name: install_pytorch
-          command: sudo pip install --progress-bar off http://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-linux_x86_64.whl
+      - run: *install_pytorch
       - run:
           name: install docs build deps
           command: sudo pip install -r pytext/docs/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ future
 hypothesis<4.0
 joblib
 numpy
-onnx==1.3.0
+onnx
 pandas
 requests
 scipy


### PR DESCRIPTION
Summary:
Doing a bunch of tests on my macbook suggests that:
1.) if we use torch nightly and ONNX 1.5 the tests all pass
2.) if we don't uninstall torch before installing torch nighly, we're going to have a bad day

So this diff fixes both of those issues

Expect the Docs build to still be broken, as it has other issues, that will be fixed in a later diff

Differential Revision: D15142345

