### PR TITLE
Small fix to new bitransformer embedding

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -132,7 +132,7 @@ class NewDocModel(DocModel_Deprecated):
 
     @classmethod
     def create_embedding(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        return create_module(config.embedding, tensorizer=tensorizers["tokens"])
+        return create_module(config, tensorizer=tensorizers["tokens"])
 
     @classmethod
     def create_decoder(cls, config: Config, representation_dim: int, num_labels: int):
@@ -143,7 +143,7 @@ class NewDocModel(DocModel_Deprecated):
     @classmethod
     def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
         labels = tensorizers["labels"].labels
-        embedding = cls.create_embedding(config, tensorizers)
+        embedding = cls.create_embedding(config.embedding, tensorizers)
         representation = create_module(
             config.representation, embed_dim=embedding.embedding_dim
         )
@@ -177,7 +177,7 @@ class NewDocRegressionModel(NewDocModel):
 
     @classmethod
     def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        embedding = cls.create_embedding(config, tensorizers)
+        embedding = cls.create_embedding(config.embedding, tensorizers)
         representation = create_module(
             config.representation, embed_dim=embedding.embedding_dim
         )


### PR DESCRIPTION
Summary: The new bitransformer module assumes the config passed to `create_embedding` is an embedding config - make the model pass embedding configs in general

Differential Revision: D15169834

