### PR TITLE
Allow absence of word embeddings from model

### DIFF
--- a/pytext/config/doc_classification.py
+++ b/pytext/config/doc_classification.py
@@ -15,7 +15,7 @@ from .module_config import ModuleConfig
 
 
 class ModelInputConfig(ModuleConfig):
-    word_feat: WordFeatConfig = WordFeatConfig()
+    word_feat: Optional[WordFeatConfig] = WordFeatConfig()
     dict_feat: Optional[DictFeatConfig] = None
     char_feat: Optional[CharFeatConfig] = None
     contextual_token_embedding: Optional[ContextualTokenEmbeddingConfig] = None

--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -72,7 +72,7 @@ class FloatVectorConfig(ConfigBase):
 
 
 class FeatureConfig(ModuleConfig):  # type: ignore
-    word_feat: WordFeatConfig = WordFeatConfig()
+    word_feat: Optional[WordFeatConfig] = WordFeatConfig()
     seq_word_feat: Optional[WordFeatConfig] = None
     dict_feat: Optional[DictFeatConfig] = None
     char_feat: Optional[CharFeatConfig] = None

--- a/pytext/models/embeddings/embedding_list.py
+++ b/pytext/models/embeddings/embedding_list.py
@@ -36,6 +36,7 @@ class EmbeddingList(EmbeddingBase, ModuleList):
     def __init__(self, embeddings: Iterable[EmbeddingBase], concat: bool) -> None:
         EmbeddingBase.__init__(self, 0)
         embeddings = list(filter(None, embeddings))
+        assert len(embeddings) > 0, "All embedding sub-module cannot be None"
         self.num_emb_modules = sum(emb.num_emb_modules for emb in embeddings)
         embeddings_list, input_start_indices = [], []
         start = 0


### PR DESCRIPTION
Summary: Word embeddings are necessary when using Model class. Removing this requirement.

Differential Revision: D15209837

