### PR TITLE
fix tensorizer init for distributed traning

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -242,7 +242,12 @@ class Data(Component):
         self.sort_key = sort_key
         self.epoch_size = epoch_size
         self.batch = {Stage.TRAIN: None, Stage.EVAL: None, Stage.TEST: None}
-        initialize_tensorizers(self.tensorizers, self.data_source.train)
+        full_train_data = (
+            data_source.train_unsharded
+            if isinstance(data_source, ShardedDataSource)
+            else data_source.train
+        )
+        initialize_tensorizers(self.tensorizers, full_train_data)
 
     def _get_batches(self, stage, data_source):
         if not self.batch[stage]:

--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -161,6 +161,11 @@ class RowShardedDataSource(ShardedDataSource):
     def train(self):
         return shard(iter(self.data_source.train), self.rank, self.world_size)
 
+    @generator_property
+    def train_unsharded(self):
+        """Used to initialize tensorizer on the intire dataset."""
+        return iter(self.data_source.train)
+
 
 class RootDataSource(DataSource):
     """A data source which actually loads data from a location. This data source

--- a/pytext/data/sources/tsv.py
+++ b/pytext/data/sources/tsv.py
@@ -233,6 +233,15 @@ class BlockShardedTSVDataSource(TSVDataSource, ShardedDataSource):
         )
         self._test_tsv = make_tsv(test_file) if test_file else []
         self._eval_tsv = make_tsv(eval_file) if eval_file else []
+        self._train_unsharded = (
+            TSV(train_file, field_names=field_names, delimiter=delimiter)
+            if train_file
+            else []
+        )
+
+    @generator_property
+    def train_unsharded(self):
+        return iter(self._train_unsharded)
 
 
 class SessionTSVDataSource(TSVDataSource):


### PR DESCRIPTION
Summary: Following recent move to sharded datasource, tensorizer init happened on different data on each worker, sometimes leading to label vocabs being ordered differently.  This diff adds an unsharded train data iterator to sharded datasources which is used for tensorizer initialization.  This should solve the issue.

Differential Revision: D15223937

