### PR TITLE
Sort slots in filled_slots_to_str

### DIFF
--- a/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
+++ b/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
@@ -59,7 +59,7 @@ class IntentSlotChannel(FileChannel):
         annotation_str = OPEN + escape_brackets(intent_label) + " "
         slots = parse_slot_string(slots_label)
         cur_index = 0
-        for slot in slots:
+        for slot in sorted(slots, key=lambda slot: slot.start):
             annotation_str += escape_brackets(utterance[cur_index : slot.start])
             annotation_str += (
                 OPEN

--- a/pytext/metric_reporters/tests/intent_slot_metric_reporter_test.py
+++ b/pytext/metric_reporters/tests/intent_slot_metric_reporter_test.py
@@ -31,6 +31,13 @@ class TestIntentSlotMetricReporter(TestCase):
                 "[IN:CREATE_REMINDER Set a reminder to [SL:TODO pick up Sean ] "
                 "at [SL:DATE_TIME 3:15 pm today ]. ]",
             ),
+            (
+                "Set a reminder to pick up Sean at 3:15 pm today.",
+                "IN:CREATE_REMINDER",
+                "34:47:SL:DATE_TIME,18:30:SL:TODO",
+                "[IN:CREATE_REMINDER Set a reminder to [SL:TODO pick up Sean ] "
+                "at [SL:DATE_TIME 3:15 pm today ]. ]",
+            ),
             ('["Fine"]', "cu:other", "", r'[cu:other \["Fine"\] ]'),
         ]
         for (


### PR DESCRIPTION
Summary: `frame_builder` and `intent_slot_detection_metric_reporter` didn't support out-of-order slots, which can occur on some rare occasions.

Differential Revision: D15231670

