### PR TITLE
Allow setting PyText config version = 0 when set to null

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -203,7 +203,7 @@ def upgrade_one_version(json_config):
 
 
 def upgrade_to_latest(json_config):
-    current_version = json_config.get("version", 0)
+    current_version = json_config.get("version") or 0
     if current_version > LATEST_VERSION:
         raise Exception(
             f"config version {json_config['version']} shouldn't exceed lastest \


### PR DESCRIPTION
Summary: If PyTextConfig's version is set to null, the check against LATEST_VERSION throws an exception complaining that it cannot compare None type and int. Fixing to set version = 0 when it's null.

Differential Revision: D15232311

