### PR TITLE
resolve zeus and NCCL timeouts in distributed training

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -19,7 +19,7 @@ from pytext.models.doc_model import (
 from pytext.models.model import BaseModel as Model
 from pytext.models.pair_classification_model import PairwiseClassificationModel
 from pytext.trainers import Trainer, TrainingState
-from pytext.utils import cuda, distributed, precision, timing
+from pytext.utils import cuda, precision, timing
 from torch import jit
 
 from .task import TaskBase
@@ -177,14 +177,9 @@ class _NewTask(TaskBase):
         )
         self.trainer = trainer or NewTaskTrainer()
 
-    def train(
-        self, config: PyTextConfig, rank: int = 0, world_size: int = 1, dist_init_url=""
-    ):
+    def train(self, config: PyTextConfig, rank: int = 0, world_size: int = 1):
         # TODO: move dist_init back to prepare_task in pytext/workflow.py
         # when processing time between dist_init and first loss.backward() is short
-        if dist_init_url and world_size > 1:
-            distributed.dist_init(rank, world_size, dist_init_url)
-
         return self.trainer.train(
             self.data.batches(Stage.TRAIN),
             self.data.batches(Stage.EVAL),

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -24,7 +24,7 @@ from pytext.loss import KLDivergenceBCELoss, KLDivergenceCELoss, SoftHardBCELoss
 from pytext.metric_reporters import MetricReporter
 from pytext.models import Model
 from pytext.trainers import Trainer
-from pytext.utils import cuda, distributed, precision
+from pytext.utils import cuda, precision
 
 
 def create_task(task_config, metadata=None, model_state=None, rank=0, world_size=1):
@@ -141,7 +141,7 @@ class TaskBase(Component):
         self.metric_reporter: MetricReporter = metric_reporter
         self.exporter = exporter
 
-    def train(self, train_config, rank=0, world_size=1, dist_init_url=""):
+    def train(self, train_config, rank=0, world_size=1):
         """
         Wrapper method to train the model using :class:`~Trainer` object.
 
@@ -151,14 +151,9 @@ class TaskBase(Component):
             world_size (int): for distributed training only, total gpu to use, default
                 is 1
         """
-        train_iter = self.data_handler.get_train_iter(rank, world_size)
-        eval_iter = self.data_handler.get_eval_iter()
-        if dist_init_url and world_size > 1:
-            distributed.dist_init(rank, world_size, dist_init_url)
-
         result = self.trainer.train(
-            train_iter,
-            eval_iter,
+            self.data_handler.get_train_iter(rank, world_size),
+            self.data_handler.get_eval_iter(),
             self.model,
             self.metric_reporter,
             train_config,

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -15,7 +15,7 @@ from pytext.task import NewTask, Task, create_task, load, save
 from pytext.task.disjoint_multitask import NewDisjointMultitask
 from pytext.utils import set_random_seeds
 
-from .utils import cuda, precision, timing
+from .utils import cuda, distributed, precision, timing
 
 
 def _set_cuda(
@@ -53,6 +53,18 @@ def _set_fp16(use_fp16: bool) -> None:
     # only support single GPU training at this moment.
     precision.set_fp16(fp16_enabled=use_fp16)
     print(f"# for debug of FP16: fp16_enabled={precision._FP16_ENABLED}")
+
+
+def _set_distributed(
+    rank: int,
+    world_size: int,
+    dist_init_url: str,
+    device_id: int,
+    metadata: CommonMetadata,
+) -> None:
+    if dist_init_url and world_size > 1:
+        assert metadata is not None
+        distributed.dist_init(rank, world_size, dist_init_url, device_id)
 
 
 def prepare_task_metadata(config: PyTextConfig) -> CommonMetadata:
@@ -100,12 +112,11 @@ def prepare_task(
     metadata: CommonMetadata = None,
 ) -> Task:
 
-    if dist_init_url and world_size > 1:
-        assert metadata is not None
-
     print("\nParameters: {}\n".format(config))
     _set_cuda(config.use_cuda_if_available, device_id, world_size)
     _set_fp16(config.use_fp16)
+    _set_distributed(rank, world_size, dist_init_url, device_id, metadata)
+
     if config.random_seed is not None:
         set_random_seeds(config.random_seed)
 


### PR DESCRIPTION
Summary:
By myle and pieter, there's two constraints here -- you want all workers to call dist_init around the same time or zeus times out. After dist_init, you want all workers to start calling all_reduce around the same time or you get NCCL timeouts

In PyText, we will call init_process_group as soon as process been spawned and calling barrier after start process_group

Differential Revision: D15203148

