### PR TITLE
Fix intent attribute

### DIFF
--- a/demo/datasource/source.py
+++ b/demo/datasource/source.py
@@ -124,7 +124,7 @@ class AtisIntentDataSource(RootDataSource):
         return iter(
             self._iter_rows(
                 query_reader=reader(self.train_queries_filepath, self.words),
-                intent_reader=reader(self.train_intent_filepath, self.intent),
+                intent_reader=reader(self.train_intent_filepath, self.intents),
                 select_fn=self._selector(select_eval=False),
             )
         )
@@ -133,7 +133,7 @@ class AtisIntentDataSource(RootDataSource):
         return iter(
             self._iter_rows(
                 query_reader=reader(self.train_queries_filepath, self.words),
-                intent_reader=reader(self.train_intent_filepath, self.intent),
+                intent_reader=reader(self.train_intent_filepath, self.intents),
                 select_fn=self._selector(select_eval=True),
             )
         )
@@ -142,7 +142,7 @@ class AtisIntentDataSource(RootDataSource):
         return iter(
             self._iter_rows(
                 query_reader=reader(self.test_queries_filepath, self.words),
-                intent_reader=reader(self.test_intent_filepath, self.intent),
+                intent_reader=reader(self.test_intent_filepath, self.intents),
             )
         )
 

--- a/demo/datasource/source.py
+++ b/demo/datasource/source.py
@@ -24,10 +24,15 @@ def load_vocab(file_path):
 def reader(file_path, vocab):
     with open(file_path, "r") as reader:
         for line in reader:
+            split_line = line.split()
+            # ATIS every row starts/ends with BOS/EOS: remove them
+            # except for e.g. intents line, which have a single token
+            if len(split_line) > 1:
+                split_line = split_line[1:-1]
             yield " ".join(
                 vocab.get(s.strip(), UNK)
                 # ATIS every row starts/ends with BOS/EOS: remove them
-                for s in line.split()[1:-1]
+                for s in split_line
             )
 
 


### PR DESCRIPTION
## Motivation and Context

The demo file `demo/datasource/source.py` attempts to access `self.intent`, whereas the actual attribute is named `self.intents` (notice the plural). This obviously causes a crash for any new users attempting to use `PyText`.

I chose to update the attribute call to use the plural rather than the other way around (renaming the attribute to singular) as it describes the contents of `intents` better.

Secondly, the BOS/EOS tags appear only in queries, not in intents. So running the original script removes the intents tag by running `line.split()[1:-1]`. Solved this by splitting and checking the number of tokens before splicing some of them out.

As a side note, further following up on the documentation and tutorial, running:
`python3 demo/datasource/source.py | head -n 3` results in:
```shell
Traceback (most recent call last):
  File "demo/datasource/source.py", line 155, in <module>
    print("TRAIN", row)
BrokenPipeError: [Errno 32] Broken pipe
```

## How Has This Been Tested

By re-running the test suite and going over the tutorial manually.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
