### PR TITLE
Enable `CrossLingualData` (renamed) to work with more general `LangAwareData` classes.

### DIFF
--- a/pytext/data/disjoint_multitask_data.py
+++ b/pytext/data/disjoint_multitask_data.py
@@ -53,12 +53,15 @@ class DisjointMultitaskData(Data):
         test_key: str = None,
         task_key: str = BatchContext.TASK_NAME,
     ) -> None:
+        # Currently the data object needs to specify `data_source` and `tensorizers`
+        # to be used at test time. Set these variables to the values of the `test_key`
+        # task.
         test_key = test_key or list(data_dict)[0]
-        # currently the way training is set up is that, the data object needs
-        # to specify a data_source which is used at test time. For multitask
-        # this is set to the data_source associated with the test_key
-        self.data_source = data_dict[test_key].data_source
-        super().__init__(self.data_source, {}, epoch_size=epoch_size)
+        data_source = data_dict[test_key].data_source
+        tensorizers = data_dict[test_key].tensorizers
+        # Don't pass tensorizers to __init__, or else initialization will happen again.
+        super().__init__(data_source, tensorizers={}, epoch_size=epoch_size)
+        self.tensorizers = tensorizers
         self.data_dict = data_dict
         self.samplers = samplers
         self.task_key = task_key


### PR DESCRIPTION
Summary: Currently `CrossLingualLMData` only works with `PackedLMData`, but it'd be nice to use this for fine-tuning (via regular `Data` classes). Rename this class to `CrossLingualData` and allow it to sample from `LangAwareData`, which is just a thin wrapper of `Data`. (it'd be messier to make it work for `Data`, because `CrossLingualData` is a subclass of `Data` and the config would complain if it contained a dictionary of `Data` configs).

Differential Revision: D15232451

