### PR TITLE
Use WordEmbedding.Config.lowercase_tokens

### DIFF
--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -61,7 +61,7 @@ class WordEmbedding(EmbeddingBase):
             if config.pretrained_embeddings_path:
                 pretrained_embedding = PretrainedEmbedding(
                     config.pretrained_embeddings_path,  # doesn't support fbpkg
-                    lowercase_tokens=tensorizer.tokenizer.lowercase,
+                    lowercase_tokens=config.lowercase_tokens,
                 )
 
                 if config.vocab_from_pretrained_embeddings:


### PR DESCRIPTION
Summary: When initializing word embeddings, use `WordEmbedding.lowercase_tokens` instead of `tensorizer.tokenizer.lowercase` (this attribute doesn't even exist for `YodaFeaturizer`).

Differential Revision: D15263946

