### PR TITLE
configurable special tokens in BERT vocab

### DIFF
--- a/pytext/models/module.py
+++ b/pytext/models/module.py
@@ -39,10 +39,11 @@ def create_module(
     # SHARED_MODULE_REGISTRY.  The rest will reuse the saved module and thus
     # share parameters.
     shared_module_key = getattr(module_config, "shared_module_key", None)
-    module = SHARED_MODULE_REGISTRY.get(
-        (shared_module_key, type(module_config)),
-        create_fn(module_config, *args, **kwargs),
-    )
+    try:
+        module = SHARED_MODULE_REGISTRY[(shared_module_key, type(module_config))]
+    except KeyError:
+        module = create_fn(module_config, *args, **kwargs)
+
     name = type(module).__name__
     if getattr(module_config, "load_path", None):
         print(f"Loading state of module {name} from {module_config.load_path} ...")


### PR DESCRIPTION
Summary:
Make BOS and other special tokens configurable in BERT tensorizer.  I'm using this to give each task it's own CLS token.

Also small change to shared_module mechanism to make it more efficient.  Currently it'll build a new module each time and discard it if it's shared.  Skip building if shared module already exists.

Differential Revision: D15050425

