### PR TITLE
deprecate all tasks with data_handler parameter

### DIFF
--- a/pytext/builtin_task.py
+++ b/pytext/builtin_task.py
@@ -11,15 +11,15 @@ from pytext.task.disjoint_multitask import DisjointMultitask, NewDisjointMultita
 from pytext.task.new_task import NewTask, PairwiseClassification
 from pytext.task.task import Task_Deprecated
 from pytext.task.tasks import (
-    ContextualIntentSlotTask,
-    DocClassificationTask,
-    EnsembleTask,
-    JointTextTask,
-    LMTask,
-    PairClassification,
-    SemanticParsingTask,
-    SeqNNTask,
-    WordTaggingTask,
+    ContextualIntentSlotTask_Deprecated,
+    DocClassificationTask_Deprecated,
+    EnsembleTask_Deprecated,
+    JointTextTask_Deprecated,
+    LMTask_Deprecated,
+    PairClassificationTask_Deprecated,
+    SemanticParsingTask_Deprecated,
+    SeqNNTask_Deprecated,
+    WordTaggingTask_Deprecated,
 )
 from pytext.utils.documentation import eprint
 
@@ -57,17 +57,16 @@ def add_include(path):
 def register_builtin_tasks():
     register_tasks(
         (
-            DocClassificationTask,
-            WordTaggingTask,
-            JointTextTask,
-            LMTask,
-            EnsembleTask,
-            PairClassification,
-            SeqNNTask,
-            ContextualIntentSlotTask,
-            SemanticParsingTask,
+            ContextualIntentSlotTask_Deprecated,
             DisjointMultitask,
+            DocClassificationTask_Deprecated,
+            EnsembleTask_Deprecated,
+            JointTextTask_Deprecated,
+            LMTask_Deprecated,
             NewDisjointMultitask,
-            PairwiseClassification,
+            PairClassificationTask_Deprecated,
+            SemanticParsingTask_Deprecated,
+            SeqNNTask_Deprecated,
+            WordTaggingTask_Deprecated,
         )
     )

--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -188,9 +188,57 @@ def doc_model_deprecated(json_config):
     return json_config
 
 
+@register_adapter(from_version=5)
+def old_tasks_deprecated(json_config):
+    """
+    Rename tasks with data_handler config to _Deprecated
+    """
+
+    def rename(t):
+        for section in find_dicts_containing_key(json_config, t):
+            section[t + "_Deprecated"] = section.pop(t)
+
+    rename("BertClassificationTask")
+    rename("BertPairClassificationTask")
+    rename("BertPairwiseClassificationTask")
+    rename("COLMClassifyTask")
+    rename("ContextSCLSTMCompositionalTask")
+    rename("ContextSeq2SeqTask")
+    rename("ContextualIntentSlotTask")
+    rename("DocClassificationTask")
+    rename("ElmoDocClassificationTask")
+    rename("ElmoFineTunePairwiseClassificationTask")
+    rename("EnsembleTask")
+    rename("FederatedLearningTaskBase")
+    rename("FLDocClassificationTask")
+    rename("FLQueryDocumentPairwiseRankingTask")
+    rename("I18NDocClassificationTask")
+    rename("I18NJointTextTask")
+    rename("JointTextTask")
+    rename("KDDocClassificationTask")
+    rename("LMTask")
+    rename("NLGSeq2SeqTask")
+    rename("PairClassificationTask")
+    rename("PairwiseAttentionClassificationTask")
+    rename("QueryDocumentPairwiseRankingTask")
+    rename("SCLSTMCompositionalTask")
+    rename("SCLSTMTask")
+    rename("SemanticParsingCppTask")
+    rename("SemanticParsingTask")
+    rename("Seq2SeqTask")
+    rename("SeqNNTask")
+    rename("SGNNClassificationTask")
+    rename("ShallowClassificationTask")
+    rename("ShallowTaggingTask")
+    rename("SpanClassificationTask")
+    rename("TreeParserTask")
+    rename("WordTaggingTask")
+
+    return json_config
+
+
 def upgrade_one_version(json_config):
     current_version = json_config.get("version", 0)
-    print(f"... upgrade config from version {current_version}")
     adapter = ADAPTERS.get(current_version)
     if not adapter:
         raise Exception(f"no adapter found for version {current_version}")
@@ -200,7 +248,7 @@ def upgrade_one_version(json_config):
 
 
 def upgrade_to_latest(json_config):
-    current_version = json_config.get("version", 0)
+    current_version = json_config.get("version") or 0
     if current_version > LATEST_VERSION:
         raise Exception(
             f"config version {json_config['version']} shouldn't exceed lastest \

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -128,4 +128,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 5
+LATEST_VERSION = 6

--- a/pytext/config/test/json_config/v6.json
+++ b/pytext/config/test/json_config/v6.json
@@ -1,0 +1,185 @@
+[
+  {
+    "original": {
+      "task": {
+        "DocClassificationTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 5
+    },
+    "adapted": {
+      "task": {
+        "DocClassificationTask_Deprecated": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 6
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "WordTaggingTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 5
+    },
+    "adapted": {
+      "task": {
+        "WordTaggingTask_Deprecated": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 6
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "WordTaggingTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 5
+    },
+    "adapted": {
+      "task": {
+        "WordTaggingTask_Deprecated": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 6
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "WordTaggingTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 5
+    },
+    "adapted": {
+      "task": {
+        "WordTaggingTask_Deprecated": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 6
+    }
+  },
+
+  {
+    "original": {
+      "task": {
+        "QueryDocumentPairwiseRankingTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 5
+    },
+    "adapted": {
+      "task": {
+        "QueryDocumentPairwiseRankingTask_Deprecated": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 6
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "PairClassificationTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 5
+    },
+    "adapted": {
+      "task": {
+        "PairClassificationTask_Deprecated": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 6
+    }
+  },
+  {
+    "original": {
+      "task": {
+        "SeqNNTask": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 5
+    },
+    "adapted": {
+      "task": {
+        "SeqNNTask_Deprecated": {
+          "data_handler": {
+            "train_path": "tests/data/train_data_tiny.tsv",
+            "eval_path": "tests/data/test_data_tiny.tsv",
+            "test_path": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "version": 6
+    }
+  }
+]

--- a/pytext/exporters/test/text_model_exporter_test.py
+++ b/pytext/exporters/test/text_model_exporter_test.py
@@ -14,11 +14,11 @@ import torch.nn.functional as F
 from caffe2.python import workspace
 from hypothesis import given
 from pytext.builtin_task import (
-    ContextualIntentSlotTask,
-    DocClassificationTask,
-    JointTextTask,
-    SeqNNTask,
-    WordTaggingTask,
+    ContextualIntentSlotTask_Deprecated,
+    DocClassificationTask_Deprecated,
+    JointTextTask_Deprecated,
+    SeqNNTask_Deprecated,
+    WordTaggingTask_Deprecated,
 )
 from pytext.common.constants import DatasetFieldName
 from pytext.config import config_from_json
@@ -394,7 +394,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         test_num_chars,
     ):
         for config in DOC_CONFIGS:
-            config = self._get_config(DocClassificationTask.Config, config)
+            config = self._get_config(DocClassificationTask_Deprecated.Config, config)
             metadata = self._get_metadata(num_doc_classes, 0)
             py_model = create_model(config.model, config.features, metadata)
             exporter = create_exporter(
@@ -454,7 +454,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         test_num_chars,
     ):
         for config in DOC_CONFIGS_WITH_EXPORT_LOGITS:
-            config = self._get_config(DocClassificationTask.Config, config)
+            config = self._get_config(DocClassificationTask_Deprecated.Config, config)
             metadata = self._get_metadata(num_doc_classes, 0)
             py_model = create_model(config.model, config.features, metadata)
             exporter = create_exporter(
@@ -522,7 +522,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         test_num_chars,
     ):
         for WORD_CONFIG in WORD_CONFIGS:
-            config = self._get_config(WordTaggingTask.Config, WORD_CONFIG)
+            config = self._get_config(WordTaggingTask_Deprecated.Config, WORD_CONFIG)
             metadata = self._get_metadata(0, num_word_classes)
             py_model = create_model(config.model, config.features, metadata)
             exporter = create_exporter(
@@ -585,7 +585,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         num_predictions,
         test_num_chars,
     ):
-        config = self._get_config(JointTextTask.Config, JOINT_CONFIG)
+        config = self._get_config(JointTextTask_Deprecated.Config, JOINT_CONFIG)
         metadata = self._get_metadata(num_doc_classes, num_word_classes)
         py_model = create_model(config.model, config.features, metadata)
         exporter = create_exporter(
@@ -670,7 +670,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         test_num_chars,
         test_num_seq,
     ):
-        config = self._get_config(SeqNNTask.Config, SEQ_NN_CONFIG)
+        config = self._get_config(SeqNNTask_Deprecated.Config, SEQ_NN_CONFIG)
         metadata = self._get_seq_metadata(num_doc_classes, 0)
         py_model = create_model(config.model, config.features, metadata)
         exporter = create_exporter(
@@ -734,7 +734,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         test_num_seq,
     ):
         config = self._get_config(
-            ContextualIntentSlotTask.Config, CONTEXTUAL_INTENT_SLOT_CONFIG
+            ContextualIntentSlotTask_Deprecated.Config, CONTEXTUAL_INTENT_SLOT_CONFIG
         )
         metadata = self._get_metadata(num_doc_classes, num_word_classes)
         py_model = create_model(config.model, config.features, metadata)

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -49,7 +49,7 @@ from pytext.task.new_task import NewTask
 from pytext.trainers import EnsembleTrainer, HogwildTrainer, Trainer
 
 
-class QueryDocumentPairwiseRankingTask(Task_Deprecated):
+class QueryDocumentPairwiseRankingTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         features: QueryDocumentPairwiseRanking.ModelInputConfig = (
             QueryDocumentPairwiseRanking.ModelInputConfig()
@@ -68,7 +68,7 @@ class QueryDocumentPairwiseRankingTask(Task_Deprecated):
 
 
 # TODO better to have separate Task for different ensemble model
-class EnsembleTask(Task_Deprecated):
+class EnsembleTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         model: Union[BaggingDocEnsemble.Config, BaggingIntentSlotEnsemble.Config]
         trainer: EnsembleTrainer.Config = EnsembleTrainer.Config()
@@ -96,7 +96,7 @@ class EnsembleTask(Task_Deprecated):
         )
 
 
-class DocClassificationTask(Task_Deprecated):
+class DocClassificationTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         model: DocModel.Config = DocModel.Config()
         trainer: Trainer.Config = Trainer.Config()
@@ -123,7 +123,7 @@ class DocClassificationTask(Task_Deprecated):
             }
 
 
-class WordTaggingTask(Task_Deprecated):
+class WordTaggingTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         model: WordTaggingModel.Config = WordTaggingModel.Config()
         trainer: Trainer.Config = Trainer.Config()
@@ -163,7 +163,7 @@ class NewWordTaggingTask(NewTask):
         )
 
 
-class JointTextTask(Task_Deprecated):
+class JointTextTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         labels: List[TargetConfigBase]
         model: JointModel.Config = JointModel.Config()
@@ -180,10 +180,10 @@ class JointTextTask(Task_Deprecated):
         doc_target_meta, word_target_meta = target_meta
 
         for intent, slot in zip(
-            DocClassificationTask.format_prediction(
+            DocClassificationTask_Deprecated.format_prediction(
                 doc_preds, doc_scores, context, doc_target_meta
             ),
-            WordTaggingTask.format_prediction(
+            WordTaggingTask_Deprecated.format_prediction(
                 word_preds, word_scores, context, word_target_meta
             ),
         ):
@@ -194,7 +194,7 @@ class JointTextTask(Task_Deprecated):
         return cls.Config(labels=[DocLabelConfig(), WordLabelConfig()])
 
 
-class LMTask(Task_Deprecated):
+class LMTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         data_handler: Union[
             LanguageModelDataHandler.Config, BPTTLanguageModelDataHandler.Config
@@ -207,7 +207,7 @@ class LMTask(Task_Deprecated):
         )
 
 
-class PairClassificationTask(Task_Deprecated):
+class PairClassificationTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         features: PairClassification.ModelInputConfig = (
             PairClassification.ModelInputConfig()
@@ -223,7 +223,7 @@ class PairClassificationTask(Task_Deprecated):
         )
 
 
-class SeqNNTask(Task_Deprecated):
+class SeqNNTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         model: SeqNNModel.Config = SeqNNModel.Config()
         trainer: Trainer.Config = Trainer.Config()
@@ -234,7 +234,7 @@ class SeqNNTask(Task_Deprecated):
         )
 
 
-class ContextualIntentSlotTask(Task_Deprecated):
+class ContextualIntentSlotTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         labels: ContextualIntentSlot.TargetConfig
         features: ContextualIntentSlot.ModelInputConfig = (
@@ -255,7 +255,7 @@ class ContextualIntentSlotTask(Task_Deprecated):
         return cls.Config(labels=[DocLabelConfig(), WordLabelConfig()])
 
 
-class SemanticParsingTask(Task_Deprecated):
+class SemanticParsingTask_Deprecated(Task_Deprecated):
     class Config(Task_Deprecated.Config):
         model: RNNGParser.Config = RNNGParser.Config()
         trainer: HogwildTrainer.Config = HogwildTrainer.Config()


### PR DESCRIPTION
Summary:
rename all tasks using the old data_handler to _Deprecated
(including the ones inheriting from such tasks, recusively)

Differential Revision: D15272139

