### PR TITLE
migrate ElmoFineTunePairwiseClassificationTask

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -234,15 +234,20 @@ class CharacterTokenTensorizer(TokenTensorizer):
         characters = [
             self._numberize_token(token)[: self.max_char_length] for token in tokens
         ]
-        lengths = [len(token_chars) for token_chars in characters]
-        return characters, lengths
+        token_lengths = len(tokens)
+        char_lengths = [len(token_chars) for token_chars in characters]
+        return characters, token_lengths, char_lengths
 
     def _numberize_token(self, token):
         return [ord(c) for c in token.value]
 
     def tensorize(self, batch):
-        characters, lengths = zip(*batch)
-        return (pad_and_tensorize(characters), pad_and_tensorize(lengths))
+        characters, token_lengths, char_lengths = zip(*batch)
+        return (
+            pad_and_tensorize(characters),
+            pad_and_tensorize(token_lengths),
+            pad_and_tensorize(char_lengths),
+        )
 
     def sort_key(self, row):
         return len(row[0])

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -162,18 +162,21 @@ class TensorizersTest(unittest.TestCase):
             [ords("i", 5), ords("want", 5), ords("some", 5), ords("coffe", 5)],
             [ords("turn", 5), ords("it", 5), ords("up", 5), ords("", 5)],
         ]
+        expected_token_lens = [4, 3]
+        expected_char_lens = [[1, 4, 4, 5], [4, 2, 2, 0]]
 
-        expected_lens = [[1, 4, 4, 5], [4, 2, 2, 0]]
-
-        chars, seq_lens = tensorizer.tensorize(
+        chars, token_lens, char_lens = tensorizer.tensorize(
             tensorizer.numberize(row) for row in batch
         )
         self.assertIsInstance(chars, torch.LongTensor)
-        self.assertIsInstance(seq_lens, torch.LongTensor)
+        self.assertIsInstance(token_lens, torch.LongTensor)
+        self.assertIsInstance(char_lens, torch.LongTensor)
         self.assertEqual((2, 4, 5), chars.size())
-        self.assertEqual((2, 4), seq_lens.size())
+        self.assertEqual((2,), token_lens.size())
+        self.assertEqual((2, 4), char_lens.size())
         self.assertEqual(expected, chars.tolist())
-        self.assertEqual(expected_lens, seq_lens.tolist())
+        self.assertEqual(expected_token_lens, token_lens.tolist())
+        self.assertEqual(expected_char_lens, char_lens.tolist())
 
     def test_initialize_label_tensorizer(self):
         tensorizer = LabelTensorizer(label_column="label")


### PR DESCRIPTION
Summary:
migrate ElmoFineTunePairwiseClassificationTask
It is similar to BiTransformer, just ElmoTenkenizer accept a pair of text and concat as input

Differential Revision: D15289783

