### PR TITLE
Make deprecated tasks config adapter work with flow AttrDict types.

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -25,7 +25,7 @@ def find_dicts_containing_key(json_config, key):
     if key in json_config:
         yield json_config
     for _, v in json_config.items():
-        if isinstance(v, dict):
+        if isinstance(v, dict) or hasattr(v, "items"):
             yield from find_dicts_containing_key(v, key)
 
 


### PR DESCRIPTION
Summary:
Integration tests were failing due to config adapter failing on FBL flow dictionary types, this fixes it

From PDB:
```
(Pdb) isinstance(json_config["task"], dict)
False
(Pdb) type (json_config["task"])
<class 'fblearner.flow.core.types_lib.attrdict.AttrDict'>
```

Differential Revision: D15344262

