### PR TITLE
Add token ranges to TokenTensorizer output

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -165,14 +165,16 @@ class TokenTensorizer(Tensorizer):
 
     def numberize(self, row):
         """Tokenize, look up in vocabulary."""
-        tokens, _, _ = self._lookup_tokens(row[self.text_column])
-        return tokens, len(tokens)
+        tokens, start_idx, end_idx = self._lookup_tokens(row[self.text_column])
+        token_ranges = list(zip(start_idx, end_idx))
+        return tokens, len(tokens), token_ranges
 
     def tensorize(self, batch):
-        tokens, seq_lens = zip(*batch)
+        tokens, seq_lens, token_ranges = zip(*batch)
         return (
             pad_and_tensorize(tokens, self.vocab.idx[PAD]),
             pad_and_tensorize(seq_lens),
+            pad_and_tensorize(token_ranges),
         )
 
     def sort_key(self, row):

--- a/pytext/data/test/data_test.py
+++ b/pytext/data/test/data_test.py
@@ -43,7 +43,7 @@ class DataTest(unittest.TestCase):
         self.assertEqual(1, len(batches))
         batch = next(iter(batches))
         self.assertEqual(set(self.tensorizers), set(batch))
-        tokens, seq_lens = batch["tokens"]
+        tokens, seq_lens, _ = batch["tokens"]
         self.assertEqual((10,), seq_lens.size())
         self.assertEqual((10,), batch["labels"].size())
         self.assertEqual({"tokens", "labels"}, set(batch))
@@ -56,7 +56,7 @@ class DataTest(unittest.TestCase):
         self.assertEqual(1, len(batches))
         batch = next(iter(batches))
         self.assertEqual({"tokens"}, set(batch))
-        tokens, seq_lens = batch["tokens"]
+        tokens, seq_lens, _ = batch["tokens"]
         self.assertEqual((10,), seq_lens.size())
         self.assertEqual(10, len(tokens))
 
@@ -95,7 +95,7 @@ class DataTest(unittest.TestCase):
         )
         batches = list(data.batches(Stage.TRAIN))
         batch = next(iter(batches))
-        _, seq_lens = batch["tokens"]
+        _, seq_lens, _ = batch["tokens"]
         seq_lens = seq_lens.tolist()
         for i in range(len(seq_lens) - 1):
             self.assertTrue(seq_lens[i] >= seq_lens[i + 1])

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -124,11 +124,11 @@ class TensorizersTest(unittest.TestCase):
 
         rows = [{"text": "I want some coffee"}, {"text": "Turn it up"}]
         tensors = (tensorizer.numberize(row) for row in rows)
-        tokens, seq_len = next(tensors)
+        tokens, seq_len, _ = next(tensors)
         self.assertEqual([24, 0, 0, 0], tokens)
         self.assertEqual(4, seq_len)
 
-        tokens, seq_len = next(tensors)
+        tokens, seq_len, _ = next(tensors)
         self.assertEqual([13, 47, 9], tokens)
         self.assertEqual(3, seq_len)
 

--- a/pytext/docs/source/overview.rst
+++ b/pytext/docs/source/overview.rst
@@ -149,7 +149,7 @@ Code Example
           return cls(embedding, representation, decoder, output_layer)
 
       def arrange_model_inputs(self, tensor_dict):
-          tokens, seq_lens = tensor_dict["tokens"]
+          tokens, seq_lens, _ = tensor_dict["tokens"]
           return (tokens, seq_lens)
 
       def arrange_targets(self, tensor_dict):
@@ -165,4 +165,3 @@ Code Example
           representation = self.representation(final_embedding)
 
           return self.decoder(representation)
-

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -75,7 +75,7 @@ class NewDocModel(DocModel_Deprecated):
         embedding: WordEmbedding.Config = WordEmbedding.Config()
 
     def arrange_model_inputs(self, tensor_dict):
-        tokens, seq_lens = tensor_dict["tokens"]
+        tokens, seq_lens, _ = tensor_dict["tokens"]
         return (tokens, seq_lens)
 
     def arrange_targets(self, tensor_dict):

--- a/pytext/models/pair_classification_model.py
+++ b/pytext/models/pair_classification_model.py
@@ -268,7 +268,7 @@ class PairwiseModel(BasePairwiseModel):
         )
 
     def arrange_model_inputs(self, tensor_dict):
-        return tensor_dict["tokens1"], tensor_dict["tokens2"]
+        return tensor_dict["tokens1"][:2], tensor_dict["tokens2"][:2]
 
     def arrange_targets(self, tensor_dict):
         return tensor_dict["labels"]

--- a/pytext/models/query_document_pairwise_ranking_model.py
+++ b/pytext/models/query_document_pairwise_ranking_model.py
@@ -184,9 +184,9 @@ class NewQueryDocumentPairwiseRankingModel(PairwiseModel):
 
     def arrange_model_inputs(self, tensor_dict):
         return (
-            tensor_dict["pos_response"],
-            tensor_dict["neg_response"],
-            tensor_dict["query"],
+            tensor_dict["pos_response"][:2],
+            tensor_dict["neg_response"][:2],
+            tensor_dict["query"][:2],
         )
 
     def arrange_targets(self, tensor_dict):

--- a/pytext/models/word_model.py
+++ b/pytext/models/word_model.py
@@ -104,7 +104,7 @@ class NewWordTaggingModel(Model):
             self.find_unused_parameters = False
 
     def arrange_model_inputs(self, tensor_dict):
-        tokens, seq_lens = tensor_dict["tokens"]
+        tokens, seq_lens, _ = tensor_dict["tokens"]
         return (tokens, seq_lens)
 
     def arrange_targets(self, tensor_dict):


### PR DESCRIPTION
Summary: Updates the numberize and tensorize methods of TokenTensorizer to output a triple (tokens, seq_lens, token_ranges), rather than a pair (tokens, seq_lens)

Differential Revision: D15349930

