### PR TITLE
Pass raw data to metric_reporter for batch_context

### DIFF
--- a/pytext/data/disjoint_multitask_data.py
+++ b/pytext/data/disjoint_multitask_data.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 from pytext.common.constants import BatchContext, Stage
 from pytext.config.component import Component, ComponentType, create_component
 from pytext.data import BaseBatchSampler, Data, EvalBatchSampler, generator_iterator
+from pytext.data.data import BatchData
 
 
 class DisjointMultitaskData(Data):
@@ -71,6 +72,6 @@ class DisjointMultitaskData(Data):
         }
         sampled_batches = self.samplers[stage].batchify(all_batches)
 
-        for name, batch in sampled_batches:
+        for name, (raw_batch, batch) in sampled_batches:
             batch[self.task_key] = name
-            yield batch
+            yield BatchData(raw_batch, batch)

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -698,53 +698,6 @@ class GazetteerTensorizer(Tensorizer):
         )
 
 
-class RawString(Tensorizer):
-    """A pass-through tensorizer to include raw fields from datasource in the batch.
-       Used mostly for metric reporting."""
-
-    class Config(Tensorizer.Config):
-        #: The name of the pass-through column to parse from the data source.
-        column: str
-
-    @classmethod
-    def from_config(cls, config: Config):
-        return cls(config.column)
-
-    def __init__(self, column: str):
-        super().__init__([(column, str)])
-        self.column = column
-
-    def numberize(self, row):
-        return row[self.column]
-
-
-class JoinStringTensorizer(Tensorizer):
-    """A pass-through tensorizer to include raw fields from datasource in the batch.
-       Used mostly for metric reporting."""
-
-    class Config(Tensorizer.Config):
-        #: The name of the pass-through column to parse from the data source.
-        columns: List[str]
-        delimiter: str = " | "
-
-    @classmethod
-    def from_config(cls, config: Config):
-        return cls(config.columns, config.delimiter)
-
-    def __init__(self, columns: List[str], delimiter: str):
-        super().__init__([(column, str) for column in columns])
-        self.columns = columns
-        self.delimiter = delimiter
-
-    def numberize(self, row):
-        return self.delimiter.join([row[column] for column in self.columns])
-
-
-class RawJson(RawString):
-    def numberize(self, row):
-        return json.loads(row[self.column])
-
-
 class MetricTensorizer(Tensorizer):
     """A tensorizer which use other tensorizers' numerized data.
        Used mostly for metric reporting."""

--- a/pytext/docs/source/overview.rst
+++ b/pytext/docs/source/overview.rst
@@ -115,8 +115,6 @@ Code Example
           class ModelInput(Model.Config.ModelInput):
               tokens: TokenTensorizer.Config = TokenTensorizer.Config()
               labels: WordLabelTensorizer.Config = WordLabelTensorizer.Config()
-              # for metric reporter
-              raw_text: RawString.Config = RawString.Config(column="text")
 
           inputs: ModelInput = ModelInput()
           embedding: WordEmbedding.Config = WordEmbedding.Config()

--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -47,10 +47,10 @@ class DisjointMultitaskMetricReporter(MetricReporter):
         self.total_loss = 0
         self.num_batches = 0
 
-    def batch_context(self, batch):
+    def batch_context(self, raw_batch, batch):
         context = {BatchContext.TASK_NAME: batch[BatchContext.TASK_NAME]}
         for reporter in self.reporters.values():
-            context.update(reporter.batch_context(batch))
+            context.update(reporter.batch_context(raw_batch, batch))
         return context
 
     def add_batch_stats(

--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -25,7 +25,7 @@ class LanguageModelChannel(FileChannel):
 
 class LanguageModelMetricReporter(MetricReporter):
     UTTERANCE_COLUMN = "utterance"
-    RAW_TEXT_COLUMN = "raw_text"
+    RAW_TEXT_COLUMN = "text"
     lower_is_better = True
 
     @classmethod
@@ -55,12 +55,14 @@ class LanguageModelMetricReporter(MetricReporter):
     def get_model_select_metric(self, metrics) -> float:
         return metrics.perplexity_per_word
 
-    def batch_context(self, batch):
-        context = super().batch_context(batch)
-        if self.RAW_TEXT_COLUMN in batch:
+    def batch_context(self, raw_batch, batch):
+        context = super().batch_context(raw_batch, batch)
+        if any(self.RAW_TEXT_COLUMN in row for row in raw_batch):
             context.update(
                 {
-                    self.UTTERANCE_COLUMN: batch[self.RAW_TEXT_COLUMN],
+                    self.UTTERANCE_COLUMN: [
+                        row.get(self.RAW_TEXT_COLUMN) for row in raw_batch
+                    ],
                     DatasetFieldName.TARGET_SEQ_LENS: batch["tokens"][1],
                 }
             )

--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -139,7 +139,7 @@ class MetricReporter(Component):
     def add_channel(self, channel):
         self.channels.append(channel)
 
-    def batch_context(self, batch):
+    def batch_context(self, raw_batch, batch):
         context = {}
         if DatasetFieldName.NUM_TOKENS in batch:
             context.update(

--- a/pytext/metric_reporters/word_tagging_metric_reporter.py
+++ b/pytext/metric_reporters/word_tagging_metric_reporter.py
@@ -121,7 +121,7 @@ class SequenceTaggingMetricReporter(MetricReporter):
             self.calculate_loss(),
         )
 
-    def batch_context(self, batch):
+    def batch_context(self, raw_batch, batch):
         return {}
 
     @staticmethod

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -9,8 +9,6 @@ from pytext.config.component import create_loss
 from pytext.data.tensorizers import (
     LabelTensorizer,
     NumericLabelTensorizer,
-    RawJson,
-    RawString,
     Tensorizer,
     TokenTensorizer,
 )
@@ -68,8 +66,6 @@ class DocModel(Model):
         class ModelInput(Model.Config.ModelInput):
             tokens: TokenTensorizer.Config = TokenTensorizer.Config()
             labels: LabelTensorizer.Config = LabelTensorizer.Config()
-            # for metric reporter
-            raw_text: RawString.Config = RawString.Config(column="text")
 
         inputs: ModelInput = ModelInput()
         embedding: WordEmbedding.Config = WordEmbedding.Config()

--- a/pytext/models/language_models/lmlstm.py
+++ b/pytext/models/language_models/lmlstm.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 from pytext.config import ConfigBase
 from pytext.data import CommonMetadata
-from pytext.data.tensorizers import RawString, Tensorizer, TokenTensorizer
+from pytext.data.tensorizers import Tensorizer, TokenTensorizer
 from pytext.models.decoders import DecoderBase
 from pytext.models.decoders.mlp_decoder import MLPDecoder
 from pytext.models.embeddings import EmbeddingBase
@@ -163,8 +163,6 @@ class LMLSTM(BaseModel):
             tokens: TokenTensorizer.Config = TokenTensorizer.Config(
                 add_bos_token=True, add_eos_token=True
             )
-            # for metric reporter
-            raw_text: RawString.Config = RawString.Config(column="text")
 
         inputs: ModelInput = ModelInput()
         embedding: WordEmbedding.Config = WordEmbedding.Config()

--- a/pytext/models/pair_classification_model.py
+++ b/pytext/models/pair_classification_model.py
@@ -8,12 +8,7 @@ from typing import Dict, List, Tuple, Union
 import torch
 import torch.nn as nn
 from pytext.config import ConfigBase
-from pytext.data.tensorizers import (
-    JoinStringTensorizer,
-    LabelTensorizer,
-    Tensorizer,
-    TokenTensorizer,
-)
+from pytext.data.tensorizers import LabelTensorizer, Tensorizer, TokenTensorizer
 from pytext.models.decoders import DecoderBase
 from pytext.models.decoders.mlp_decoder import MLPDecoder
 from pytext.models.embeddings import EmbeddingBase, EmbeddingList, WordEmbedding
@@ -186,10 +181,6 @@ class PairwiseModel(BasePairwiseModel):
             tokens1: TokenTensorizer.Config = TokenTensorizer.Config(column="text1")
             tokens2: TokenTensorizer.Config = TokenTensorizer.Config(column="text2")
             labels: LabelTensorizer.Config = LabelTensorizer.Config()
-            # for metric reporter
-            raw_text: JoinStringTensorizer.Config = JoinStringTensorizer.Config(
-                columns=["text1", "text2"]
-            )
 
         inputs: ModelInput = ModelInput()
         embedding: WordEmbedding.Config = WordEmbedding.Config()

--- a/pytext/models/word_model.py
+++ b/pytext/models/word_model.py
@@ -3,9 +3,8 @@
 
 from typing import Union
 
-from pytext.data.tensorizers import RawString, TokenTensorizer, WordLabelTensorizer
+from pytext.data.tensorizers import TokenTensorizer, WordLabelTensorizer
 from pytext.data.utils import UNK
-from pytext.loss import CrossEntropyLoss
 from pytext.models.decoders.mlp_decoder import MLPDecoder
 from pytext.models.embeddings import WordEmbedding
 from pytext.models.model import Model
@@ -55,8 +54,6 @@ class WordTaggingModel(Model):
         class ModelInput(Model.Config.ModelInput):
             tokens: TokenTensorizer.Config = TokenTensorizer.Config()
             labels: WordLabelTensorizer.Config = WordLabelTensorizer.Config()
-            # for metric reporter
-            raw_text: RawString.Config = RawString.Config(column="text")
 
         inputs: ModelInput = ModelInput()
         embedding: WordEmbedding.Config = WordEmbedding.Config()

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -268,7 +268,7 @@ class PairwiseClassificationTask(NewTask):
     class Config(NewTask.Config):
         model: BasePairwiseModel.Config = PairwiseModel.Config()
         metric_reporter: ClassificationMetricReporter.Config = (
-            ClassificationMetricReporter.Config()
+            ClassificationMetricReporter.Config(text_column_names=["text1", "text2"])
         )
 
 


### PR DESCRIPTION
Summary:
We have a bunch of pass-through tensorizers that exist to funnel data into the metric reporter. Instead now we pass the raw batch data to metric_reporter.batch_context so it can get that info directly.

This allows us to also delete a bunch of the pass-through tensorizers.

I'll also work to eliminate MetricTensorizer and NtokenTensorizer in a follow-up diff. This is a bit more complicated partly because there are already 10+ models which are using it, partly because it's implemented in the base MetricReporter class, and partly because the number of tokens are located in a different place for different models.

Differential Revision: D15368631

