### PR TITLE
Fix docstring / help string for torchscript-export

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -386,7 +386,7 @@ def export(context, model, output_path, output_onnx_path):
 @click.option("--quantize", help="whether to quantize the model")
 @click.pass_context
 def torchscript_export(context, model, output_path, quantize=False):
-    """Convert a pytext model snapshot to a caffe2 model."""
+    """Convert a pytext model snapshot to a torchscript model."""
     config = context.obj.load_config()
     model = model or config.save_snapshot_path
     output_path = output_path or f"{config.save_snapshot_path}.torchscript"


### PR DESCRIPTION
The docstring for torchscript_export() mistakenly refers to caffe2
(probably cut-n-paste from export()), and this is reflected in the
help text:

Before:

$ pytext --help
Usage: pytext [OPTIONS] COMMAND [ARGS]...
...
Commands:
  export              Convert a pytext model snapshot to a caffe2 model.
...
  torchscript-export  Convert a pytext model snapshot to a caffe2 model.

After:

  export              Convert a pytext model snapshot to a caffe2 model.
...
  torchscript-export  Convert a pytext model snapshot to torchscript.

## Motivation and Context

Minor fix to help text / documentation.

## How Has This Been Tested

Built and confirmed locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
