### PR TITLE
Add options to skip tensorizer initialization

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -273,12 +273,16 @@ class Trainer(TrainerBase):
             model=model, optimizer=self.optimizer, scheduler=self.scheduler, rank=rank
         )
         self.set_up_training(state, training_data)
+        trainable_params = sum(
+            p.numel() for p in state.model.parameters() if p.requires_grad
+        )
+        print(f"Num trainable parameters: {trainable_params}")
+
         while self.continue_training(state):
             state.epoch += 1
             state.epochs_since_last_improvement += 1
-            print(f"\nWorker {state.rank} starting epoch {state.epoch}", flush=True)
-            print(f"Num parameters: {sum(p.numel() for p in state.model.parameters())}")
             lrs = learning_rates(state.optimizer)
+            print(f"\nWorker {state.rank} starting epoch {state.epoch}", flush=True)
             print(f"Learning rate(s): {', '.join(map(str, lrs))}")
 
             with timing.time("train epoch"):


### PR DESCRIPTION
Summary:
Many of our regular workflows don't need really need initializing tensorizers over the training data, which can take a lot of time. (e.g. bi-transformer, BERT, XLM, and LSTMs with vocab determined from pretrained embeddings don't need initialization).

This diff adds the option to specify label values (so we don't have to go through the dataset to find them). Also add the option to skip creating token vocab from data (e.g. if we know we will use the pretrained embedding vocab anyways).

Skipping initialization is particularly valuable for finding mistakes / errors early (e.g. if there is a misconfiguration it can take hours for training to start and hit the error).

Differential Revision: D15377265

