### PR TITLE
Add `ByteTokensDocumentModel`

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -128,4 +128,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 8
+LATEST_VERSION = 9

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -130,7 +130,7 @@ class TokenTensorizer(Tensorizer):
         self.max_seq_len = max_seq_len or 2 ** 30  # large number
         self.vocab_builder = None
 
-    def _lookup_tokens(self, text):
+    def _tokenize(self, text):
         tokenized = self.tokenizer.tokenize(text)[: self.max_seq_len]
         if self.add_bos_token:
             bos = EOS if self.use_eos_token_for_bos else BOS
@@ -139,7 +139,10 @@ class TokenTensorizer(Tensorizer):
             tokenized.append(Token(EOS, -1, -1))
         if not tokenized:
             tokenized = [Token(PAD, -1, -1)]
+        return tokenized
 
+    def _lookup_tokens(self, text):
+        tokenized = self._tokenize(text)
         tokenized_texts, start_idx, end_idx = zip(
             *((t.value, t.start, t.end) for t in tokenized)
         )
@@ -224,6 +227,78 @@ class ByteTensorizer(Tensorizer):
     def sort_key(self, row):
         # use bytes_len as sort key
         return row[1]
+
+
+class ByteTokenTensorizer(Tensorizer):
+    """Turn words into 2-dimensional tensors of int8 bytes. Words are padded to
+    `max_byte_len`. Also computes sequence lengths (1-D tensor) and token lengths
+    (2-D tensor). 0 is the pad byte.
+    """
+
+    NUM_BYTES = 256
+
+    class Config(TokenTensorizer.Config):
+        #: The name of the text column to parse from the data source.
+        column: str = "text"
+        #: The tokenizer to use to split input text into tokens.
+        tokenizer: Tokenizer.Config = Tokenizer.Config()
+        #: The max token length for input text.
+        max_seq_len: Optional[int] = None
+        #: The max byte length for a token.
+        max_byte_len: int = 15
+        #: Offset to add to all non-padding bytes
+        offset_for_non_padding: int = 0
+
+    @classmethod
+    def from_config(cls, config: Config):
+        tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
+        return cls(
+            text_column=config.column,
+            tokenizer=tokenizer,
+            max_seq_len=config.max_seq_len,
+            max_byte_len=config.max_byte_len,
+            offset_for_non_padding=config.offset_for_non_padding,
+        )
+
+    def __init__(
+        self,
+        text_column,
+        tokenizer=None,
+        max_seq_len=Config.max_seq_len,
+        max_byte_len=Config.max_byte_len,
+        offset_for_non_padding=Config.offset_for_non_padding,
+    ):
+        super().__init__([(text_column, str)])
+        self.text_column = text_column
+        self.tokenizer = tokenizer or Tokenizer()
+        self.max_seq_len = max_seq_len or 2 ** 30  # large number
+        self.max_byte_len = max_byte_len
+        self.offset_for_non_padding = offset_for_non_padding
+
+    def numberize(self, row):
+        """Convert text to bytes, pad batch."""
+        tokens = self.tokenizer.tokenize(row[self.text_column])[: self.max_seq_len]
+        if not tokens:
+            tokens = [Token(PAD, -1, -1)]
+        bytes = [self._numberize_token(token)[: self.max_byte_len] for token in tokens]
+        token_lengths = len(tokens)
+        byte_lengths = [len(token_bytes) for token_bytes in bytes]
+        return bytes, token_lengths, byte_lengths
+
+    def _numberize_token(self, token):
+        return [c + self.offset_for_non_padding for c in token.value.encode()]
+
+    def tensorize(self, batch):
+        bytes, token_lengths, byte_lengths = zip(*batch)
+        pad_shape = (len(batch), max(len(l) for l in byte_lengths), self.max_byte_len)
+        return (
+            pad_and_tensorize(bytes, pad_shape=pad_shape),
+            pad_and_tensorize(token_lengths),
+            pad_and_tensorize(byte_lengths),
+        )
+
+    def sort_key(self, row):
+        return len(row[0])
 
 
 class CharacterTokenTensorizer(TokenTensorizer):

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -10,7 +10,7 @@ from pytext.data.sources.data_source import Gazetteer, SafeFileWrapper
 from pytext.data.sources.tsv import SessionTSVDataSource, TSVDataSource
 from pytext.data.tensorizers import (
     ByteTensorizer,
-    CharacterTokenTensorizer,
+    ByteTokenTensorizer,
     FloatListTensorizer,
     GazetteerTensorizer,
     LabelListTensorizer,
@@ -124,13 +124,15 @@ class TensorizersTest(unittest.TestCase):
 
         rows = [{"text": "I want some coffee"}, {"text": "Turn it up"}]
         tensors = (tensorizer.numberize(row) for row in rows)
-        tokens, seq_len, _ = next(tensors)
+        tokens, seq_len, token_ranges = next(tensors)
         self.assertEqual([24, 0, 0, 0], tokens)
         self.assertEqual(4, seq_len)
+        self.assertEqual([(0, 1), (2, 6), (7, 11), (12, 18)], token_ranges)
 
-        tokens, seq_len, _ = next(tensors)
+        tokens, seq_len, token_ranges = next(tensors)
         self.assertEqual([13, 47, 9], tokens)
         self.assertEqual(3, seq_len)
+        self.assertEqual([(0, 4), (5, 7), (8, 10)], token_ranges)
 
     def test_create_byte_tensors(self):
         tensorizer = ByteTensorizer(text_column="text", lower=False)
@@ -145,9 +147,9 @@ class TensorizersTest(unittest.TestCase):
         tensors = [tensorizer.numberize(row) for row in rows]
         self.assertEqual([(bytes, len(bytes)) for bytes in expected], tensors)
 
-    def test_create_word_character_tensors(self):
-        tensorizer = CharacterTokenTensorizer(
-            text_column="text", max_seq_len=4, max_char_length=5
+    def test_create_byte_token_tensors(self):
+        tensorizer = ByteTokenTensorizer(
+            text_column="text", max_seq_len=4, max_byte_len=5
         )
         # not initializing because initializing is a no-op for this tensorizer
 
@@ -155,7 +157,7 @@ class TensorizersTest(unittest.TestCase):
         s2 = "Turn it up"
 
         def ords(word, pad_to):
-            return [ord(c) for c in word] + [0] * (pad_to - len(word))
+            return list(word.encode()) + [0] * (pad_to - len(word))
 
         batch = [{"text": s1}, {"text": s2}]
         # Note that the tokenizer lowercases here
@@ -164,20 +166,20 @@ class TensorizersTest(unittest.TestCase):
             [ords("turn", 5), ords("it", 5), ords("up", 5), ords("", 5)],
         ]
         expected_token_lens = [4, 3]
-        expected_char_lens = [[1, 4, 4, 5], [4, 2, 2, 0]]
+        expected_byte_lens = [[1, 4, 4, 5], [4, 2, 2, 0]]
 
-        chars, token_lens, char_lens = tensorizer.tensorize(
-            tensorizer.numberize(row) for row in batch
+        bytes, token_lens, byte_lens = tensorizer.tensorize(
+            [tensorizer.numberize(row) for row in batch]
         )
-        self.assertIsInstance(chars, torch.LongTensor)
+        self.assertIsInstance(bytes, torch.LongTensor)
         self.assertIsInstance(token_lens, torch.LongTensor)
-        self.assertIsInstance(char_lens, torch.LongTensor)
-        self.assertEqual((2, 4, 5), chars.size())
+        self.assertIsInstance(byte_lens, torch.LongTensor)
+        self.assertEqual((2, 4, 5), bytes.size())
         self.assertEqual((2,), token_lens.size())
-        self.assertEqual((2, 4), char_lens.size())
-        self.assertEqual(expected, chars.tolist())
+        self.assertEqual((2, 4), byte_lens.size())
+        self.assertEqual(expected, bytes.tolist())
         self.assertEqual(expected_token_lens, token_lens.tolist())
-        self.assertEqual(expected_char_lens, char_lens.tolist())
+        self.assertEqual(expected_byte_lens, byte_lens.tolist())
 
     def test_initialize_label_tensorizer(self):
         tensorizer = LabelTensorizer(label_column="label")

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -7,6 +7,7 @@ import torch
 from pytext.config import ConfigBase
 from pytext.config.component import create_loss
 from pytext.data.tensorizers import (
+    ByteTokenTensorizer,
     LabelTensorizer,
     NumericLabelTensorizer,
     RawJson,
@@ -18,7 +19,7 @@ from pytext.data.utils import PAD, UNK
 from pytext.exporters.exporter import ModelExporter
 from pytext.loss import BinaryCrossEntropyLoss
 from pytext.models.decoders.mlp_decoder import MLPDecoder
-from pytext.models.embeddings import WordEmbedding
+from pytext.models.embeddings import CharacterEmbedding, EmbeddingList, WordEmbedding
 from pytext.models.model import Model
 from pytext.models.module import create_module
 from pytext.models.output_layers import ClassificationOutputLayer, RegressionOutputLayer
@@ -29,7 +30,12 @@ from pytext.models.output_layers.doc_classification_output_layer import (
 from pytext.models.representations.bilstm_doc_attention import BiLSTMDocAttention
 from pytext.models.representations.docnn import DocNNRepresentation
 from pytext.models.representations.pure_doc_attention import PureDocAttention
-from pytext.utils.torch import Vocabulary, list_max
+from pytext.utils.torch import (
+    Vocabulary,
+    make_byte_inputs,
+    make_sequence_lengths,
+    pad_2d,
+)
 from torch import jit
 
 
@@ -115,17 +121,9 @@ class NewDocModel(DocModel_Deprecated):
 
             @jit.script_method
             def forward(self, tokens: List[List[str]]):
+                seq_lens = make_sequence_lengths(tokens)
                 word_ids = self.vocab.lookup_indices_2d(tokens)
-
-                seq_lens = jit.annotate(List[int], [])
-
-                for sentence in word_ids:
-                    seq_lens.append(len(sentence))
-                pad_to_length = list_max(seq_lens)
-                for sentence in word_ids:
-                    for _ in range(pad_to_length - len(sentence)):
-                        sentence.append(self.pad_idx)
-
+                word_ids = pad_2d(word_ids, seq_lens, self.pad_idx)
                 logits = self.model(torch.tensor(word_ids), torch.tensor(seq_lens))
                 return self.output_layer(logits)
 
@@ -133,7 +131,7 @@ class NewDocModel(DocModel_Deprecated):
 
     @classmethod
     def create_embedding(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        return create_module(config, tensorizer=tensorizers["tokens"])
+        return create_module(config.embedding, tensorizer=tensorizers["tokens"])
 
     @classmethod
     def create_decoder(cls, config: Config, representation_dim: int, num_labels: int):
@@ -144,7 +142,7 @@ class NewDocModel(DocModel_Deprecated):
     @classmethod
     def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
         labels = tensorizers["labels"].vocab
-        embedding = cls.create_embedding(config.embedding, tensorizers)
+        embedding = cls.create_embedding(config, tensorizers)
         representation = create_module(
             config.representation, embed_dim=embedding.embedding_dim
         )
@@ -160,6 +158,83 @@ class NewDocModel(DocModel_Deprecated):
         )
         output_layer = output_layer_cls(list(labels), loss)
         return cls(embedding, representation, decoder, output_layer)
+
+
+class ByteTokensDocumentModel(NewDocModel):
+    """
+    DocModel that receives both word IDs and byte IDs as inputs (concatenating
+    word and byte-token embeddings to represent input tokens).
+    """
+
+    class Config(NewDocModel.Config):
+        class ModelInput(NewDocModel.Config.ModelInput):
+            token_bytes: ByteTokenTensorizer.Config = ByteTokenTensorizer.Config()
+
+        inputs: ModelInput = ModelInput()
+        byte_embedding: CharacterEmbedding.Config = CharacterEmbedding.Config()
+
+    @classmethod
+    def create_embedding(cls, config, tensorizers: Dict[str, Tensorizer]):
+        word_tensorizer = config.inputs.tokens
+        byte_tensorizer = config.inputs.token_bytes
+        assert word_tensorizer.column == byte_tensorizer.column
+        assert word_tensorizer.tokenizer.items() == byte_tensorizer.tokenizer.items()
+        assert word_tensorizer.max_seq_len == byte_tensorizer.max_seq_len
+
+        word_embedding = create_module(
+            config.embedding, tensorizer=tensorizers["tokens"]
+        )
+        byte_embedding = CharacterEmbedding(
+            ByteTokenTensorizer.NUM_BYTES,
+            config.byte_embedding.embed_dim,
+            config.byte_embedding.cnn.kernel_num,
+            config.byte_embedding.cnn.kernel_sizes,
+            config.byte_embedding.highway_layers,
+            config.byte_embedding.projection_dim,
+        )
+        return EmbeddingList([word_embedding, byte_embedding], concat=True)
+
+    def arrange_model_inputs(self, tensor_dict):
+        tokens, seq_lens, _ = tensor_dict["tokens"]
+        token_bytes, byte_seq_lens, _ = tensor_dict["token_bytes"]
+        assert (seq_lens == byte_seq_lens).all().item()
+        return tokens, token_bytes, seq_lens
+
+    def get_export_input_names(self, tensorizers):
+        return ["tokens", "token_bytes", "tokens_lens"]
+
+    def torchscriptify(self, tensorizers, traced_model):
+        output_layer = self.output_layer.torchscript_predictions()
+        max_byte_len = tensorizers["token_bytes"].max_byte_len
+        byte_offset_for_non_padding = tensorizers["token_bytes"].offset_for_non_padding
+        input_vocab = tensorizers["tokens"].vocab
+
+        class Model(jit.ScriptModule):
+            def __init__(self):
+                super().__init__()
+                self.vocab = Vocabulary(input_vocab, unk_idx=input_vocab.idx[UNK])
+                self.max_byte_len = jit.Attribute(max_byte_len, int)
+                self.byte_offset_for_non_padding = jit.Attribute(
+                    byte_offset_for_non_padding, int
+                )
+                self.pad_idx = jit.Attribute(input_vocab.idx[PAD], int)
+                self.model = traced_model
+                self.output_layer = output_layer
+
+            @jit.script_method
+            def forward(self, tokens: List[List[str]]):
+                seq_lens = make_sequence_lengths(tokens)
+                word_ids = self.vocab.lookup_indices_2d(tokens)
+                word_ids = pad_2d(word_ids, seq_lens, self.pad_idx)
+                token_bytes, _ = make_byte_inputs(
+                    tokens, self.max_byte_len, self.byte_offset_for_non_padding
+                )
+                logits = self.model(
+                    torch.tensor(word_ids), token_bytes, torch.tensor(seq_lens)
+                )
+                return self.output_layer(logits)
+
+        return Model()
 
 
 class NewDocRegressionModel(NewDocModel):
@@ -178,7 +253,7 @@ class NewDocRegressionModel(NewDocModel):
 
     @classmethod
     def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        embedding = cls.create_embedding(config.embedding, tensorizers)
+        embedding = cls.create_embedding(config, tensorizers)
         representation = create_module(
             config.representation, embed_dim=embedding.embedding_dim
         )


### PR DESCRIPTION
Summary: Add a model that gets a token ID and a sequence of byte IDs for each token in the input text. Applies and concatenates representations from `WordEmbedding` and `CharacterEmbedding`.

Differential Revision: D15460934

