### PR TITLE
unified model.cuda() callsite

### DIFF
--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -106,8 +106,6 @@ class DisjointMultitask(TaskBase):
         )
         if model_state:
             model.load_state_dict(model_state)
-        if cuda.CUDA_ENABLED:
-            model = model.cuda()
 
         return cls(
             target_task_name=task_config.target_task_name,

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -180,10 +180,6 @@ class _NewTask(TaskBase):
         if model_state:
             model.load_state_dict(model_state)
 
-        precision.activate(model)
-        if cuda.CUDA_ENABLED:
-            model = model.cuda()
-
         return model
 
     def __init__(

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -103,9 +103,6 @@ class TaskBase(Component):
         if model_state:
             model.load_state_dict(model_state)
 
-        precision.activate(model)
-        if cuda.CUDA_ENABLED:
-            model = model.cuda()
         metric_reporter = create_metric_reporter(task_config.metric_reporter, metadata)
         exporter = (
             create_exporter(

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -93,7 +93,7 @@ class Trainer(TrainerBase):
             if config.scheduler
             else Scheduler()
         )
-        model, self.optimizer = precision.initialize(model, optimizer)
+        self.optimizer = precision.initialize(model, optimizer)
         self.config = config
 
     @classmethod


### PR DESCRIPTION
Summary:
Currently, PyText calling model.cuda() in both Task and Trainer, idealy we should make it happen in a single place where it required.

After this diff:
1. model.cuda() is called at the beginning of trainer.train or trainer.test
2. Mixed precision training model.half() is called during trainer initialization and before model.cuda() to avoid store both fp32 and fp16 params in cuda

All model.cuda() calls: https://our.intern.facebook.com/intern/codesearch/?bunny_arg=model.cuda()&bunny_command=fbgs&q=repo%3Afbcode%20case%3Ainsensitive%20regex%3Aoff%20file%3Apytext%20model.cuda()&source=redirect

Differential Revision: D15477091

