### PR TITLE
Add batch dimension to dict feat length

### DIFF
--- a/pytext/exporters/test/text_model_exporter_test.py
+++ b/pytext/exporters/test/text_model_exporter_test.py
@@ -974,7 +974,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         )
         dict_lengths = torch.from_numpy(
             np.random.randint(
-                1, num_dict_feats + 1, size=(num_words * batch_size)
+                1, num_dict_feats + 1, size=(batch_size, num_words)
             ).astype(np.int64)
         )
         chars = torch.from_numpy(

--- a/pytext/fields/test/dict_field_test.py
+++ b/pytext/fields/test/dict_field_test.py
@@ -45,7 +45,7 @@ PADDED_DICT_FEATS = [
 ]
 
 PADDED_DICT_WEIGHTS = [[0.0, 0.0, 0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]
-PADDED_LENGTHS = [1, 1, 2, 1, 1, 1]
+PADDED_LENGTHS = [[1, 1, 2], [1, 1, 1]]
 NUMERICAL_FEATS = np.array([[1, 1, 1, 1, 3, 2], [1, 1, 4, 1, 1, 1]])
 
 

--- a/pytext/models/embeddings/dict_embedding.py
+++ b/pytext/models/embeddings/dict_embedding.py
@@ -89,10 +89,13 @@ class DictEmbedding(EmbeddingBase, nn.Embedding):
 
         Args:
             feats (torch.Tensor): Batch of sentences with dictionary feature ids.
+                shape: [bsz, seq_len * max_feat_per_token]
             weights (torch.Tensor): Batch of sentences with dictionary feature
-            weights for the dictionary features.
+                weights for the dictionary features.
+                shape: [bsz, seq_len * max_feat_per_token]
             lengths (torch.Tensor): Batch of sentences with the number of
-            dictionary features per token.
+                dictionary features per token.
+                shape: [bsz, seq_len]
 
         Returns:
             torch.Tensor: Embedded batch of sentences. Dimension:
@@ -101,8 +104,6 @@ class DictEmbedding(EmbeddingBase, nn.Embedding):
 
         """
         batch_size = torch.onnx.operators.shape_as_tensor(feats)[0]
-        new_len_shape = torch.cat((batch_size.view(1), torch.LongTensor([-1])))
-        lengths = torch.onnx.operators.reshape_from_tensor_shape(lengths, new_len_shape)
         max_toks = torch.onnx.operators.shape_as_tensor(lengths)[1]
         dict_emb = super().forward(feats)
 

--- a/pytext/models/test/rnng_test.py
+++ b/pytext/models/test/rnng_test.py
@@ -204,7 +204,7 @@ class RNNGParserTest(unittest.TestCase):
         dict_feat = (
             torch.tensor([[1, 1, 1, 1, 1, 1, 3, 1]]),
             torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]]),
-            torch.tensor([1, 1, 2, 1]),
+            torch.tensor([[1, 1, 2, 1]]),
         )
 
         actions, scores = self.parser(


### PR DESCRIPTION
Summary: DictEmbedding has three inputs: feats, weights, lengths. Because of legacy issue, lengths doesn't have batch dimension (flattened) while feats and weights have, this is confusing and doesn't work with the new GazetteerTensorizer. This diff added the batch dimension to it

Differential Revision: D15467816

