### PR TITLE
Minor debugging improvements

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -65,7 +65,7 @@ class ConfigBase(metaclass=ConfigBaseMeta):
 
     def __str__(self):
         lines = [self.__class__.__name__ + ":"]
-        for key, val in vars(self).items():
+        for key, val in sorted(self._asdict().items()):
             lines += f"{key}: {val}".split("\n")
         return "\n    ".join(lines)
 

--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -204,9 +204,9 @@ class RootDataSource(DataSource):
             example[name] = self.load(value, self.schema[name])
         if len(example) != len(self.schema):
             # We might need to re-evaluate this for multi-task training
-            logging.warn(
+            logging.warning(
                 "Skipping row missing values: row {} -> schema {}".format(
-                    list(example.keys()), list(self.schema.keys())
+                    list(row.keys()), list(self.schema.keys())
                 )
             )
             return None

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -221,7 +221,7 @@ class TensorizersTest(unittest.TestCase):
             test_file=None,
             eval_file=None,
             field_names=["text", "dict"],
-            schema={"text": str, "dict": str},
+            schema={"text": str, "dict": Gazetteer},
         )
 
         init = tensorizer.initialize()

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -138,7 +138,9 @@ class _NewTask(TaskBase):
         for tensorizer in tensorizers.values():
             for name, type in tensorizer.column_schema:
                 if name in schema and type != schema[name]:
-                    raise TypeError(f"Expected two different types for column {name}")
+                    raise TypeError(
+                        f"Unexpected different types for column {name}: {type} != {schema[name]}"
+                    )
                 schema[name] = type
 
         # This initializes the tensorizers


### PR DESCRIPTION
Summary:
small improvements to make debugging easier in some cases: better logging and debugging messages

- print all the class members in config objects, not just the locally-defined ones
- consistent order of config fields makes it easier to find what you're looking for
- skipped rows are often caused by mis-named column name: print the actual list of columns vs. the declared list of columns (not just the matching ones: the missing ones are the most important)
- tensorizers_test.py fix Gazetteer type to match the class declaration (not tested)
- new_task.py: when 2 tensorizers need the same column with different types (ie: List[float] for the main tsrz and str for metric reporter), we get this message. Add information that helps debug the issue and fix message.

Differential Revision: D15487889

