### PR TITLE
Fix nullable children in Tree Token

### DIFF
--- a/pytext/data/data_structures/annotation.py
+++ b/pytext/data/data_structures/annotation.py
@@ -355,10 +355,10 @@ class Token(Node):
     def __init__(self, label, index):
         super().__init__(label)
         self.index = index
-        self.children = None
+        self.children = []
 
     def validate_node(self):
-        if self.children is not None:
+        if len(self.children) != 0:
             raise TypeError(
                 "A token node is terminal and should not \
                     have children: "


### PR DESCRIPTION
Summary: With decoupled form it's possible that Token.children is None, which causes downstream error: https://our.intern.facebook.com/intern/fblearner/details/117596320?tab=operator_details

Differential Revision: D15531331

