### PR TITLE
Allow pad token to be set when building vocab

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -184,7 +184,7 @@ class TokenTensorizer(Tensorizer):
     def tensorize(self, batch):
         tokens, seq_lens, token_ranges = zip(*batch)
         return (
-            pad_and_tensorize(tokens, self.vocab.idx[PAD]),
+            pad_and_tensorize(tokens, self.vocab.get_pad_index()),
             pad_and_tensorize(seq_lens),
             pad_and_tensorize(token_ranges),
         )
@@ -336,7 +336,11 @@ class LabelTensorizer(Tensorizer):
 
     def _create_vocab(self):
         vocab = self.vocab_builder.make_vocab()
-        pad_idx = vocab.idx[PAD] if self.pad_in_vocab else Padding.DEFAULT_LABEL_PAD_IDX
+        pad_idx = (
+            vocab.get_pad_index()
+            if self.pad_in_vocab
+            else Padding.DEFAULT_LABEL_PAD_IDX
+        )
         return vocab, pad_idx
 
     def numberize(self, row):
@@ -681,7 +685,7 @@ class GazetteerTensorizer(Tensorizer):
 
         num_tokens = len(self.tokenizer.tokenize(row[self.text_column]))
         num_labels = max(len(t["features"]) for t in row[self.dict_column])
-        res_idx = [self.vocab.idx[PAD]] * (num_labels * num_tokens)
+        res_idx = [self.vocab.get_pad_index()] * (num_labels * num_tokens)
         res_weights = [0.0] * (num_labels * num_tokens)
         res_lens = [1] * num_tokens
         for dict_feature in row[self.dict_column]:
@@ -700,8 +704,8 @@ class GazetteerTensorizer(Tensorizer):
     def tensorize(self, batch):
         dict_feat_ids, weights, seq_lens = zip(*batch)
         return (
-            pad_and_tensorize(dict_feat_ids, self.vocab.idx[PAD]),
-            pad_and_tensorize(weights, self.vocab.idx[PAD]),
+            pad_and_tensorize(dict_feat_ids, self.vocab.get_pad_index()),
+            pad_and_tensorize(weights, self.vocab.get_pad_index()),
             pad_and_tensorize(seq_lens),
         )
 
@@ -845,13 +849,13 @@ class SeqTokenTensorizer(Tensorizer):
         for sentence in seq:
             pad_len = max_len - len(sentence)
             if pad_len:
-                sentence += [self.vocab.idx[PAD]] * pad_len
+                sentence += [self.vocab.get_pad_index()] * pad_len
         return seq, len(seq)
 
     def tensorize(self, batch):
         tokens, seq_lens = zip(*batch)
         return (
-            pad_and_tensorize(tokens, self.vocab.idx[PAD]),
+            pad_and_tensorize(tokens, self.vocab.get_pad_index()),
             pad_and_tensorize(seq_lens),
         )
 

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -138,7 +138,11 @@ class DocModel(Model):
 
     @classmethod
     def create_embedding(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        return create_module(config, tensorizer=tensorizers["tokens"])
+        return create_module(
+            config,
+            tensorizer=tensorizers["tokens"],
+            init_from_saved_state=config.init_from_saved_state,
+        )
 
     @classmethod
     def create_decoder(cls, config: Config, representation_dim: int, num_labels: int):

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -116,7 +116,7 @@ class DocModel(Model):
                 self.vocab = Vocabulary(input_vocab, unk_idx=input_vocab.idx[UNK])
                 self.model = traced_model
                 self.output_layer = output_layer
-                self.pad_idx = jit.Attribute(input_vocab.idx[PAD], int)
+                self.pad_idx = jit.Attribute(input_vocab.get_pad_index(), int)
 
             @jit.script_method
             def forward(self, tokens: List[List[str]]):

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -43,6 +43,7 @@ class WordEmbedding(EmbeddingBase):
         config: WordFeatConfig,
         metadata: Optional[FieldMeta] = None,
         tensorizer: Optional[Tensorizer] = None,
+        init_from_saved_state: Optional[bool] = False,
     ):
         """Factory method to construct an instance of WordEmbedding from
         the module's config object and the field's metadata object.
@@ -58,7 +59,7 @@ class WordEmbedding(EmbeddingBase):
         """
         if tensorizer is not None:
             embeddings_weight = None
-            if config.pretrained_embeddings_path:
+            if config.pretrained_embeddings_path and not init_from_saved_state:
                 pretrained_embedding = PretrainedEmbedding(
                     config.pretrained_embeddings_path,  # doesn't support fbpkg
                     lowercase_tokens=config.lowercase_tokens,

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -261,6 +261,10 @@ class Model(BaseModel):
         representation = None
         decoder = None
         output_layer = None
+        # This config flag tells the model whether its parameters are being
+        # loaded from saved state, hence it can skip certain initialization
+        # steps such as loading pre-trained embeddings from file
+        init_from_saved_state = False
 
     def __init__(
         self,

--- a/pytext/models/output_layers/lm_output_layer.py
+++ b/pytext/models/output_layers/lm_output_layer.py
@@ -37,7 +37,7 @@ class LMOutputLayer(OutputLayerBase):
     ):
         if labels is not None:
             vocab = list(labels)
-            pad_token_idx = labels.idx[PAD]
+            pad_token_idx = labels.get_pad_index()
         else:
             vocab = metadata.vocab.itos
             pad_token_idx = metadata.pad_token_idx

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -101,6 +101,7 @@ class _NewTask(TaskBase):
 
     @classmethod
     def _init_model(cls, config: Config, tensorizers, model_state=None):
+        config.model.init_from_saved_state = model_state is not None
         model = create_component(
             ComponentType.MODEL, config.model, tensorizers=tensorizers
         )


### PR DESCRIPTION
Summary: Some tokenization libraries (e.g. Assistant's featurization library) use special pad tokens, so we expose this in VocabBuilder so it can be configured

Differential Revision: D15534264

