### PR TITLE
Add config flag to indicate whether model is being loaded from a saved model state

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -136,7 +136,11 @@ class DocModel(Model):
 
     @classmethod
     def create_embedding(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        return create_module(config.embedding, tensorizer=tensorizers["tokens"])
+        return create_module(
+            config.embedding,
+            tensorizer=tensorizers["tokens"],
+            init_from_saved_state=config.init_from_saved_state,
+        )
 
     @classmethod
     def create_decoder(cls, config: Config, representation_dim: int, num_labels: int):

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -43,6 +43,7 @@ class WordEmbedding(EmbeddingBase):
         config: WordFeatConfig,
         metadata: Optional[FieldMeta] = None,
         tensorizer: Optional[Tensorizer] = None,
+        init_from_saved_state: Optional[bool] = False,
     ):
         """Factory method to construct an instance of WordEmbedding from
         the module's config object and the field's metadata object.
@@ -58,7 +59,14 @@ class WordEmbedding(EmbeddingBase):
         """
         if tensorizer is not None:
             embeddings_weight = None
-            if config.pretrained_embeddings_path:
+            if config.pretrained_embeddings_path and (
+                # We don't need to load pretrained embeddings if we know the
+                # embedding weights are going to be loaded from a snapshot. The
+                # exception is if we rely on the pretrained embeddings to give us
+                # the vocab, in which case, we have to load it regardless.
+                config.vocab_from_pretrained_embeddings
+                or not init_from_saved_state
+            ):
                 pretrained_embedding = PretrainedEmbedding(
                     config.pretrained_embeddings_path,  # doesn't support fbpkg
                     lowercase_tokens=config.lowercase_tokens,

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -261,6 +261,17 @@ class Model(BaseModel):
         representation = None
         decoder = None
         output_layer = None
+        # This config flag tells the model whether its parameters are being
+        # loaded from saved state, hence it can skip certain initialization
+        # steps such as loading pre-trained embeddings from file.
+        #
+        # TODO (geoffreygoh): Using config for such a purpose is really a hack,
+        # and the alternative is either to pickle model objects directly so we
+        # can skip initialization, or to pass this flag as an additional param
+        # to create_model (which will involve changing from_config method of
+        # every model in the repository). Clean this up once the above pickling
+        # solution is fully explored.
+        init_from_saved_state = False
 
     def __init__(
         self,

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -101,6 +101,7 @@ class _NewTask(TaskBase):
 
     @classmethod
     def _init_model(cls, config: Config, tensorizers, model_state=None):
+        config.model.init_from_saved_state = model_state is not None
         model = create_component(
             ComponentType.MODEL, config.model, tensorizers=tensorizers
         )


### PR DESCRIPTION
Summary:
We need some way to indicate during initialization that the model is being loaded from a saved snapshot model state, so that we can do things such as skipping the loading of pretrained embeddings (since the embedding state is already stored in the saved state).

In the old design, where we still had metadata, we had a somewhat hacky solution: First, the pretrained embeddings were not saved in the metadata in the snapshot (https://fburl.com/skhq8gb8), second, the data handler would skip loading the pretrained embeddings if metadata is already loaded (https://fburl.com/q46dezei, `init_metadata` method is what loads the pretrained embeddings from file).

For the new design, I can think of a few options:

1. Add an extra argument to model from_config function. However, this would require changing every single model in PyText that overrides that function :(

2. Create a global context map that we can use to store something like this. This is probably the better solution, however that will need some design discussion

3. The solution in this diff. While overriding config value in this way is probably a misuse of config, it is a temporary hack that will help me to unblock the migration of Assistant models to the new module design.

Differential Revision: D15534210

