### PR TITLE
disjoint multitask metric reporter bug fix

### DIFF
--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -49,8 +49,8 @@ class DisjointMultitaskMetricReporter(MetricReporter):
 
     def batch_context(self, raw_batch, batch):
         context = {BatchContext.TASK_NAME: batch[BatchContext.TASK_NAME]}
-        for reporter in self.reporters.values():
-            context.update(reporter.batch_context(raw_batch, batch))
+        reporter = self.reporters[context[BatchContext.TASK_NAME]]
+        context.update(reporter.batch_context(raw_batch, batch))
         return context
 
     def add_batch_stats(


### PR DESCRIPTION
Summary: Batch context should only be called for current tasks reporter.

Differential Revision: D15588293

