### PR TITLE
EASY [PyText] better create_component error message

### DIFF
--- a/pytext/config/component.py
+++ b/pytext/config/component.py
@@ -149,7 +149,10 @@ def register_tasks(task_cls: Union[Type, List[Type]]):
 def create_component(component_type: ComponentType, config: Any, *args, **kwargs):
     config_cls = type(config)
     cls = Registry.get(component_type, config_cls)
-    return cls.from_config(config, *args, **kwargs)
+    try:
+        return cls.from_config(config, *args, **kwargs)
+    except TypeError as e:
+        raise Exception(f"Can't create component {cls}: {str(e)}")
 
 
 def create_data_handler(data_handler_config, *args, **kwargs):


### PR DESCRIPTION
Summary:
default exception message only gives the missing arguments, not
which class it's missing from, which makes hunting down the source hard.

This diff prints the class causing the error.

Differential Revision: D15590535

