### PR TITLE
fix BPE tokenizer

### DIFF
--- a/pytext/utils/torch.py
+++ b/pytext/utils/torch.py
@@ -181,6 +181,11 @@ class BPE(torch.jit.ScriptModule):
     def from_vocab_file(cls, vocab_file: io.IOBase) -> "BPE":
         return cls(cls.load_vocab(vocab_file))
 
+    @classmethod
+    def from_vocab_filename(cls, vocab_filename: str) -> "BPE":
+        with open(vocab_filename) as vocab_file:
+            return cls(cls.load_vocab(vocab_file))
+
     @staticmethod
     def load_vocab(file: io.IOBase) -> Dict[str, int]:
         def read_words(lines):


### PR DESCRIPTION
Summary:
We had a bug that we were trying to initialize BPE directly with the vocab filename, instead of with a dictionary. see f118561131
1. add a helper method to open the vocab file
2. call it from the bpe tokenizer

Differential Revision: D15608051

