### PR TITLE
Fix bug in StackedBidirectionalRNN for input with batch_size = 1

### DIFF
--- a/pytext/data/sources/squad.py
+++ b/pytext/data/sources/squad.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 import json
 from typing import List, Optional
 
 from pytext.data.sources.data_source import DataSource, generator_property
+from pytext.data.sources.tsv import TSV, SafeFileWrapper
 
 
-def unflatten(fname, ignore_impossible):
+def get_json_iter(fname, ignore_impossible):
     if not fname:
         return
     with open(fname) as file:
@@ -32,6 +34,23 @@ def unflatten(fname, ignore_impossible):
                     }
 
 
+def get_tsv_iter(file_path, field_names, delimiter):
+    for row in iter(
+        TSV(
+            SafeFileWrapper(file_path, encoding="utf-8", errors="replace"),
+            field_names=field_names,
+            delimiter=delimiter,
+        )
+    ):
+        yield {
+            "doc": row["doc"],
+            "question": row["question"],
+            "answers": json.loads(row["answers"]),
+            "answer_starts": json.loads(row["answer_starts"]),
+            "has_answer": json.loads(row["has_answer"]),
+        }
+
+
 class SquadDataSource(DataSource):
     """
     Download data from https://rajpurkar.github.io/SQuAD-explorer/
@@ -43,6 +62,15 @@ class SquadDataSource(DataSource):
         test_filename: Optional[str] = "dev-v2.0.json"
         eval_filename: Optional[str] = "dev-v2.0.json"
         ignore_impossible: bool = True
+        is_json: bool = True
+        field_names: List[str] = [
+            "doc",
+            "question",
+            "answers",
+            "answer_starts",
+            "has_answer",
+        ]
+        delimiter: str = "\t"
 
     @classmethod
     def from_config(cls, config: Config, schema=None):
@@ -51,6 +79,9 @@ class SquadDataSource(DataSource):
             config.test_filename,
             config.eval_filename,
             config.ignore_impossible,
+            config.is_json,
+            config.field_names,
+            config.delimiter,
         )
 
     def __init__(
@@ -59,6 +90,9 @@ class SquadDataSource(DataSource):
         test_filename=None,
         eval_filename=None,
         ignore_impossible=Config.ignore_impossible,
+        is_json=Config.is_json,
+        field_names=Config.field_names,
+        delimiter=Config.delimiter,
     ):
         schema = {
             "doc": str,
@@ -73,15 +107,30 @@ class SquadDataSource(DataSource):
         self.test_filename = test_filename
         self.eval_filename = eval_filename
         self.ignore_impossible = ignore_impossible
+        self.is_json = is_json
+        self.field_names = field_names
+        self.delimiter = delimiter
 
     @generator_property
     def train(self):
-        return unflatten(self.train_filename, self.ignore_impossible)
+        return (
+            get_json_iter(self.train_filename, self.ignore_impossible)
+            if self.is_json
+            else get_tsv_iter(self.train_filename, self.field_names, self.delimiter)
+        )
 
     @generator_property
     def test(self):
-        return unflatten(self.test_filename, self.ignore_impossible)
+        return (
+            get_json_iter(self.test_filename, self.ignore_impossible)
+            if self.is_json
+            else get_tsv_iter(self.train_filename, self.field_names, self.delimiter)
+        )
 
     @generator_property
     def eval(self):
-        return unflatten(self.eval_filename, self.ignore_impossible)
+        return (
+            get_json_iter(self.eval_filename, self.ignore_impossible)
+            if self.is_json
+            else get_tsv_iter(self.train_filename, self.field_names, self.delimiter)
+        )

--- a/pytext/models/representations/stacked_bidirectional_rnn.py
+++ b/pytext/models/representations/stacked_bidirectional_rnn.py
@@ -97,7 +97,7 @@ class StackedBidirectionalRNN(Module):
                 concat_layers = True else batch, max_seq_len, hidden_size
         """
         # Sort in descending order of sequence lengths.
-        seq_lengths = tokens_mask.eq(0).long().sum(1).squeeze()
+        seq_lengths = tokens_mask.eq(0).long().sum(1)
         seq_lengths_sorted, idx_of_sorted = torch.sort(
             seq_lengths, dim=0, descending=True
         )


### PR DESCRIPTION
Summary:
There's no need to squeeze after calling torch.Tenor.sum() because the sum function's default behavior is to squeeze the dimension along which the sum is done. Squeezing explicitly removes batch dimension when batch_size = 1 resulting in the exception

```
torch._C._VariableFunctions._pack_padded_sequence(input, lengths, batch_first)
RuntimeError: 'lengths' argument should be a 1D CPU int64 tensor
```

Differential Revision: D15609010

