### PR TITLE
make crossentropy fp16 friendly

### DIFF
--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -28,12 +28,12 @@ class CrossEntropyLoss(Loss):
         self.weight = weight
 
     def __call__(self, logits, targets, reduce=True):
-        return F.cross_entropy(
-            logits,
+        return F.nll_loss(
+            F.log_softmax(logits, 1, dtype=torch.float32),
             targets,
-            ignore_index=self.ignore_index,
-            reduction="elementwise_mean" if reduce else "none",
             weight=self.weight,
+            ignore_index=self.ignore_index,
+            reduction="mean" if reduce else "none",
         )
 
 


### PR DESCRIPTION
Summary: Do softmax in fp32 to maintain precision.

Differential Revision: D15613933

