### PR TITLE
Use stage when creating batches so that corresponding stage batch size can be used.

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -307,6 +307,6 @@ class Data(Component):
             return self.tensorizers[sort_key].sort_key(row.numberized[sort_key])
 
         batches = self.batcher.batchify(
-            numberized_rows, sort_key=(key if sort_key else None)
+            numberized_rows, sort_key=(key if sort_key else None), stage=stage
         )
         return pad_and_tensorize_batches(self.tensorizers, batches)


### PR DESCRIPTION
Summary: We don't pass the stage when calling `self.batcher.batchify()` in `Data.batches()` method. We should in order to use stage specific batch size.

Differential Revision: D15620401

