### PR TITLE
optimize in memory cache

### DIFF
--- a/pytext/data/test/data_test.py
+++ b/pytext/data/test/data_test.py
@@ -111,6 +111,30 @@ class DataTest(unittest.TestCase):
             self.tensorizers["labels"].vocab[batch["labels"][8]], "alarm/snooze_alarm"
         )
 
+    def test_create_batches_with_cache(self):
+        data = Data(
+            self.data_source,
+            self.tensorizers,
+            Batcher(train_batch_size=1),
+            in_memory=True,
+        )
+        list(data.batches(Stage.TRAIN))
+        self.assertEqual(10, len(data.numberized_cache[Stage.TRAIN]))
+
+        data1 = Data(
+            self.data_source,
+            self.tensorizers,
+            Batcher(train_batch_size=1),
+            in_memory=True,
+        )
+        with self.assertRaises(Exception):
+            # Concurrent iteration not supported
+            batches1 = data1.batches(Stage.TRAIN)
+            batches2 = data1.batches(Stage.TRAIN)
+            for _ in batches1:
+                for _ in batches2:
+                    continue
+
 
 class BatcherTest(unittest.TestCase):
     def test_batcher(self):


### PR DESCRIPTION
Summary:
Previously, we simply convert a generator into a list before training, which might take a lot time when dataset is large (could be 10+ or 20+ minutes),
In this new implementation, we construct cache during the first epoch, so that we could benefits cache from the following epochs and also resolve the problem of large overhead before training.

Differential Revision: D15635512

