### PR TITLE
Depends on torch nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,18 @@ _run:
     command: |
       sudo ./install_deps
       sudo pip install --progress-bar off pytest pytest-cov
+  install_pytorch_nightly: &install_pytorch_nightly
+    name: install_pytorch_nightly
+    command: |
+      sudo pip uninstall -y torch
+      sudo pip install --progress-bar off torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
 
 _do_tests: &do_tests
   - checkout
   - run: *install_system_deps
   - run: *install_test_deps
+  - run: *install_pytorch_nightly
   - run:
       name: run tests and gather coverag
       command: pytest --junitxml=test-reports/junit.xml --cov=pytext --cov-report=html:htmlcov
@@ -51,6 +57,7 @@ jobs:
             sudo pip install --upgrade pip
             sudo pip install -r docs_requirements.txt
             sudo pip install -r pytext/docs/requirements.txt
+      - run: *install_pytorch_nightly
       - run:
           name: build docs
           command: |

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,3 @@
-https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
 click
 future
 hypothesis<4.0


### PR DESCRIPTION
Summary: make torch nightly as dependency because some of the latest TorchScript features are required for JIT models

Differential Revision: D15675568

