### PR TITLE
allow layernorm in mlp decoder

### DIFF
--- a/pytext/models/decoders/mlp_decoder.py
+++ b/pytext/models/decoders/mlp_decoder.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 import torch
 import torch.nn as nn
+from fairseq.modules import LayerNorm
 
 from .decoder_base import DecoderBase
 
@@ -36,6 +37,7 @@ class MLPDecoder(DecoderBase):
 
         hidden_dims: List[int] = []
         out_dim: Optional[int] = None
+        layer_norm: bool = False
 
     def __init__(self, config: Config, in_dim: int, out_dim: int = 0) -> None:
         super().__init__(config)
@@ -44,6 +46,8 @@ class MLPDecoder(DecoderBase):
         for dim in config.hidden_dims or []:
             layers.append(nn.Linear(in_dim, dim))
             layers.append(nn.ReLU())
+            if config.layer_norm:
+                layers.append(LayerNorm(dim))
             in_dim = dim
         if config.out_dim:
             out_dim = config.out_dim


### PR DESCRIPTION
Summary: Option to have LayerNorm between decoder layers.

Differential Revision: D15706411

