### PR TITLE
migrate FP16_Optimizer to unified API

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -115,7 +115,6 @@ class _NewTask(TaskBase):
         if model_state:
             model.load_state_dict(model_state)
 
-        precision.activate(model)
         if cuda.CUDA_ENABLED:
             model = model.cuda()
 

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -103,7 +103,6 @@ class TaskBase(Component):
         if model_state:
             model.load_state_dict(model_state)
 
-        precision.activate(model)
         if cuda.CUDA_ENABLED:
             model = model.cuda()
         metric_reporter = create_metric_reporter(task_config.metric_reporter, metadata)


### PR DESCRIPTION
Summary:
Reference: https://nvidia.github.io/apex/amp.html#advanced-use-cases

```
model, optimizer = amp.initialize(model, optimizer, opt_level="O1")

with amp.scale_loss(loss, optimizer) as scaled_loss:
    scaled_loss.backward()

torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), max_norm)
```

Differential Revision: D15707600

