### PR TITLE
Plumb row index to metric reporter

### DIFF
--- a/pytext/common/constants.py
+++ b/pytext/common/constants.py
@@ -84,3 +84,7 @@ class Stage(Enum):
     TRAIN = "Training"
     EVAL = "Evaluation"
     TEST = "Test"
+
+
+class RawExampleFieldName:
+    ROW_INDEX = "row_index"

--- a/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
+++ b/pytext/metric_reporters/intent_slot_detection_metric_reporter.py
@@ -3,7 +3,12 @@
 
 from typing import Dict, List, Optional, Tuple
 
-from pytext.common.constants import BatchContext, DatasetFieldName, Stage
+from pytext.common.constants import (
+    BatchContext,
+    DatasetFieldName,
+    RawExampleFieldName,
+    Stage,
+)
 from pytext.data import CommonMetadata
 from pytext.data.data_structures.annotation import CLOSE, OPEN, escape_brackets
 from pytext.metrics.intent_slot_metrics import (
@@ -216,7 +221,9 @@ class IntentSlotMetricReporter(MetricReporter):
                 ",".join([str(x) for x in row[self.slot_column_name]])
                 for row in raw_batch
             ],
-            BatchContext.INDEX: [x for x in range(len(raw_batch))],
+            BatchContext.INDEX: [
+                row[RawExampleFieldName.ROW_INDEX] for row in raw_batch
+            ],
         }
 
     def get_model_select_metric(self, metrics):


### PR DESCRIPTION
Summary: The row indices were previously plumbed to the metric reporters, whereas in the new behaviour (after D15593875), the indicies are just the indices within the batch. These indices are important in joining with domain info when calculating and evaluating per-domain metrics in the NLU integration tests, which should hopefully be fixed in this diff.

Differential Revision: D15722005

