### PR TITLE
minor fix of compositional data handler

### DIFF
--- a/pytext/data/compositional_data_handler.py
+++ b/pytext/data/compositional_data_handler.py
@@ -102,6 +102,7 @@ class CompositionalDataHandler(DataHandler):
             test_batch_size=config.test_batch_size,
             shuffle=config.shuffle,
             sort_within_batch=config.sort_within_batch,
+            column_mapping=config.column_mapping,
             **kwargs,
         )
 


### PR DESCRIPTION
Summary: column_mapping is not passed when init

Differential Revision: D15724276

