### PR TITLE
EASY [PyText] fix --include to work with subdirectories

### DIFF
--- a/pytext/builtin_task.py
+++ b/pytext/builtin_task.py
@@ -47,7 +47,7 @@ def add_include(path):
         if os.path.isfile(f) and not f.endswith("__init__.py")
     ]
     for mod_name in all:
-        mod_path = path + "." + mod_name
+        mod_path = path.replace("/", ".") + "." + mod_name
         eprint("... importing module:", mod_path)
         my_module = importlib.import_module(mod_path)
 


### PR DESCRIPTION
Summary:
--include only works with top directories. This diff fixes the
import path to replace / with . from file path to get a module

Differential Revision: D15745509

