### PR TITLE
Change rnng jit output format

### DIFF
--- a/pytext/models/semantic_parsers/rnng/jit/inference.py
+++ b/pytext/models/semantic_parsers/rnng/jit/inference.py
@@ -53,8 +53,7 @@ class RNNGInference(jit.ScriptModule):
                 res.append(tokens[token_idx])
                 token_idx += 1
             else:
-                res.append(self.OPEN_BRACKET)
-                res.append(self.action_vocab.lookup_word(action))
+                res.append(self.OPEN_BRACKET + self.action_vocab.lookup_word(action))
         return res
 
     @jit.script_method

--- a/pytext/models/test/rnng_jit_test.py
+++ b/pytext/models/test/rnng_jit_test.py
@@ -114,15 +114,5 @@ class RNNGJitTest(unittest.TestCase):
             self.inference_model.actions_to_seqlogical(
                 torch.tensor([2, 0, 0, 3, 0, 1, 1]), ["cancel", "the", "call"]
             ),
-            [
-                "[",
-                "IN:END_CALL",
-                "cancel",
-                "the",
-                "[",
-                "SL:METHOD_CALL",
-                "call",
-                "]",
-                "]",
-            ],
+            ["[IN:END_CALL", "cancel", "the", "[SL:METHOD_CALL", "call", "]", "]"],
         )


### PR DESCRIPTION
Summary: open bracket should be part of intent/slot labels in seqlogical tokens

Differential Revision: D15752351

