### PR TITLE
Fixing condition in tokenization util

### DIFF
--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -112,7 +112,7 @@ class Vocabulary:
 
     def lookup_all(self, nested_values):
         res, unk_counter, total = self.lookup_all_internal(nested_values)
-        if (unk_counter / total) > 0.8 and total > 1:
+        if total > 1 and (unk_counter / total) > 0.8:
             print(f"{unk_counter / total} of tokens not in vocab:", flush=True)
             print(f"{nested_values}", flush=True)
         return res


### PR DESCRIPTION
Summary: One liner to fix order of conditions that is causing an exception in pre-training.

Differential Revision: D15781268

