### PR TITLE
Combine KLDivergenceBCELoss with SoftHardBCELoss and F.cross_entropy() in CrossEntropyLoss

### DIFF
--- a/pytext/loss/__init__.py
+++ b/pytext/loss/__init__.py
@@ -12,7 +12,6 @@ from .loss import (
     MSELoss,
     NLLLoss,
     PairwiseRankingLoss,
-    SoftHardBCELoss,
 )
 
 
@@ -25,7 +24,6 @@ __all__ = [
     "KLDivergenceCELoss",
     "MSELoss",
     "NLLLoss",
-    "SoftHardBCELoss",
     "PairwiseRankingLoss",
     "LabelSmoothedCrossEntropyLoss",
 ]

--- a/pytext/models/output_layers/doc_classification_output_layer.py
+++ b/pytext/models/output_layers/doc_classification_output_layer.py
@@ -14,7 +14,6 @@ from pytext.loss import (
     CrossEntropyLoss,
     KLDivergenceBCELoss,
     KLDivergenceCELoss,
-    SoftHardBCELoss,
 )
 from pytext.utils.label import get_label_weights
 from torch import jit
@@ -44,7 +43,6 @@ class ClassificationOutputLayer(OutputLayerBase):
             AUCPRHingeLoss.Config,
             KLDivergenceBCELoss.Config,
             KLDivergenceCELoss.Config,
-            SoftHardBCELoss.Config,
         ] = CrossEntropyLoss.Config()
         label_weights: Optional[Dict[str, float]] = None
 

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -19,7 +19,7 @@ from pytext.config.field_config import FeatureConfig
 from pytext.data import DataHandler
 from pytext.data.featurizer import Featurizer, SimpleFeaturizer
 from pytext.exporters import ModelExporter
-from pytext.loss import KLDivergenceBCELoss, KLDivergenceCELoss, SoftHardBCELoss
+from pytext.loss import KLDivergenceBCELoss, KLDivergenceCELoss
 from pytext.metric_reporters import MetricReporter
 from pytext.models import Model
 from pytext.trainers import Trainer
@@ -76,11 +76,7 @@ class TaskBase(Component):
         if hasattr(task_config.labels, "target_prob"):
             assert task_config.labels.target_prob == isinstance(
                 task_config.model.output_layer.loss,
-                (
-                    KLDivergenceBCELoss.Config,
-                    KLDivergenceCELoss.Config,
-                    SoftHardBCELoss.Config,
-                ),
+                (KLDivergenceBCELoss.Config, KLDivergenceCELoss.Config),
             ), "target_prob must be set to True for KD losses"
         featurizer = create_featurizer(task_config.featurizer, task_config.features)
         # load data


### PR DESCRIPTION
Summary:
1. By virtue of its name `KLDivergenceBCELoss` should take care of BCELoss with hard targets but it doesn't. On the other hand SoftHardBCELoss does exactly that. Combining the two.
2. Using `F.cross_entropy()` in CrossEntropyLoss which is numerically more stable than doing `log_sftmax()` -> `nll_loss()`.

Differential Revision: D15795206

