### PR TITLE
remove output_encoded_layers from config

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -31,7 +31,9 @@ def find_dicts_containing_key(json_config, key):
 
 def rename(json_config, old_name, new_name):
     for section in find_dicts_containing_key(json_config, old_name):
-        section[new_name] = section.pop(old_name)
+        value = section.pop(old_name)
+        if new_name:
+            section[new_name] = value
 
 
 def is_type_specifier(json_dict):
@@ -429,6 +431,12 @@ def rename_bitransformer_inputs(json_config):
         char_config["offset_for_non_padding"] = 1
         model_val["inputs"]["bytes"] = char_config
 
+    return json_config
+
+
+@register_adapter(from_version=12)
+def remove_output_encoded_layers(json_config):
+    rename(json_config, "output_encoded_layers", None)
     return json_config
 
 

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -130,4 +130,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 12
+LATEST_VERSION = 13


### PR DESCRIPTION
Summary:
output_encoded_layers is a parameter which changes the output interface of transformer encoders.  There is only one correct way to set this for each model, so it should not be configurable.

Move it out of config and into model constuction.

Differential Revision: D15807477

