### PR TITLE
Make device as forward parameter

### DIFF
--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from pprint import pprint
 from typing import List, Optional
 
 from pytext.common.constants import BatchContext
-from pytext.config import ConfigBase, config_to_json
+from pytext.config import ConfigBase
 from pytext.config.component import (
     Component,
     ComponentType,


### PR DESCRIPTION
Summary:
Current device is constant attribute of the model, and can't be changed after training. This caused issue when loading the GPU trained model in inference time.

This diff fix the issue by making it a parameter of forward function, and hardcode it to cpu in inference model

Differential Revision: D15814606

