### PR TITLE
Implement dropout for slot-specific values

### DIFF
--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -97,6 +97,7 @@ class RNNGParser(BaseModel):
         constraints: RNNGConstraints = RNNGConstraints()
         max_open_NT: int = 10
         dropout: float = 0.1
+        slot_dropout: float = 0.0
         beam_size: int = 1
         top_k: int = 1
         compositional_type: CompositionalType = CompositionalType.BLSTM


### PR DESCRIPTION
Summary:
This diff tackles the problem of RNNG overfitting on slot-specific values. For example, "Call Mom" is a common utterance, and as a result, RNNG may overfit on the "Mom" token for other utterances to predict annotations scuh as ```[IN:CREATE_CALL call [SL:CONTACT Mom]]```.

Here, dropout is applied to a token embedding (before concatenation with the dictionary features) if the last non-shift, non-reduce oracle (gold) action was a slot (and not an intent).

Differential Revision: D15160322

