### PR TITLE
Move all token vocab creation to TokenTensorizer

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -137,4 +137,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 13
+LATEST_VERSION = 14

--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -211,6 +211,23 @@ class VocabBuilder:
         """Count a single value in the vocabulary."""
         self._counter[value] += 1
 
+    def add_from_file(self, file_pointer, skip_header_line, lowercase_tokens, size):
+        vocab_from_file = set()
+        if skip_header_line:
+            next(file_pointer)
+        for i, line in enumerate(file_pointer):
+            if size and len(vocab_from_file) == size:
+                print(
+                    f"Read {i + 1} items from vocab file and loaded {size} tokens. "
+                    f"Skipping rest of the file."
+                )
+                break
+            token = line.split()[0].strip()
+            if lowercase_tokens:
+                token = token.lower()
+            vocab_from_file.add(token)
+        self.add_all(sorted(vocab_from_file))
+
     def make_vocab(self) -> Vocabulary:
         """Build a Vocabulary object from the values seen by the builder."""
         tokens_to_insert: List[Tuple[int, object]] = []
@@ -237,6 +254,12 @@ class VocabBuilder:
             vocab_list.insert(index, token)
 
         return Vocabulary(vocab_list, counts=self._counter, pad_token=self.pad_token)
+
+    def truncate_to_vocab_size(self, vocab_size) -> None:
+        if len(self._counter) > vocab_size > 0:
+            self._counter = collections.Counter(
+                dict(self._counter.most_common(vocab_size))
+            )
 
 
 def align_target_labels(


### PR DESCRIPTION
Summary:
for the common models with word embeddings, the vocab for tokens is usually created in the `TokenTensorizer`'s initialize() method, then overwritten or added to during initialization of `WordEmbedding`. It's unexpected that a model's module initialization should alter the tensorizer's state, so vocab creation will now happen entirely in `TokenTensorizer` according two steps according to the flags:

- `build_vocab_from_data` - if True tokens from training data are added to vocab
  - `vocab_from_data_min_freq` - tokens with frequency below this are not added to vocab

- `vocab_file` - if provided tokens from this file are added to vocab
  - `vocab_file_skip_header_line`, `vocab_file_size_limit`, `vocab_file_lowercase` modify how to read the vocab file

If vocab is already provided to the tensorizer (e.g. the `BERTTensorizer` subclass), the above steps are skipped.

Pretrained word embeddings will be initialized as before - for each token in the final vocab, we try to look it up in the pretrained word embedding file and use it if there.

Differential Revision: D15835417

