### PR TITLE
fluent2 - init model and tensorizers from config

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -19,7 +19,7 @@ from pytext.data.data_structures.annotation import (
     is_valid_nonterminal,
 )
 from pytext.data.sources.data_source import Gazetteer
-from pytext.data.tokenizers import Token, Tokenizer
+from pytext.data.tokenizers import DoNothingTokenizer, Token, Tokenizer
 from pytext.utils import cuda
 from pytext.utils.data import Slot
 
@@ -146,7 +146,10 @@ class TokenTensorizer(Tensorizer):
         vocab_file=Config.vocab_file,
         vocab_file_size_limit=Config.vocab_file_size_limit,
     ):
-        super().__init__([(text_column, str)])
+        if isinstance(tokenizer, DoNothingTokenizer):
+            super().__init__([(text_column, List[str])])
+        else:
+            super().__init__([(text_column, str)])
         self.text_column = text_column
         self.tokenizer = tokenizer or Tokenizer()
         self.vocab = vocab
@@ -322,7 +325,10 @@ class ByteTokenTensorizer(Tensorizer):
         max_byte_len=Config.max_byte_len,
         offset_for_non_padding=Config.offset_for_non_padding,
     ):
-        super().__init__([(text_column, str)])
+        if isinstance(tokenizer, DoNothingTokenizer):
+            super().__init__([(text_column, List[str])])
+        else:
+            super().__init__([(text_column, str)])
         self.text_column = text_column
         self.tokenizer = tokenizer or Tokenizer()
         self.max_seq_len = max_seq_len or 2 ** 30  # large number

--- a/pytext/data/tokenizers/__init__.py
+++ b/pytext/data/tokenizers/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from .tokenizer import Token, Tokenizer
+from .tokenizer import DoNothingTokenizer, Token, Tokenizer
 
 
-__all__ = ["Token", "Tokenizer"]
+__all__ = ["Token", "Tokenizer", "DoNothingTokenizer"]

--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -47,3 +47,24 @@ class Tokenizer(Component):
             start = split_end
         tokens.append(Token(tokenize_input[start : len(input)], start, len(input)))
         return [token for token in tokens if token.value]
+
+
+class DoNothingTokenizer(Tokenizer):
+    """
+    Tokenizer that takes a list of strings and converts to a list of Tokens.
+    Used for Fluent2 integration, where tokenizer is run before-hand
+    """
+
+    class Config(Component.Config):
+        do_nothing: str = ""
+
+    @classmethod
+    def from_config(cls, config: Config):
+        return cls()
+
+    def __init__(self):
+        super().__init__(None)
+
+    def tokenize(self, input: List[str]) -> List[Token]:
+        tokens = [Token(token_text, -1, -1) for token_text in input if token_text]
+        return tokens

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -182,7 +182,7 @@ class NewDisjointMultitask(_NewTask):
         for name, task in task_config.tasks.items():
             tensorizers, data = NewTask._init_tensorizers(task, rank, world_size)
             data_dict[name] = data
-            models[name] = NewTask._init_model(task, tensorizers)
+            models[name] = NewTask._init_model(task.model, tensorizers)
             metric_reporters[name] = create_component(
                 ComponentType.METRIC_REPORTER,
                 task.metric_reporter,


### PR DESCRIPTION
Summary:
add tokenizers that accepts list of strings and returns list of tokens, to allow fluent2 to work with any tensorizer.
init tensorizers and models from config, to allow more flexability

Differential Revision: D15869522

