### PR TITLE
(Easy)Echo epoch number to console while training

### DIFF
--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -84,6 +84,7 @@ class ConsoleChannel(Channel):
         *args,
     ):
         print(f"\n\n{stage}")
+        print(f"Epoch:{epoch}")
         print(f"loss: {loss:.6f}")
         # TODO change print_metrics function to __str__ T33522209
         if hasattr(metrics, "print_metrics"):


### PR DESCRIPTION
Summary:
We output a bunch of training metrics to the console, but not the epoch number. This diff adds epoch number - very useful to monitor progress of long training runs

Output before diff:
`Stage.EVAL`
`loss: 1.219663`
`Accuracy: 96.70`

Output after diff:
`Stage.EVAL`
**`Epoch:10`**
`loss: 1.219663`
`Accuracy: 96.70`

Differential Revision: D15924282

