### PR TITLE
pytext - add metric reporter columns to schema

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -95,6 +95,17 @@ class _NewTask(TaskBase):
                     )
                 schema[name] = type
 
+        if hasattr(config.metric_reporter, "text_column_names"):
+            for text_column in config.metric_reporter.text_column_names:
+                if text_column in schema and schema[text_column] != str:
+                    raise TypeError(
+                        f"""
+                        Unexpected different types for column {text_column}:
+                        {str} != {schema[text_column]}
+                        """
+                    )
+                schema[text_column] = str
+
         # This initializes the tensorizers
         data = create_component(
             ComponentType.DATA_HANDLER,


### PR DESCRIPTION
Summary:
currently, the column which metric reporter is looking at is not added to the schema.
This causes the code to fail, if the metric reporter is configed to look at a column for which no tensorizer is using.
This is needed when running OSS XLM on pre-processed data, but wanting to output raw text, for example for human evaluation of results.

Differential Revision: D15908650

