### PR TITLE
Remove token & byte token assertion

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -219,8 +219,6 @@ class ByteTokensDocumentModel(DocModel):
         word_tensorizer = config.inputs.tokens
         byte_tensorizer = config.inputs.token_bytes
         assert word_tensorizer.column == byte_tensorizer.column
-        assert word_tensorizer.tokenizer.items() == byte_tensorizer.tokenizer.items()
-        assert word_tensorizer.max_seq_len == byte_tensorizer.max_seq_len
 
         word_embedding = create_module(
             config.embedding, tensorizer=tensorizers["tokens"]


### PR DESCRIPTION
Summary: The token and byte token features in `ByteTokensDocumentModel` need to be the same length as they are concatenated, but we don't have to assert that the tokenizer configs are identical. It can be convenient to have different capitalizations of the features (lower-cased word embeddings, cased byte features), or a different append dialect option in multilingual mode). There already is a runtime check in `arrange_model_inputs`, so a failure in different tokenization will still happen reasonably early.

Differential Revision: D15975189

