### PR TITLE
knowledge distillation for fluent2 pytext

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -41,6 +41,11 @@ class ConfigBase(metaclass=ConfigBaseMeta):
     def _asdict(self):
         return {k: getattr(self, k) for k in type(self).__annotations__}
 
+    def _replace(self, **kwargs):
+        args = self._asdict()
+        args.update(kwargs)
+        return type(self)(**args)
+
     def __init__(self, **kwargs):
         """Configs can be constructed by specifying values by keyword.
         If a keyword is supplied that isn't in the config, or if a config requires


### PR DESCRIPTION
Summary:
Add knowledge distillation support to fluent2 PyTextDocumentClassifier transformer.

Look at the unit test added for an example of using the new behavior. At a high level, we add a "teacher_model_config" parameter which takes an optional DocModel.Config. If this is present, we train this model first, then use it to compute logits on the training/eval sets, and then train the final model based on these values with a SoftLabelTensorizer. We require the model_config to configure a loss function which is either KLDivergenceCELoss or KLDivergenceBCELoss.

Differential Revision: D15999729

