### PR TITLE
pytext multi-label support (#729)

### DIFF
--- a/pytext/loss/__init__.py
+++ b/pytext/loss/__init__.py
@@ -10,6 +10,7 @@ from .loss import (
     LabelSmoothedCrossEntropyLoss,
     Loss,
     MSELoss,
+    MultiLabelSoftMarginLoss,
     NLLLoss,
     PairwiseRankingLoss,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "Loss",
     "CrossEntropyLoss",
     "BinaryCrossEntropyLoss",
+    "MultiLabelSoftMarginLoss",
     "KLDivergenceBCELoss",
     "KLDivergenceCELoss",
     "MSELoss",

--- a/pytext/metric_reporters/__init__.py
+++ b/pytext/metric_reporters/__init__.py
@@ -2,7 +2,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .channel import Channel
-from .classification_metric_reporter import ClassificationMetricReporter
+from .classification_metric_reporter import (
+    ClassificationMetricReporter,
+    MultiLabelClassificationMetricReporter,
+)
 from .compositional_metric_reporter import CompositionalMetricReporter
 from .intent_slot_detection_metric_reporter import IntentSlotMetricReporter
 from .language_model_metric_reporter import LanguageModelMetricReporter
@@ -19,6 +22,7 @@ __all__ = [
     "Channel",
     "MetricReporter",
     "ClassificationMetricReporter",
+    "MultiLabelClassificationMetricReporter",
     "RegressionMetricReporter",
     "IntentSlotMetricReporter",
     "LanguageModelMetricReporter",

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -27,6 +27,7 @@ from pytext.metric_reporters import (
     CompositionalMetricReporter,
     IntentSlotMetricReporter,
     LanguageModelMetricReporter,
+    MultiLabelClassificationMetricReporter,
     PairwiseRankingMetricReporter,
     RegressionMetricReporter,
     SequenceTaggingMetricReporter,
@@ -184,6 +185,8 @@ class DocumentClassificationTask(NewTask):
         metric_reporter: ClassificationMetricReporter.Config = (
             ClassificationMetricReporter.Config()
         )
+        #   for multi-label classification task,
+        #   choose MultiLabelClassificationMetricReporter
 
 
 class DocumentRegressionTask(NewTask):


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/pytext/pull/729

Add multi-label support to Pytext training workflow including
* LabelListTensorizer to read label list
* MultiLabelSoftMarginLoss with n_hot_encoding encoding to calculate the loss of multi-label task
(need to take care of the padded -1 in n_hot_encoding)
* MultiLabelOutputLayer with predictions of all potential labels for each example
* LabelListPrediction(NamedTuple) for an example including
   * label_scores: List[float]
   * predicted_label: List[int]
   * expected_label: List[int]
* MultiLabelClassificationMetricReporter
  * compute_multi_label_classification_metrics with both predicted and expected labels in lists
  * compute_multi_label_soft_metrics with both predicted and expected labels in lists
* handle the label / label list inputs at the same time in channel.py
* In input arguments, users are able to choose
  * LabelTensorizer / LabelListTensorizer
  * BinaryClassificationOutputLayer/ MultiLabelOutputLayer / MulticlassOutputLayer
  * loss including BinaryCrossEntropyLoss, MultiLabelSoftMarginLoss, etc.
  * associated with loss, user can choose ClassificationMetricReporter / MultiLabelClassificationMetricReporter
* define@register_adapter(from_version=12) v11_to_v12 in config_adapter.py to make ClassificationMetricReporter expansible

* keep RECALL_AT_PRECISION_THREHOLDS as it was, users can change the values to test their data set (for example, add 0.7 into the list of thresholds)

It has been tested on single-label and multi-label examples for DocNN and BERT models

Differential Revision: D15777482

