### PR TITLE
Create AlternatingRandomizedBatchSampler

### DIFF
--- a/pytext/data/__init__.py
+++ b/pytext/data/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .batch_sampler import (
+    AlternatingRandomizedBatchSampler,
     BaseBatchSampler,
     EvalBatchSampler,
     RandomizedBatchSampler,
@@ -24,6 +25,7 @@ from .tensorizers import Tensorizer
 
 
 __all__ = [
+    "AlternatingRandomizedBatchSampler",
     "Batcher",
     "BaseBatchSampler",
     "BatchIterator",


### PR DESCRIPTION
Summary:
The AlternatingRandomizedBatchSampler is a RandomizedBatchSampler that alternates creating batches from two sets of keys. It takes two dictionaries of unnormalized iterator probabilities and chooses a batch using a key from the first dictionary using the corresponding probabilities and then a batch from the other dictionary the next round.

The AlternatingRandomizedBatchSampler is intended to be used during XLM pre-training to enforce a pattern of MLM, TLM, MLM, TLM tasks.

Differential Revision: D15931223

