### PR TITLE
(Easy) Bugfix for trainer not reporting eval results

### DIFF
--- a/tests/data/eval_data_tiny.tsv
+++ b/tests/data/eval_data_tiny.tsv
@@ -1,0 +1,3 @@
+alarm/time_left_on_alarm		How much time is left?
+alarm/set_alarm	23:38:datetime	Set my alarm on all days
+reminder/set_reminder	10:18:datetime,22:38:reminder/todo	remind me tomorrow to call my mom


### PR DESCRIPTION
Summary:
PyText FBLearner config has an option to report eval results (useful for hyperparameter search). That option doesn't quite work for some input configs.
This diff fixes the issue, and also adds a unit test (and changes another unit test) to check that reporting eval results works correctly for two different configs.

Differential Revision: D16033433

