### PR TITLE
pytext distributed training in fluent2

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -41,6 +41,11 @@ class ConfigBase(metaclass=ConfigBaseMeta):
     def _asdict(self):
         return {k: getattr(self, k) for k in type(self).__annotations__}
 
+    def _replace(self, **kwargs):
+        args = self._asdict()
+        args.update(kwargs)
+        return type(self)(**args)
+
     def __init__(self, **kwargs):
         """Configs can be constructed by specifying values by keyword.
         If a keyword is supplied that isn't in the config, or if a config requires

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -55,14 +55,9 @@ def _set_fp16(use_fp16: bool) -> None:
 
 
 def _set_distributed(
-    rank: int,
-    world_size: int,
-    dist_init_url: str,
-    device_id: int,
-    metadata: CommonMetadata,
+    rank: int, world_size: int, dist_init_url: str, device_id: int,
 ) -> None:
     if dist_init_url and world_size > 1:
-        assert metadata is not None
         distributed.dist_init(rank, world_size, dist_init_url, device_id)
 
 
@@ -114,7 +109,7 @@ def prepare_task(
     print("\nParameters: {}\n".format(config))
     _set_cuda(config.use_cuda_if_available, device_id, world_size)
     _set_fp16(config.use_fp16)
-    _set_distributed(rank, world_size, dist_init_url, device_id, metadata)
+    _set_distributed(rank, world_size, dist_init_url, device_id)
 
     if config.random_seed is not None:
         set_random_seeds(config.random_seed, config.use_deterministic_cudnn)


### PR DESCRIPTION
Summary:
Enable distributed training of PyText models in fluent2 via torch.multiprocessing.spawn.

This was a bit awkward to do as serializing tasks for sending to torch.multiprocessing.spawn isn't trivial. The easiest way to do it is to pass through the config objects directly, as they can pickle well.

In the future we should investigate making this easier so we can avoid the config interface; it looks like the third-party `dill` library would be good to investigate, as some simple testing showed that it could already serialize most of our tasks/models.

Differential Revision: D16015676

