### PR TITLE
adapt prediction workflow to new design

### DIFF
--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -199,6 +199,15 @@ class DocumentClassificationTask(NewTask):
         #   for multi-label classification task,
         #   choose MultiLabelClassificationMetricReporter
 
+    @classmethod
+    def format_prediction(cls, predictions, scores, context, target_names):
+        for prediction, score in zip(predictions, scores):
+            score_with_name = {n: s for n, s in zip(target_names, score.tolist())}
+            yield {
+                "prediction": target_names[prediction.data],
+                "score": score_with_name,
+            }
+
 
 class DocumentRegressionTask(NewTask):
     class Config(NewTask.Config):


### PR DESCRIPTION
Summary: the prediction workflow only supports the old design, migrate it to support the new design. since I found some recurring jobs set using the old design, I didn't completely remove the old design support, but making it rather separate so it's easy to get rid of the old design in the future.

Differential Revision: D16096788

