### PR TITLE
Reintroduce metrics export in new task

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -178,6 +178,11 @@ class _NewTask(TaskBase):
         precision.deactivate(model)
 
         unused_raw_batch, batch = next(iter(self.data.batches(Stage.TRAIN)))
+        if metric_channels:
+            print("Exporting metrics")
+            for mc in metric_channels:
+                mc.export(model, model.arrange_model_inputs(batch))
+
         print(f"Saving caffe2 model to: {export_path}")
         return model.caffe2_export(
             self.data.tensorizers, batch, export_path, export_onnx_path=export_onnx_path


### PR DESCRIPTION
Summary: We used to export to metrics in old task https://fburl.com/d48a54yb, this adds the same functionality in the new task

Differential Revision: D16106855

