### PR TITLE
Add HiveFloatListTensorizer, sort vocab in vocab builder

### DIFF
--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -5,6 +5,7 @@ import json
 import logging
 from typing import Dict, List, TypeVar
 
+import torch
 from pytext.config.component import Component, ComponentType
 from pytext.data.utils import shard
 from pytext.utils.data import Slot, parse_slot_string


### PR DESCRIPTION
Summary:
HiveFloatListTensorizer - When querying from Hive data source, we get the float list as a Tensor, not a string, so this new tensorizer handles that.

Sorting - Need this so that when model is reloaded and vocab is reinitialized, indices are in the same order.

Differential Revision: D16116153

