### PR TITLE
Change the create_optimizer()'s input parameters

### DIFF
--- a/pytext/config/component.py
+++ b/pytext/config/component.py
@@ -177,9 +177,9 @@ def create_model(model_config, *args, **kwargs):
     return create_component(ComponentType.MODEL, model_config, *args, **kwargs)
 
 
-def create_optimizer(optimizer_config, model: torch.nn.Module, *args, **kwargs):
+def create_optimizer(optimizer_config, model_params, *args, **kwargs):
     return create_component(
-        ComponentType.OPTIMIZER, optimizer_config, model, *args, **kwargs
+        ComponentType.OPTIMIZER, optimizer_config, model_params, *args, **kwargs
     )
 
 

--- a/pytext/optimizer/optimizers.py
+++ b/pytext/optimizer/optimizers.py
@@ -26,8 +26,8 @@ class Adagrad(torch.optim.Adagrad, Optimizer):
         super().__init__(parameters, lr=lr, weight_decay=weight_decay)
 
     @classmethod
-    def from_config(cls, config: Config, model: torch.nn.Module):
-        return cls(model.parameters(), config.lr, config.weight_decay)
+    def from_config(cls, config: Config, model_params):
+        return cls(model_params, config.lr, config.weight_decay)
 
 
 class Adam(torch.optim.Adam, Optimizer):
@@ -39,8 +39,8 @@ class Adam(torch.optim.Adam, Optimizer):
         super().__init__(parameters, lr=lr, weight_decay=weight_decay)
 
     @classmethod
-    def from_config(cls, config: Config, model: torch.nn.Module):
-        return cls(model.parameters(), config.lr, config.weight_decay)
+    def from_config(cls, config: Config, model_params):
+        return cls(model_params, config.lr, config.weight_decay)
 
 
 class SGD(torch.optim.SGD, Optimizer):
@@ -52,8 +52,8 @@ class SGD(torch.optim.SGD, Optimizer):
         super().__init__(parameters, lr=lr, momentum=momentum)
 
     @classmethod
-    def from_config(cls, config: Config, model: torch.nn.Module):
-        return cls(model.parameters(), config.lr, config.momentum)
+    def from_config(cls, config: Config, model_params):
+        return cls(model_params, config.lr, config.momentum)
 
 
 def learning_rates(optimizer):

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -102,7 +102,9 @@ class Trainer(TrainerBase):
         scheduler: Optional[Scheduler.Config] = None
 
     def __init__(self, config: Config, model: torch.nn.Module):
-        optimizer: torch.optim.Optimizer = create_optimizer(config.optimizer, model)
+        optimizer: torch.optim.Optimizer = create_optimizer(
+            config.optimizer, model.parameters()
+        )
         self.scheduler: torch.optim.lr_scheduler = (
             create_scheduler(config.scheduler, optimizer)
             if config.scheduler


### PR DESCRIPTION
Summary:
I changed the input of create_optimizer() from model to model_params in create_optimizer().
Since when creating the new optimizer wrapper, we need two versions of model_params.
If we cannot separate model and model params when creating the optimizer, we need to copy a model instead, which might be memory-inefficient.

Differential Revision: D16134253

