### PR TITLE
add left padding to dictionary field

### DIFF
--- a/pytext/fields/dict_field.py
+++ b/pytext/fields/dict_field.py
@@ -23,11 +23,13 @@ class DictFeatureField(VocabUsingField):
         pad_token=VocabMeta.PAD_TOKEN,
         unk_token=VocabMeta.UNK_TOKEN,
         batch_first=True,
+        left_pad=False,
         **kwargs,
     ):
         super().__init__(
             sequential=True,
             batch_first=batch_first,
+            pad_first=left_pad,
             tokenize=no_tokenize,
             use_vocab=True,
             pad_token=pad_token,
@@ -92,9 +94,16 @@ class DictFeatureField(VocabUsingField):
             ex_lengths.extend(feats_lengths)
             # Pad examples
             ex_padding = (max_ex_len - seq_len) * max_feat_len
-            ex_feats.extend([self.pad_token] * ex_padding)
-            ex_weights.extend([0.0] * ex_padding)
-            ex_lengths.extend([1] * (max_ex_len - seq_len))
+            if self.pad_first:
+                # left padding
+                ex_feats = [self.pad_token] * ex_padding + ex_feats
+                ex_weights = [0.0] * ex_padding + ex_weights
+                ex_lengths = [1] * (max_ex_len - seq_len) + ex_lengths
+            else:
+                # right padding
+                ex_feats.extend([self.pad_token] * ex_padding)
+                ex_weights.extend([0.0] * ex_padding)
+                ex_lengths.extend([1] * (max_ex_len - seq_len))
             all_feats.append(ex_feats)
             all_weights.append(ex_weights)
             all_lengths.append(ex_lengths)

--- a/pytext/fields/test/dict_field_test.py
+++ b/pytext/fields/test/dict_field_test.py
@@ -25,6 +25,7 @@ DICT_FEATS_STR = [
 ]
 WEIGHTS = [[0.0, 0.0, 0.0, 0.0, 1.0, 1.0], [0.0, 1.0]]
 LENGTHS = [[1, 1, 2], [1, 1]]
+# right padding
 PADDED_DICT_FEATS = [
     [
         VocabMeta.PAD_TOKEN,
@@ -48,6 +49,33 @@ PADDED_DICT_WEIGHTS = [[0.0, 0.0, 0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 0.0, 0.0,
 PADDED_LENGTHS = [[1, 1, 2], [1, 1, 1]]
 NUMERICAL_FEATS = np.array([[1, 1, 1, 1, 3, 2], [1, 1, 4, 1, 1, 1]])
 
+# left padding
+LEFT_PADDED_DICT_FEATS = [
+    [
+        VocabMeta.PAD_TOKEN,
+        VocabMeta.PAD_TOKEN,
+        VocabMeta.PAD_TOKEN,
+        VocabMeta.PAD_TOKEN,
+        "name",
+        "cities",
+    ],
+    [
+        VocabMeta.PAD_TOKEN,
+        VocabMeta.PAD_TOKEN,
+        VocabMeta.PAD_TOKEN,
+        VocabMeta.PAD_TOKEN,
+        "time",
+        VocabMeta.PAD_TOKEN,
+    ],
+]
+
+LEFT_PADDED_DICT_WEIGHTS = [
+    [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+    [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+]
+LEFT_PADDED_LENGTHS = [[1, 1, 2], [1, 1, 1]]
+LEFT_NUMERICAL_FEATS = np.array([[1, 1, 1, 1, 3, 2], [1, 1, 1, 1, 4, 1]])
+
 
 class DictFieldTest(unittest.TestCase):
     def setUp(self):
@@ -55,11 +83,12 @@ class DictFieldTest(unittest.TestCase):
             batch_first=True,
             pad_token=VocabMeta.PAD_TOKEN,
             unk_token=VocabMeta.UNK_TOKEN,
+            left_pad=False,
         )
         self.dict_field.build_vocab(FEATS_VOCAB)
         print(self.dict_field.vocab.stoi)
 
-    def test_pad_numericalize(self):
+    def test_right_pad_numericalize(self):
         minibatch = [dict_feat for dict_feat in zip(DICT_FEATS_STR, WEIGHTS, LENGTHS)]
         padded_feats, padded_weights, padded_lengths = self.dict_field.pad(minibatch)
 
@@ -70,6 +99,25 @@ class DictFieldTest(unittest.TestCase):
             (padded_feats, padded_weights, padded_lengths), device="cpu"
         )
         np.testing.assert_array_equal(feats.data.numpy(), NUMERICAL_FEATS)
+
+        precision._FP16_ENABLED = True
+        padded_feats, padded_weights, padded_lengths = self.dict_field.pad(minibatch)
+        self.assertTrue(len(padded_feats[0]) % 8 == 0)
+        self.assertTrue(len(padded_weights[0]) % 8 == 0)
+        precision._FP16_ENABLED = False
+
+    def test_left_pad_numericalize(self):
+        minibatch = [dict_feat for dict_feat in zip(DICT_FEATS_STR, WEIGHTS, LENGTHS)]
+        self.dict_field.pad_first = True
+        padded_feats, padded_weights, padded_lengths = self.dict_field.pad(minibatch)
+
+        self.assertEqual(padded_feats, LEFT_PADDED_DICT_FEATS)
+        self.assertEqual(padded_weights, LEFT_PADDED_DICT_WEIGHTS)
+        self.assertEqual(padded_lengths, LEFT_PADDED_LENGTHS)
+        feats, _, _ = self.dict_field.numericalize(
+            (padded_feats, padded_weights, padded_lengths), device="cpu"
+        )
+        np.testing.assert_array_equal(feats.data.numpy(), LEFT_NUMERICAL_FEATS)
 
         precision._FP16_ENABLED = True
         padded_feats, padded_weights, padded_lengths = self.dict_field.pad(minibatch)


### PR DESCRIPTION
Summary:
Currently dictionary field (for sparse features) only supports right padding, while inputs are left padded by default.

For example, assume input sequence is "hello world", with each token have two sparse features, and the maximum sequence length in current batch is 4. Then we have:

padded_tokens = ['unk', 'unk', 'hello', 'world']
padded_feats = ['hello_f1', 'hello_f2', 'world_f1', 'world_f2', 'unk', 'unk', 'unk', 'unk']

which creates misalignment between token inputs and feature inputs.

This diff add left padding as a config to dictionary field.

Differential Revision: D15981346

