### PR TITLE
Set default dropout of 0.3 for DeepCNN

### DIFF
--- a/pytext/models/representations/deepcnn.py
+++ b/pytext/models/representations/deepcnn.py
@@ -23,7 +23,7 @@ class DeepCNNRepresentation(RepresentationBase):
 
     class Config(RepresentationBase.Config):
         cnn: CNNParams = CNNParams()
-        dropout: float = 0
+        dropout: float = 0.3
 
     def __init__(self, config: Config, embed_dim: int) -> None:
         super().__init__(config)


### PR DESCRIPTION
Summary:
Set default dropout of 0.3 for DeepCNN

Created from Diffusion's 'Open in Editor' feature.

Differential Revision: D16079460

