### PR TITLE
changed lmlstm export names

### DIFF
--- a/pytext/models/language_models/lmlstm.py
+++ b/pytext/models/language_models/lmlstm.py
@@ -227,13 +227,13 @@ class LMLSTM(BaseModel):
         return tensor_dict["tokens"][0][:, 1:].contiguous()
 
     def get_export_input_names(self, tensorizers):
-        return ["tokens", "tokens_lens"]
+        return ["tokens_vals", "tokens_lens"]
 
     def get_export_output_names(self, tensorizers):
         return ["scores"]
 
     def vocab_to_export(self, tensorizers):
-        return {"tokens": list(tensorizers["tokens"].vocab)}
+        return {"tokens_vals": list(tensorizers["tokens"].vocab)}
 
     def forward(
         self, tokens: torch.Tensor, seq_len: torch.Tensor


### PR DESCRIPTION
Summary: Changes the LMLSTM input export names from tokens to tokens_vals to be consistent with other models in the new data design. In particular, this is required for the model to work with mobile_nets_converter.py.

Differential Revision: D16189771

