### PR TITLE
changed lm metric reporting

### DIFF
--- a/pytext/models/language_models/lmlstm.py
+++ b/pytext/models/language_models/lmlstm.py
@@ -224,7 +224,8 @@ class LMLSTM(BaseModel):
 
     def arrange_targets(self, tensor_dict):
         # Omit first token because it won't have a corresponding input
-        return tensor_dict["tokens"][0][:, 1:].contiguous()
+        tokens, seq_lens, _ = tensor_dict["tokens"]
+        return (tokens[:, 1:].contiguous(), seq_lens - 1)
 
     def get_export_input_names(self, tensorizers):
         return ["tokens", "tokens_lens"]


### PR DESCRIPTION
Summary:
Changed language model metric reporting to aggregate perplexity information directly. The previous calculation aggregated logits at each evaluation step, which could potentially be large tensors given large vocabulary sizes.

Future diff will merge this metric reporter with the BERT metric reporter, which does a similar calculation sans real-time metric reporting.

Differential Revision: D16189934

