### PR TITLE
created bilstm dropout condition

### DIFF
--- a/pytext/models/representations/bilstm.py
+++ b/pytext/models/representations/bilstm.py
@@ -95,7 +95,8 @@ class BiLSTM(RepresentationBase):
                 Shape of each state is (bsize x num_layers * num_directions x nhid).
 
         """
-        embedded_tokens = self.dropout(embedded_tokens)
+        if self.dropout.p > 0.0:
+            embedded_tokens = self.dropout(embedded_tokens)
 
         if states is not None:
             # convert (h0, c0) from (bsz x num_layers*num_directions x nhid) to


### PR DESCRIPTION
Summary: Only drops out embedded_tokens if there is a non-zero probability in the dropout layer. This prevents recomputing a dropout mask even when it isn't required.

Differential Revision: D16190467

