### PR TITLE
Sync metric reporter results on multiple gpus

### DIFF
--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -4,10 +4,11 @@ from typing import Dict, List
 
 import numpy as np
 import torch
-from pytext.common.constants import DatasetFieldName
+from pytext.common.constants import DatasetFieldName, Stage
 from pytext.config.component import Component, ComponentType
 from pytext.config.pytext_config import ConfigBase
 from pytext.metrics import RealtimeMetrics
+from pytext.utils import cuda
 from pytext.utils.meter import TimeMeter
 
 
@@ -37,7 +38,6 @@ class MetricReporter(Component):
     __COMPONENT_TYPE__ = ComponentType.METRIC_REPORTER
 
     lower_is_better: bool = False
-    realtime_report_freq: int = 500
 
     class Config(ConfigBase):
         output_path: str = "/tmp/test_out.txt"
@@ -98,8 +98,6 @@ class MetricReporter(Component):
         if DatasetFieldName.NUM_TOKENS in context:
             self.realtime_meters["tps"].update(context[DatasetFieldName.NUM_TOKENS])
             self.realtime_meters["ups"].update(1)
-        if n_batches and n_batches % self.realtime_report_freq == 0:
-            self.report_realtime_metric()
 
     def aggregate_preds(self, new_batch):
         self.aggregate_data(self.all_preds, new_batch)
@@ -197,6 +195,10 @@ class MetricReporter(Component):
         metrics = self.calculate_metric()
         model_select_metric = self.get_model_select_metric(metrics)
 
+        # print_to_channels is true only on gpu 0, but we need all gpus to sync
+        # metric
+        self.report_realtime_metric(stage)
+
         if print_to_channels:
             for channel in self.channels:
                 if stage in channel.stages:
@@ -213,20 +215,33 @@ class MetricReporter(Component):
                         self.get_meta(),
                         model,
                     )
-            self.report_realtime_metric()
 
         if reset:
             self._reset()
             self._reset_realtime()
         return metrics
 
-    def report_realtime_metric(self):
-        tps = self.realtime_meters["tps"].avg
-        ups = self.realtime_meters["ups"].avg
+    def report_realtime_metric(self, stage):
+        if stage != Stage.TRAIN:
+            return
+
+        samples_total = self.n_batches + 1
+        tps_total = self.realtime_meters["tps"].n
+        ups_total = self.realtime_meters["ups"].n
+        elapsed_time = self.realtime_meters["tps"].elapsed_time
+        result = [samples_total, tps_total, ups_total]
+
+        if cuda.DISTRIBUTED_WORLD_SIZE > 1:
+            tensor = torch.cuda.IntTensor(result)
+            torch.distributed.all_reduce(tensor)
+            result = tensor.data.tolist()[:]
+
+        tps = result[1] / elapsed_time
+        ups = result[2] / elapsed_time
 
         if not tps or not ups:
             return
-        metrics = RealtimeMetrics(samples=self.n_batches + 1, tps=tps, ups=ups)
+        metrics = RealtimeMetrics(samples=result[0], tps=tps, ups=ups)
         print(metrics, flush=True)
 
     def get_model_select_metric(self, metrics):

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -532,6 +532,8 @@ class TaskTrainer(Trainer):
                         *metric_data,
                         **metric_reporter.batch_context(raw_batch, batch),
                     )
+                if batch_id % self.config.num_samples_to_log_progress == 0:
+                    metric_reporter.report_realtime_metric(state.stage)
         # update gradients after #len(samples) forward & backward
         self.optimizer_step(state)
 


### PR DESCRIPTION
Summary: Currently metric_reporter only reports #samples, tps, ups on gpu 0. Call all_reduce to sync these values from all gpus.

Differential Revision: D16159174

