### PR TITLE
implemented lm scores reporting

### DIFF
--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -4,7 +4,8 @@ import math
 import time
 
 import torch
-from pytext.common.constants import DatasetFieldName, Stage
+import torch.nn.functional as F
+from pytext.common.constants import Stage
 from pytext.data import CommonMetadata
 from pytext.metrics.language_model_metrics import (
     LanguageModelMetric,
@@ -29,11 +30,21 @@ class LanguageModelMetricReporter(MetricReporter):
     RAW_TEXT_COLUMN = "text"
     lower_is_better = True
 
+    class Config(MetricReporter.Config):
+        aggregate_metrics: bool = True
+
     @classmethod
-    def from_config(cls, config, meta: CommonMetadata = None, tensorizers=None):
+    def from_config(cls, config: Config, meta: CommonMetadata = None, tensorizers=None):
         return cls(
-            [ConsoleChannel(), LanguageModelChannel((Stage.TEST,), config.output_path)]
+            [ConsoleChannel(), LanguageModelChannel((Stage.TEST,), config.output_path)],
+            tensorizers,
+            config.aggregate_metrics,
         )
+
+    def __init__(self, channels, tensorizers, aggregate_metrics):
+        super().__init__(channels)
+        self.tensorizers = tensorizers
+        self.aggregate_metrics = aggregate_metrics
 
     def add_batch_stats(
         self, n_batches, preds, targets, scores, loss, m_input, **context
@@ -43,6 +54,12 @@ class LanguageModelMetricReporter(MetricReporter):
         num_words_in_batch = targets[1].sum().item()
         self.aggregate_loss += loss * num_words_in_batch
         self.total_num_tokens += num_words_in_batch
+        if self.aggregate_metrics:
+            if isinstance(targets, tuple):
+                targets = targets[0]
+            scores = self.compute_scores(preds, targets)
+            self.aggregate_scores(scores)
+            self.aggregate_context(context)
 
     def calculate_loss(self) -> float:
         return self.aggregate_loss / float(self.total_num_tokens)
@@ -60,23 +77,37 @@ class LanguageModelMetricReporter(MetricReporter):
         return metrics.perplexity_per_word
 
     def batch_context(self, raw_batch, batch):
-        context = super().batch_context(raw_batch, batch)
+        context = {}
         if any(self.RAW_TEXT_COLUMN in row for row in raw_batch):
             context.update(
                 {
                     self.UTTERANCE_COLUMN: [
                         row.get(self.RAW_TEXT_COLUMN) for row in raw_batch
-                    ],
-                    DatasetFieldName.TARGET_SEQ_LENS: batch["tokens"][1],
+                    ]
                 }
             )
         return context
+
+    def compute_scores(self, pred, target):
+        logits, pad_idx = pred
+        scores = F.nll_loss(logits, target, ignore_index=pad_idx, reduction="none")
+        per_sentence_loss = (torch.exp(y[y != 0].mean()) for y in scores)
+        return map(lambda x: x.item(), per_sentence_loss)
+
+    def aggregate_scores(self, scores):
+        self.all_scores.extend(scores)
+
+    def aggregate_context(self, context):
+        for key, val in context.items():
+            if key not in self.all_context:
+                self.all_context[key] = []
+            self.all_context[key].extend(val)
 
 
 class MaskedLMMetricReporter(LanguageModelMetricReporter):
     @classmethod
     def from_config(cls, config, meta: CommonMetadata = None, tensorizers=None):
-        return cls([ConsoleChannel()])
+        return cls([ConsoleChannel()], tensorizers, config.aggregate_metrics)
 
     def add_batch_stats(
         self, n_batches, preds, targets, scores, loss, m_input, **context

--- a/pytext/models/output_layers/lm_output_layer.py
+++ b/pytext/models/output_layers/lm_output_layer.py
@@ -85,14 +85,14 @@ class LMOutputLayer(OutputLayerBase):
         return self.loss_fn(logit.view(-1, logit.size()[-1]), target.view(-1), reduce)
 
     def get_pred(
-        self, logit: torch.Tensor, *args, **kwargs
+        self, logits: torch.Tensor, *args, **kwargs
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Compute and return prediction and scores from the model.
         Prediction is computed using argmax over the word label/target space.
         Scores are softmax scores over the model logits.
 
         Args:
-            logit (torch.Tensor): Logits returned
+            logits (torch.Tensor): Logits returned
                 :class:`~pytext.models.language_models.lmlstm.LMLSTM`.
             targets (torch.Tensor): True words.
             context (Dict[str, Any]): Context is a dictionary of items
@@ -103,9 +103,8 @@ class LMOutputLayer(OutputLayerBase):
             Tuple[torch.Tensor, torch.Tensor]: Model prediction and scores.
 
         """
-        preds = torch.max(logit, 2)[1]
-        scores = F.log_softmax(logit, 2)
-        return preds, scores
+        logits = logits.permute(0, 2, 1)  # [bsz, vocab, seq_len]
+        return ((F.log_softmax(logits, 1), self.pad_token_idx), None)
 
     @staticmethod
     def calculate_perplexity(sequence_loss: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Summary: Implements scores reporting for the language model metric reporter. In this context, the score is the perplexity for each sentence in a batch. Additionally, scores aggregation can be memory intensive for large datasets, so there is a new option in the config to control the aggregation of metrics. If disabled, there will be no score reporting in the test_out file.

Differential Revision: D16207604

