### PR TITLE
EASY [PyText] fix doc sphinx deprecation warning

### DIFF
--- a/pytext/docs/source/conf.py
+++ b/pytext/docs/source/conf.py
@@ -201,5 +201,5 @@ class PatchedPythonDomain(PythonDomain):
 
 
 def setup(app):
-    app.override_domain(PatchedPythonDomain)
+    app.add_domain(PatchedPythonDomain, override=True)
     app.connect("builder-inited", run_apidoc)


### PR DESCRIPTION
Summary:
Before the fix, `make html` prints this warning.

  /Users/egaudet/src/pytext.src/pytext/docs/source/conf.py:204: RemovedInSphinx30Warning: app.override_domain() is deprecated. Use app.add_domain() with override option instead.

Differential Revision: D16228043

