### PR TITLE
removed bilstm dependence on seq_lengths

### DIFF
--- a/pytext/models/representations/bilstm.py
+++ b/pytext/models/representations/bilstm.py
@@ -115,7 +115,7 @@ class BiLSTM(RepresentationBase):
             # see https://github.com/pytorch/pytorch/issues/16664
             state = torch.zeros(
                 self.config.num_layers * (2 if self.config.bidirectional else 1),
-                seq_lengths.size(0),  # batch size
+                embedded_tokens.size(0),  # batch size
                 self.config.lstm_dim,
                 device=torch.cuda.current_device() if cuda.CUDA_ENABLED else None,
             )


### PR DESCRIPTION
Summary:
If seq_lengths is not provided as a parameter to BiLSTM and pack_sequence is disabled, then the BiLSTM representation should not use seq_lengths to initialize anything. This diff removes the dependence on seq_lengths in said scenarios by using the batch dimension of embedded_tokens to initialize zero hidden state.

This seemingly minor change makes a dramatic difference when exporting models to caffe2 because seq_lengths will no longer be a part of the model graph. This can give both latency and memory savings during inference, albeit small.

Differential Revision: D16229675

