### PR TITLE
improve cvs support in TSVDataSource

### DIFF
--- a/pytext/data/test/tsv_data_source_test.py
+++ b/pytext/data/test/tsv_data_source_test.py
@@ -30,6 +30,10 @@ class TSVDataSourceTest(unittest.TestCase):
         self.assertEqual({"label", "text"}, set(example))
 
     def test_quoting(self):
+        """
+        The text column of the first row of this file opens a quote but
+        does not close it.
+        """
         data_source = TSVDataSource(
             SafeFileWrapper(tests_module.test_file("test_tsv_quoting.tsv")),
             SafeFileWrapper(tests_module.test_file("test_tsv_quoting.tsv")),
@@ -40,6 +44,38 @@ class TSVDataSourceTest(unittest.TestCase):
 
         data = list(data_source.train)
         self.assertEqual(4, len(data))
+
+    def test_bad_quoting(self):
+        """
+        The text column of the first row of this file opens a quote but
+        does not close it.
+        """
+        data_source = TSVDataSource(
+            SafeFileWrapper(tests_module.test_file("test_tsv_quoting.tsv")),
+            SafeFileWrapper(tests_module.test_file("test_tsv_quoting.tsv")),
+            eval_file=None,
+            field_names=["label", "text"],
+            schema={"text": str, "label": str},
+            quoted=True,
+        )
+
+        data = list(data_source.train)
+        self.assertEqual(1, len(data))
+
+    def test_csv(self):
+        data_source = TSVDataSource(
+            SafeFileWrapper(tests_module.test_file("test_data_tiny_csv.tsv")),
+            test_file=None,
+            eval_file=None,
+            field_names=["label", "slots", "text"],
+            delimiter=",",
+            schema={"text": str, "label": str},
+            quoted=True,
+        )
+
+        for row in data_source.train:
+            self.assertEqual("alarm/set_alarm", row["label"])
+            self.assertTrue(row["text"].startswith("this is the text"))
 
     def test_read_test_data_source(self):
         data = list(self.data.test)

--- a/tests/data/test_data_tiny_csv.tsv
+++ b/tests/data/test_data_tiny_csv.tsv
@@ -1,0 +1,5 @@
+alarm/set_alarm,"16:24:datetime,39:57:datetime",this is the text,
+alarm/set_alarm,,this is the text,
+alarm/set_alarm,12:27:datetime,this is the text,
+alarm/set_alarm,,"this is the text, why not"
+alarm/set_alarm,12:37:datetime,"this is the text, it's good",


### PR DESCRIPTION
Summary:
TSVDataSource documentation for delimiter param says Change to "," for csv,
but csv files often have quoted fields and TSVDataSource does not support
quoted fields.

We cannot blindly force all fields starting with quotes to be treated as
quoted fields, because it drastically changes the behavior: unclosed quoted
fields will merge with the next row, swallowing \n characters until we find
the closing quote. Some data sets might contain unclosed fields with quotes
and rely on the current behavior.

This diff adds a parameter to the TSVDataSource config that allows users to
specify whether they want quoted fields. The default is False, which is the
current behavior.

Differential Revision: D16232774

