### PR TITLE
Renaming tokens export name for backward compatibiltiy

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -99,7 +99,7 @@ class DocModel(Model):
         return tensor_dict["labels"]
 
     def get_export_input_names(self, tensorizers):
-        res = ["tokens", "tokens_lens"]
+        res = ["tokens_vals", "tokens_lens"]
         if "dense" in tensorizers:
             res += ["float_vec_vals"]
         return res
@@ -108,7 +108,7 @@ class DocModel(Model):
         return ["scores"]
 
     def vocab_to_export(self, tensorizers):
-        return {"tokens": list(tensorizers["tokens"].vocab)}
+        return {"tokens_vals": list(tensorizers["tokens"].vocab)}
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
         exporter = ModelExporter(
@@ -249,7 +249,7 @@ class ByteTokensDocumentModel(DocModel):
         return model_inputs
 
     def get_export_input_names(self, tensorizers):
-        names = ["tokens", "token_bytes", "tokens_lens"]
+        names = ["tokens_vals", "token_bytes", "tokens_lens"]
         if "dense" in tensorizers:
             names.append("float_vec_vals")
         return names

--- a/pytext/models/joint_model.py
+++ b/pytext/models/joint_model.py
@@ -179,10 +179,10 @@ class IntentSlotModel(Model):
         return intent_tensor, slot_tensor
 
     def vocab_to_export(self, tensorizers):
-        return {"tokens": list(tensorizers["tokens"].vocab)}
+        return {"tokens_vals": list(tensorizers["tokens"].vocab)}
 
     def get_export_input_names(self, tensorizers):
-        return ["tokens", "tokens_lens"]
+        return ["tokens_vals", "tokens_lens"]
 
     def get_export_output_names(self, tensorizers):
         return ["doc_scores", "word_scores"]

--- a/pytext/models/semantic_parsers/rnng/rnng_parser.py
+++ b/pytext/models/semantic_parsers/rnng/rnng_parser.py
@@ -691,13 +691,13 @@ class RNNGParser(RNNGParserBase):
         return pad_and_tensorize(tensor_dict["actions"])
 
     def get_export_input_names(self, tensorizers):
-        return ["tokens", "tokens_lens"]
+        return ["tokens_vals", "tokens_lens"]
 
     def get_export_output_names(self, tensorizers):
         return ["scores"]
 
     def vocab_to_export(self, tensorizers):
-        ret = {"tokens": list(tensorizers["tokens"].vocab)}
+        ret = {"tokens_vals": list(tensorizers["tokens"].vocab)}
         if "actions" in tensorizers:
             ret["actions"] = list(tensorizers["actions"].vocab)
         return ret

--- a/pytext/models/word_model.py
+++ b/pytext/models/word_model.py
@@ -118,13 +118,13 @@ class WordTaggingModel(Model):
         return tensor_dict["labels"]
 
     def get_export_input_names(self, tensorizers):
-        return ["tokens", "tokens_lens"]
+        return ["tokens_vals", "tokens_lens"]
 
     def get_export_output_names(self, tensorizers):
         return ["word_scores"]
 
     def vocab_to_export(self, tensorizers):
-        return {"tokens": list(tensorizers["tokens"].vocab)}
+        return {"tokens_vals": list(tensorizers["tokens"].vocab)}
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
         exporter = ModelExporter(


### PR DESCRIPTION
Summary:
Fixing broken backward compatibility of keys in the caffe2 blob from tokens_vals_str to tokens_str.

This has impact on any infrastructure relying on blob key names to call Caffe2 or PyTorch models.

Differential Revision: D16225606

