### PR TITLE
edited target names during caffe2 export

### DIFF
--- a/pytext/models/output_layers/lm_output_layer.py
+++ b/pytext/models/output_layers/lm_output_layer.py
@@ -117,8 +117,11 @@ class LMOutputLayer(OutputLayerBase):
         output_name: str,
     ) -> List[core.BlobReference]:
         prob_out = predict_net.Softmax(output_name, axis=model_out.dim() - 1)
+        # prepend an underscore to target_names to avoid conflicts between
+        # existing cell names and target names
+        edited_target_names = [f"_{name}" for name in self.target_names]
         return OutputLayerUtils.gen_additional_blobs(
-            predict_net, prob_out, model_out, output_name, self.target_names
+            predict_net, prob_out, model_out, output_name, edited_target_names
         )
 
     @staticmethod


### PR DESCRIPTION
Summary:
The caffe2 predict_net can't be run more than once if a) a vocabulary item has the same name as a caffe2 cell and b) the target names (i.e. vocabulary) is exported along with the model.

For an example, let's say our vocabulary contains the word "10" and there is also a cell 10 in the caffe2 graph not associated with the vocab word. When the caffe2 model generates predictions, it will write word 10's score to its associated cell, which also happens to be called cell 10. Because of this, the original cell 10's contents will be overwritten, causing issues in the next run of the predict_net.

This diff introduces a fix by appending an underscore to the beginning of each vocabulary item, ensuring that its name will not conflict with existing cell names in the graph.

Differential Revision: D16257838

