### PR TITLE
PyText add list of additional fields in batch reader, run_model output file & knowledge distillation data files

### DIFF
--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -194,19 +194,36 @@ class RootDataSource(DataSource):
         #: to not map directly to the column names in the schema. This mapping will
         #: remap names from the raw data source to names in the schema.
         column_mapping: Dict[str, str] = {}
+        #: An optional additional_colname (such as post_id, page_id, page_url)
+        #: to be read into context so that it can be included in model output
+        #: file with other saving results
+        additional_colnames: List[str] = []
 
-    def __init__(self, schema: Schema, column_mapping: Dict[str, str] = ()):
+    def __init__(
+        self,
+        schema: Schema,
+        column_mapping: Dict[str, str] = (),
+        additional_colnames: List[str] = (),
+    ):
         super().__init__(schema)
         self.column_mapping = dict(column_mapping)
+        self.additional_colnames = list(additional_colnames)
 
     def _read_example(self, row):
         example = RawExample()
         for column_name, value in row.items():
             name = self.column_mapping.get(column_name, column_name)
-            if name not in self.schema:
-                continue
-            example[name] = self.load(value, self.schema[name])
-        if len(example) != len(self.schema):
+            if name in self.schema:
+                example[name] = self.load(value, self.schema[name])
+            else:
+                if name in self.additional_colnames:
+                    # default data type for additional_colname is string
+                    example[name] = self.load(value, str)
+                else:
+                    continue
+        if len(example) != len(self.schema) and not set(
+            self.additional_colnames
+        ).issubset(set(example)):
             # We might need to re-evaluate this for multi-task training
             logging.warning(
                 "Skipping row missing values: row {} -> schema {}".format(

--- a/pytext/metric_reporters/classification_metric_reporter.py
+++ b/pytext/metric_reporters/classification_metric_reporter.py
@@ -22,17 +22,32 @@ META_LABEL_NAMES = "label_names"
 
 
 class IntentModelChannel(FileChannel):
+    def __init__(self, stages, file_path, additional_colnames) -> None:
+        super().__init__(stages, file_path)
+        #: This list of additional columns can be included in the run_model
+        #: output file with other saving results
+        self.additional_colnames = additional_colnames
+
     def get_title(self):
-        return ("predicted", "actual", "scores_str", "text")
+        title = ("predicted", "actual", "scores_str", "text")
+        # if there are additional colnames, append them to title
+        if len(self.additional_colnames) > 0:
+            title = title + tuple(self.additional_colnames)
+        return title
 
     def gen_content(self, metrics, loss, preds, targets, scores, contexts):
         for i in range(len(preds)):
-            yield [
+            res = [
                 preds[i],
                 targets[i],
                 ",".join([f"{s:.2f}" for s in scores[i]]),
                 contexts["utterance"][i],
             ]
+            # if there are additional colnames, append their contexts to res
+            if len(self.additional_colnames) > 0:
+                for additional_colname in self.additional_colnames:
+                    res.append(contexts[additional_colname][i])
+            yield res
 
 
 class ComparableClassificationMetric(Enum):
@@ -59,6 +74,9 @@ class ClassificationMetricReporter(MetricReporter):
         #: columns (usually just 1 column) will be concatenated and output in
         #: the IntentModelChannel as an evaluation tsv.
         text_column_names: List[str] = ["text"]
+        #: This list of additional columns can be included in the context and run_model
+        #: output file with other saving results
+        additional_colnames: List[str] = []
         recall_at_precision_thresholds: List[float] = RECALL_AT_PRECISION_THRESHOLDS
 
     def __init__(
@@ -70,6 +88,7 @@ class ClassificationMetricReporter(MetricReporter):
         ),
         target_label: Optional[str] = None,
         text_column_names: List[str] = Config.text_column_names,
+        additional_colnames: List[str] = Config.additional_colnames,
         recall_at_precision_thresholds: List[float] = (
             Config.recall_at_precision_thresholds
         ),
@@ -79,6 +98,7 @@ class ClassificationMetricReporter(MetricReporter):
         self.model_select_metric = model_select_metric
         self.target_label = target_label
         self.text_column_names = text_column_names
+        self.additional_colnames = additional_colnames
         self.recall_at_precision_thresholds = recall_at_precision_thresholds
 
     @classmethod
@@ -107,10 +127,18 @@ class ClassificationMetricReporter(MetricReporter):
 
         return cls(
             label_names,
-            [ConsoleChannel(), IntentModelChannel((Stage.TEST,), config.output_path)],
+            [
+                ConsoleChannel(),
+                IntentModelChannel(
+                    stages=(Stage.TEST,),
+                    file_path=config.output_path,
+                    additional_colnames=config.additional_colnames,
+                ),
+            ],
             config.model_select_metric,
             config.target_label,
             config.text_column_names,
+            config.additional_colnames,
             config.recall_at_precision_thresholds,
         )
 
@@ -120,6 +148,12 @@ class ClassificationMetricReporter(MetricReporter):
             " | ".join(str(row[column_name]) for column_name in self.text_column_names)
             for row in raw_batch
         ]
+        # if there are additional colnames, read their contexts into batch
+        if len(self.additional_colnames) > 0:
+            for additional_colname in self.additional_colnames:
+                context[additional_colname] = [
+                    row[additional_colname] for row in raw_batch
+                ]
         return context
 
     def calculate_metric(self):


### PR DESCRIPTION
[The updated version] generalized the previous version (adding post_id). The main workflow can read list of addtional fields such as post_id, page_id, page_url into context,  then parse it along with classification metric reporter. Now PyText users are able to include these fields in the file of saving results, and it's useful to look into the details of the model output, explore other metric assocaited with team target, or look for other relevant info form hive table by searching on the fileds. Also, in knowledge distillation, each gen_kd_data[i] where i in {0,1,2} (training, validation, test) can handle label list for multi-label task, and include the additional fields as a dictionary in the generated data files, which is helpful for building teacher and student network for multi-label experiments.

In the debug file for the test dataset, one header example is
#predicted, actual, scores_str, text, post_id, post_url

In generating knowledge distillation data for training dataset, one header example is
#label_list, score, logit, label_names(in order), text, {"post_id": 123456, "post_url": http://post_url.com}

[The previous version] aimed at reading post_id and parsing it along with the output file, so that the file is useful for our metric calculation and building KD - teacher/student in our workflow in the following steps. Other users that have the same desired goal can use this Diff as a potentially alternative solution.

Differential Revision: D16271134

