### PR TITLE
implemented mobile exporter

### DIFF
--- a/pytext/config/module_config.py
+++ b/pytext/config/module_config.py
@@ -56,3 +56,8 @@ class Activation(Enum):
     TANH = "tanh"
     GELU = "gelu"
     GLU = "glu"
+
+
+class ExporterType(Enum):
+    PREDICTOR = "predictor"
+    INIT_PREDICT = "init_predict"

--- a/pytext/exporters/__init__.py
+++ b/pytext/exporters/__init__.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from pytext.exporters.custom_exporters import DenseFeatureExporter
+from pytext.exporters.custom_exporters import (
+    DenseFeatureExporter,
+    InitPredictNetExporter,
+)
 from pytext.exporters.exporter import ModelExporter
 
 
-__all__ = ["ModelExporter", "DenseFeatureExporter"]
+__all__ = ["ModelExporter", "DenseFeatureExporter", "InitPredictNetExporter"]

--- a/pytext/exporters/custom_exporters.py
+++ b/pytext/exporters/custom_exporters.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import Dict
+import os
+from typing import Dict, List
 
+from caffe2.python import core, workspace
 from pytext.config import ConfigBase
 from pytext.config.field_config import FeatureConfig, FloatVectorConfig
+from pytext.config.module_config import ExporterType
 from pytext.exporters.exporter import ModelExporter
 from pytext.fields import FieldMeta
+from pytext.utils import mobile_onnx
+
+
+def save_caffe2_pb_net(path, model):
+    with open(path, "wb") as f:
+        f.write(model.SerializeToString())
 
 
 class DenseFeatureExporter(ModelExporter):
@@ -50,3 +59,87 @@ class DenseFeatureExporter(ModelExporter):
             tuple(dummy_model_input_rep + dummy_model_input_dense),
             feature_itos_map_rep,
         )
+
+
+class InitPredictNetExporter(ModelExporter):
+    """
+    Exporter for converting models to their caffe2 init and predict nets.
+    Does not rely on c2_prepared, but rather splits the ONNX model into
+    the init and predict nets directly.
+
+    """
+
+    def prepend_operators(self, init_net, predict_net, input_names: List[str]):
+        return mobile_onnx.add_feats_numericalize_ops(
+            init_net, predict_net, self.vocab_map, input_names
+        )
+
+    def postprocess_output(
+        self, init_net, predict_net, workspace, output_names: List[str], model
+    ):
+        model_out = model(*self.dummy_model_input)
+        res = model.output_layer.export_to_caffe2(
+            workspace, init_net, predict_net, model_out, *output_names
+        )
+        final_output_names = [str(output) for output in res]
+        return (res, final_output_names)
+
+    def get_export_paths(self, path):
+        export_dir = os.path.dirname(path)
+        return (
+            os.path.join(export_dir, "init_net.pb"),
+            os.path.join(export_dir, "predict_net.pb"),
+        )
+
+    def export_to_caffe2(
+        self, model, export_path: str, export_onnx_path: str = None
+    ) -> List[str]:
+
+        init_net_path, predict_net_path = self.get_export_paths(export_path)
+        print(f"Saving caffe2 init net to {init_net_path}")
+        print(f"Saving caffe2 init net to {predict_net_path}")
+
+        init_net, predict_net = mobile_onnx.pytorch_to_caffe2(
+            model,
+            self.dummy_model_input,
+            self.input_names,
+            self.output_names,
+            export_path,
+            export_onnx_path,
+        )
+
+        # prepend operators
+        init_net, predict_net, final_input_names = self.prepend_operators(
+            init_net, predict_net, self.input_names
+        )
+        init_net = core.Net(init_net)
+        predict_net = core.Net(predict_net)
+
+        # postprocess input
+        mobile_onnx.create_context(init_net)
+        net_outputs, final_out_names = self.postprocess_output(
+            init_net, predict_net, workspace, self.output_names, model
+        )
+        for output in net_outputs:
+            predict_net.AddExternalOutput(output)
+
+        # convert nets to proto
+        init_net = init_net.Proto()
+        predict_net = predict_net.Proto()
+
+        # save proto files
+        save_caffe2_pb_net(init_net_path, init_net)
+        save_caffe2_pb_net(predict_net_path, predict_net)
+
+
+EXPORTER_MAP = {
+    ExporterType.PREDICTOR: ModelExporter,
+    ExporterType.INIT_PREDICT: InitPredictNetExporter,
+}
+
+
+def get_exporter(name):
+    exporter = EXPORTER_MAP.get(name, None)
+    if not exporter:
+        raise NotImplementedError
+    return exporter

--- a/pytext/exporters/exporter.py
+++ b/pytext/exporters/exporter.py
@@ -173,6 +173,9 @@ class ModelExporter(Component):
         Returns:
             final_output_names: list of caffe2 model output names
         """
+
+        print(f"Saving caffe2 model to: {export_path}")
+
         c2_prepared = onnx.pytorch_to_caffe2(
             model,
             self.dummy_model_input,

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -215,7 +215,6 @@ class _NewTask(TaskBase):
             for mc in metric_channels:
                 mc.export(model, model.arrange_model_inputs(batch))
 
-        print(f"Saving caffe2 model to: {export_path}")
         return model.caffe2_export(
             self.data.tensorizers, batch, export_path, export_onnx_path=export_onnx_path
         )

--- a/pytext/utils/mobile_onnx.py
+++ b/pytext/utils/mobile_onnx.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import itertools
+
+import numpy as np
+import onnx
+import torch
+from caffe2.python import core, utils, workspace
+from caffe2.python.onnx import backend as caffe2_backend
+from pytext.utils.onnx import convert_caffe2_blob_name
+
+
+def create_context(init_net):
+    workspace.ResetWorkspace()
+    assert workspace.RunNetOnce(init_net)
+
+
+def pytorch_to_caffe2(
+    model,
+    export_input,
+    external_input_names,
+    output_names,
+    export_path,
+    export_onnx_path=None,
+):
+    num_tensors = 0
+    for inp in export_input:
+        num_tensors += len(inp) if isinstance(inp, (tuple, list)) else 1
+    assert len(external_input_names) == num_tensors
+    all_input_names = external_input_names[:]
+    for name, _ in model.named_parameters():
+        all_input_names.append(name)
+    # export the pytorch model to ONNX
+    if export_onnx_path:
+        print(f"Saving onnx model to: {export_onnx_path}")
+    else:
+        export_onnx_path = export_path
+    model.eval()
+    with torch.no_grad():
+        torch.onnx.export(
+            model,
+            export_input,
+            export_onnx_path,
+            input_names=all_input_names,
+            output_names=output_names,
+            export_params=True,
+        )
+    onnx_model = onnx.load(export_onnx_path)
+    onnx.checker.check_model(onnx_model)
+    # split onnx model into init_net and predict_net
+    init_net, predict_net = caffe2_backend.Caffe2Backend.onnx_graph_to_caffe2_net(
+        onnx_model
+    )
+    return (init_net, predict_net)
+
+
+def add_feats_numericalize_ops(init_net, predict_net, vocab_map, input_names):
+    init_net, final_predict_net, final_input_names = get_numericalize_net(
+        init_net, predict_net, vocab_map, input_names
+    )
+
+    create_context(init_net)
+    init_net = init_net.Proto()
+    final_predict_net.Proto().op.extend(predict_net.op)
+    predict_net = final_predict_net.Proto()
+    return (init_net, predict_net, final_input_names)
+
+
+def get_numericalize_net(init_net, predict_net, vocab_map, input_names):
+    init_net = core.Net(init_net)
+    final_input_names = input_names.copy()
+
+    create_context(init_net)
+    vocab_indices = create_vocab_indices_map(init_net, vocab_map)
+
+    final_predict_net = core.Net(predict_net.name + "_processed")
+    final_inputs = set(
+        {ext_input for ext_input in input_names if ext_input not in vocab_map.keys()}
+    )
+
+    for ext_input in final_inputs:
+        final_predict_net.AddExternalInput(ext_input)
+
+    # add external_input and external_output from init_net
+    init_net_proto = init_net.Proto()
+    items = set(
+        {
+            item
+            for item in itertools.chain(
+                init_net_proto.external_input, init_net_proto.external_output
+            )
+        }
+    )
+    for item in items:
+        final_predict_net.AddExternalInput(item)
+
+    for feat in vocab_map.keys():
+        raw_input_blob = final_predict_net.AddExternalInput(
+            convert_caffe2_blob_name(feat)
+        )
+        flattened_input_blob = final_predict_net.FlattenToVec(raw_input_blob)
+        flattened_ids = final_predict_net.IndexGet(
+            [vocab_indices[feat], flattened_input_blob]
+        )
+        final_predict_net.ResizeLike([flattened_ids, raw_input_blob], [feat])
+        final_input_names[input_names.index(feat)] = convert_caffe2_blob_name(feat)
+
+    return (init_net, final_predict_net, final_input_names)
+
+
+def create_vocab_indices_map(init_net, vocab_map):
+    vocab_indices = {}
+    for feat_name, vocab in vocab_map.items():
+        assert len(vocab) > 1
+        vocab_indices[feat_name] = create_vocab_index(
+            np.array(vocab, dtype=str)[1:], init_net, workspace, feat_name + "_index"
+        )
+    return vocab_indices
+
+
+def create_vocab_index(vocab_list, net, net_workspace, index_name):
+    vocab_blob = net.AddExternalInput(f"{index_name}_vocab")
+
+    net.GivenTensorStringFill(
+        [],
+        [str(vocab_blob)],
+        arg=[
+            utils.MakeArgument("shape", vocab_list.shape),
+            utils.MakeArgument("values", vocab_list),
+        ],
+    )
+
+    vocab_index = net.StringIndexCreate([], index_name)
+    net.IndexLoad([vocab_index, vocab_blob], [vocab_index], skip_first_entry=0)
+    net.IndexFreeze([vocab_index], [vocab_index])
+
+    return vocab_index


### PR DESCRIPTION
Summary: Implements a model exporter that splits an onnx model into an init_net and predict_net, processes the nets to add vocab and output layer operators, and saves the proto files to disk. These disjoint proto files can then fully represent a model to be used on-device.

Differential Revision: D16268693

