### PR TITLE
Support using serialized pretrained embedding file

### DIFF
--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -68,14 +68,6 @@ class WordEmbedding(EmbeddingBase):
             # We don't need to load pretrained embeddings if we know the
             # embedding weights are going to be loaded from a snapshot.
             if config.pretrained_embeddings_path and not init_from_saved_state:
-                if not any(
-                    vocab_file.filepath == config.pretrained_embeddings_path
-                    for vocab_file in tensorizer.vocab_config.vocab_files
-                ):
-                    raise ValueError(
-                        f"Tensorizer's vocab files should include pretrained "
-                        f"embeddings file {config.pretrained_embeddings_path}."
-                    )
                 pretrained_embedding = PretrainedEmbedding(
                     config.pretrained_embeddings_path,  # doesn't support fbpkg
                     lowercase_tokens=config.lowercase_tokens,

--- a/pytext/utils/embeddings.py
+++ b/pytext/utils/embeddings.py
@@ -122,7 +122,12 @@ class PretrainedEmbedding(object):
         Cache the processed embedding vectors and vocab to a file for faster
         loading
         """
+        t = time.time()
+        print("loading cached pretrained embedding")
         torch.save((self.embed_vocab, self.stoi, self.embedding_vectors), cache_path)
+        print(
+            f"Embedding loaded: {self.embedding_vectors.size()} in {time.time() - t} s."
+        )
 
     def load_cached_embeddings(self, cache_path: str) -> None:
         """


### PR DESCRIPTION
Summary: loading raw embedding file is super slow comparing to the previous serialized version, this diff removed the check of comparing pretrained embedding file in vocab build config and word embedding config to enable using the serialized version

Differential Revision: D16381791

