### PR TITLE
add checkpoint save and load functions

### DIFF
--- a/pytext/task/serialize.py
+++ b/pytext/task/serialize.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import io
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 from pytext.config import PyTextConfig, config_to_json, pytext_config_from_json
 from pytext.data import CommonMetadata
 from pytext.data.tensorizers import Tensorizer
 from pytext.models import Model
-
-from .task import create_task
+from pytext.trainers.training_state import TrainingState
 
 
 DATA_STATE = "data_state"
@@ -18,8 +18,10 @@ CONFIG_JSON = "config_json"
 MODEL_STATE = "model_state"
 SERIALIZE_VERSION_KEY = "pytext_serialization_version"
 TENSORIZERS = "tensorizers"
+TRAINING_STATE = "training_state"
 
-LATEST_SERIALIZE_VERSION = 0
+
+LATEST_SERIALIZE_VERSION = 3
 LOADER_VERSION_MAP = {}
 
 
@@ -36,29 +38,50 @@ def register_snapshot_loader(version):
 def save(
     config: PyTextConfig,
     model: Model,
-    meta: CommonMetadata,
+    meta: Optional[CommonMetadata],
     tensorizers: Dict[str, Tensorizer],
+    training_state: Optional[TrainingState] = None,
+    f: Optional[io.IOBase] = None,
 ) -> None:
     """
-    Save a task, will save the original config, model state and metadata
+    Save all stateful information of a training task to a specified file-like
+    object, will save the original config, model state, metadata,
+    training state if training is not completed
     """
-    save_path = config.save_snapshot_path
-    print(f"Saving pytorch model to: {save_path}")
-    model.save_modules(base_path=config.modules_save_dir)
-    state = {
-        DATA_STATE: meta,
-        CONFIG_JSON: config_to_json(PyTextConfig, config),
-        MODEL_STATE: model.state_dict(),
-        SERIALIZE_VERSION_KEY: LATEST_SERIALIZE_VERSION,
-        TENSORIZERS: tensorizers,
-    }
-    torch.save(state, save_path)
+    if config.modules_save_dir:
+        model.save_modules(base_path=config.modules_save_dir)
+
+    # Currently torch.save() has error pickling certain models when not saving
+    # by model.state_dict(), thus currently overriding the model in
+    # training_state with None, and put back saving
+    # https://github.com/pytorch/pytorch/issues/15116
+    model_in_training_state = None
+    if training_state:
+        model_in_training_state, training_state.model = training_state.model, None
+    try:
+        state = {
+            DATA_STATE: meta,
+            CONFIG_JSON: config_to_json(PyTextConfig, config),
+            MODEL_STATE: model.state_dict(),
+            SERIALIZE_VERSION_KEY: LATEST_SERIALIZE_VERSION,
+            TENSORIZERS: tensorizers,
+            TRAINING_STATE: training_state,
+        }
+        if f is None:
+            save_path = config.save_snapshot_path
+            print(f"Saving pytorch model to: {save_path}")
+            torch.save(state, save_path)
+        else:
+            torch.save(state, f)
+    finally:
+        if training_state:
+            training_state.model = model_in_training_state
 
 
 def load(load_path: str):
     """
-    Load task, will construct the task using the saved config then load metadata
-    and model state.
+    Load task, config and training state from a saved snapshot, will construct
+    the task using the saved config then load metadata and model state.
     """
     if not (load_path and os.path.isfile(load_path)):
         raise ValueError(f"Invalid snapshot path{load_path}")
@@ -73,6 +96,9 @@ def load(load_path: str):
 @register_snapshot_loader(1)
 def load_v1(state):
     config = pytext_config_from_json(state[CONFIG_JSON])
+    # importing in file level generates circular import/dependency failures,
+    # that need refator later to fix
+    from .task import create_task
 
     task = create_task(
         config.task, metadata=state[DATA_STATE], model_state=state[MODEL_STATE]
@@ -85,6 +111,10 @@ def load_v2(state):
     config = pytext_config_from_json(state[CONFIG_JSON])
     model_state = state[MODEL_STATE]
     tensorizers = state[TENSORIZERS]
+    # importing in file level generates circular import/dependency failures,
+    # that need refator later to fix
+    from .task import create_task
+
     task = create_task(
         config.task,
         metadata=state[DATA_STATE],
@@ -92,3 +122,22 @@ def load_v2(state):
         tensorizers=tensorizers,
     )
     return task, config
+
+
+@register_snapshot_loader(3)
+def load_v3(state):
+    config = pytext_config_from_json(state[CONFIG_JSON])
+    model_state = state[MODEL_STATE]
+    tensorizers = state[TENSORIZERS]
+    training_state = state[TRAINING_STATE]
+    # importing in file level generates circular import/dependency failures,
+    # that need refator later to fix
+    from .task import create_task
+
+    task = create_task(
+        config.task,
+        metadata=state[DATA_STATE],
+        model_state=model_state,
+        tensorizers=tensorizers,
+    )
+    return task, config, training_state

--- a/pytext/trainers/__init__.py
+++ b/pytext/trainers/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from .ensemble_trainer import EnsembleTrainer, EnsembleTrainer_Deprecated
 from .hogwild_trainer import HogwildTrainer, HogwildTrainer_Deprecated
-from .trainer import TaskTrainer, Trainer, TrainingState
+from .trainer import TaskTrainer, Trainer
+from .training_state import TrainingState
 
 
 __all__ = [

--- a/pytext/trainers/training_state.py
+++ b/pytext/trainers/training_state.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+
+from typing import Any, Dict
+
+from pytext.common.constants import Stage
+from pytext.data.tensorizers import Tensorizer
+from pytext.models.model import Model
+from pytext.optimizer import Optimizer
+from pytext.optimizer.scheduler import Scheduler
+
+
+class TrainingState:
+    model: Model
+    optimizer: Optimizer
+    scheduler: Scheduler
+    start_time: float
+    epoch: int = 0
+    rank: int = 0
+    stage: Stage = Stage.TRAIN
+    epochs_since_last_improvement: int = 0
+    best_model_state: Any = None
+    best_model_metric: Any = None
+    tensorizers: Dict[str, Tensorizer] = None
+
+    def __init__(self, **kwargs):
+        unknown_keys = kwargs.keys() - TrainingState.__annotations__.keys()
+        if unknown_keys:
+            raise TypeError(f"TrainingState unexpected attributes {unknown_keys}")
+        vars(self).update(kwargs)

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -115,7 +115,7 @@ def prepare_task(
         set_random_seeds(config.random_seed, config.use_deterministic_cudnn)
 
     if config.load_snapshot_path and os.path.isfile(config.load_snapshot_path):
-        task, _ = load(config.load_snapshot_path)
+        task, _, _ = load(config.load_snapshot_path)
     else:
         task = create_task(
             config.task, metadata=metadata, rank=rank, world_size=world_size
@@ -156,7 +156,7 @@ def save_and_export(
 def export_saved_model_to_caffe2(
     saved_model_path: str, export_caffe2_path: str, output_onnx_path: str = None
 ) -> None:
-    task, train_config = load(saved_model_path)
+    task, train_config, _training_state = load(saved_model_path)
     if hasattr(task, "exporter") and task.exporter is None:
         TaskType = type(train_config.task)
         ExporterConfigType = get_type_hints(TaskType)["exporter"].__args__[0]
@@ -172,7 +172,7 @@ def export_saved_model_to_caffe2(
 def export_saved_model_to_torchscript(
     saved_model_path: str, path: str, quantize: bool = False
 ) -> None:
-    task, train_config = load(saved_model_path)
+    task, train_config, _training_state = load(saved_model_path)
     task.torchscript_export(task.model, path, quantize)
 
 
@@ -200,7 +200,7 @@ def test_model_from_snapshot_path(
     field_names: Optional[List[str]] = None,
 ):
     _set_cuda(use_cuda_if_available)
-    task, train_config = load(snapshot_path)
+    task, train_config, _training_state = load(snapshot_path)
 
     for mc in metric_channels or []:
         task.metric_reporter.add_channel(mc)
@@ -262,7 +262,7 @@ def get_logits(
     field_names: Optional[List[str]] = None,
 ):
     _set_cuda(use_cuda_if_available)
-    task, train_config = load(snapshot_path)
+    task, train_config, _traing_state = load(snapshot_path)
     print(f"Successfully loaded model from {snapshot_path}")
     print(f"Model on GPU? {next(task.model.parameters()).is_cuda}")
     if isinstance(task, NewTask):
@@ -298,5 +298,5 @@ def get_logits(
 
 
 def batch_predict(model_file: str, examples: List[Dict[str, Any]]):
-    task, train_config = load(model_file)
+    task, train_config, _training_state = load(model_file)
     return task.predict(examples)

--- a/tests/task_load_save_test.py
+++ b/tests/task_load_save_test.py
@@ -6,12 +6,17 @@ import tempfile
 import unittest
 
 import torch
+from pytext.common.constants import Stage
 from pytext.config import LATEST_VERSION, PyTextConfig
+from pytext.config.component import create_optimizer, create_scheduler
 from pytext.data import Data
 from pytext.data.sources import TSVDataSource
+from pytext.optimizer import Adam, Optimizer
+from pytext.optimizer.scheduler import Scheduler
 from pytext.task import create_task
 from pytext.task.serialize import load, save
 from pytext.task.tasks import DocumentClassificationTask
+from pytext.trainers.training_state import TrainingState
 from pytext.utils import test
 
 
@@ -44,13 +49,83 @@ class TaskLoadSaveTest(unittest.TestCase):
             model = task.model
 
             save(config, model, meta=None, tensorizers=task.data.tensorizers)
-            task2, config2 = load(snapshot_file.name)
+            task2, config2, training_state_none = load(snapshot_file.name)
 
             self.assertEqual(config, config2)
             self.assertModulesEqual(model, task2.model)
-
+            self.assertIsNone(training_state_none)
             model.eval()
             task2.model.eval()
 
             inputs = torch.LongTensor([[1, 2, 3]]), torch.LongTensor([3])
             self.assertEqual(model(*inputs).tolist(), task2.model(*inputs).tolist())
+
+        def assertOptimizerEqual(self, optim_1, optim_2, msg=None):
+            self.assertTrue(optim_1 is Optimizer and optim_2 is Optimizer, msg)
+            state_dict_1 = optim_1.state_dict()
+            state_dict_2 = optim_2.state_dict()
+            self.assertEqual(len(state_dict_1), len(state_dict_2))
+            for key_1, val_1 in optim_1.state_dict().items():
+                self.assertEqualt(val_1, state_dict_2[key_1], msg)
+
+        def test_load_checkpoint(self):
+            with tempfile.NamedTemporaryFile() as checkpoint_file:
+                train_data = tests_module.test_file("train_data_tiny.tsv")
+                eval_data = tests_module.test_file("test_data_tiny.tsv")
+                config = PyTextConfig(
+                    task=DocumentClassificationTask.Config(
+                        data=Data.Config(
+                            source=TSVDataSource.Config(
+                                train_filename=train_data,
+                                eval_filename=eval_data,
+                                field_names=["label", "slots", "text"],
+                            )
+                        )
+                    ),
+                    version=LATEST_VERSION,
+                    save_snapshot_path=checkpoint_file.name,
+                )
+                task = create_task(config.task)
+                model = task.model
+                # test checkpoint saving and loading
+                optimizer = create_optimizer(Adam.Config(), model)
+                scheduler = create_scheduler(Scheduler.Config(), optimizer)
+                training_state = TrainingState(
+                    model=model,
+                    optimizer=optimizer,
+                    scheduler=scheduler,
+                    start_time=0,
+                    epoch=0,
+                    rank=0,
+                    stage=Stage.TRAIN,
+                    epochs_since_last_improvement=0,
+                    best_model_state=None,
+                    best_model_metric=None,
+                    tensorizers=None,
+                )
+
+                checkpoint_path = checkpoint_file.name
+                save(
+                    config,
+                    model,
+                    None,
+                    task.data.tensorizers,
+                    training_state,
+                    checkpoint_file,
+                )
+                task_restored, config_restored, training_state_restored = load(
+                    checkpoint_path
+                )
+                optimizer_restored = training_state_restored.optimizer
+                scheduler_restored = training_state_restored.scheduler
+                self.assertOptimizerEqual(optimizer, optimizer_restored)
+                self.assertNotNone(scheduler_restored)
+                self.assertEqual(config, config_restored)
+                self.assertModulesEqual(model, task_restored.model)
+                model.eval()
+                task_restored.model.eval()
+
+                inputs = torch.LongTensor([[1, 2, 3]]), torch.LongTensor([3])
+                self.assertEqual(
+                    model(*inputs).tolist(), task_restored.model(*inputs).tolist()
+                )


### PR DESCRIPTION
Summary:
- design doc draft: https://fb.quip.com/u1QCAyFvCu9V
- modified save() to support saving snapshot and checkpoint to save`TrainingState` in addition to existing schema
- modify loading logic to also return training state in addition to task and config, thus checkpoint effectively contains Task, config and training state
- some refactoring: move TrainingState to a separate file to prevent circular dependency/import
- fix unit test data to only run 1 epoch instead of 50 epochs
- added new load_v3() and update LATEST_SERIALIZE_VERSION to load new schema

Differential Revision: D16385868

