### PR TITLE
support byte token input for Language Model

### DIFF
--- a/demo/configs/lm.json
+++ b/demo/configs/lm.json
@@ -13,12 +13,14 @@
         }
       },
       "model": {
-        "tied_weights": true,
-        "stateful": true,
-        "decoder": {
-          "hidden_dims": [
-            10
-          ]
+        "LMLSTM": {
+          "tied_weights": true,
+          "stateful": true,
+          "decoder": {
+            "hidden_dims": [
+              100
+            ]
+          }
         }
       }
     }

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -324,6 +324,9 @@ class ByteTokenTensorizer(Tensorizer):
         max_byte_len: int = 15
         #: Offset to add to all non-padding bytes
         offset_for_non_padding: int = 0
+        add_bos_token: bool = False
+        add_eos_token: bool = False
+        use_eos_token_for_bos: bool = False
 
     @classmethod
     def from_config(cls, config: Config):
@@ -334,6 +337,9 @@ class ByteTokenTensorizer(Tensorizer):
             max_seq_len=config.max_seq_len,
             max_byte_len=config.max_byte_len,
             offset_for_non_padding=config.offset_for_non_padding,
+            add_bos_token=config.add_bos_token,
+            add_eos_token=config.add_eos_token,
+            use_eos_token_for_bos=config.use_eos_token_for_bos,
         )
 
     def __init__(
@@ -343,12 +349,18 @@ class ByteTokenTensorizer(Tensorizer):
         max_seq_len=Config.max_seq_len,
         max_byte_len=Config.max_byte_len,
         offset_for_non_padding=Config.offset_for_non_padding,
+        add_bos_token=Config.add_bos_token,
+        add_eos_token=Config.add_eos_token,
+        use_eos_token_for_bos=Config.use_eos_token_for_bos,
     ):
         self.text_column = text_column
         self.tokenizer = tokenizer or Tokenizer()
         self.max_seq_len = max_seq_len or 2 ** 30  # large number
         self.max_byte_len = max_byte_len
         self.offset_for_non_padding = offset_for_non_padding
+        self.add_bos_token = add_bos_token
+        self.add_eos_token = add_eos_token
+        self.use_eos_token_for_bos = use_eos_token_for_bos
 
     @property
     def column_schema(self):
@@ -357,6 +369,11 @@ class ByteTokenTensorizer(Tensorizer):
     def numberize(self, row):
         """Convert text to bytes, pad batch."""
         tokens = self.tokenizer.tokenize(row[self.text_column])[: self.max_seq_len]
+        if self.add_bos_token:
+            bos = EOS if self.use_eos_token_for_bos else BOS
+            tokens = [Token(bos, -1, -1)] + tokens
+        if self.add_eos_token:
+            tokens.append(Token(EOS, -1, -1))
         if not tokens:
             tokens = [Token(PAD, -1, -1)]
         bytes = [self._numberize_token(token)[: self.max_byte_len] for token in tokens]

--- a/pytext/models/language_models/lmlstm.py
+++ b/pytext/models/language_models/lmlstm.py
@@ -6,12 +6,11 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 from pytext.config import ConfigBase
 from pytext.data import CommonMetadata
-from pytext.data.tensorizers import Tensorizer, TokenTensorizer
+from pytext.data.tensorizers import ByteTokenTensorizer, Tensorizer, TokenTensorizer
 from pytext.exporters.exporter import ModelExporter
 from pytext.models.decoders import DecoderBase
 from pytext.models.decoders.mlp_decoder import MLPDecoder
-from pytext.models.embeddings import EmbeddingBase
-from pytext.models.embeddings.word_embedding import WordEmbedding
+from pytext.models.embeddings import CharacterEmbedding, EmbeddingBase, WordEmbedding
 from pytext.models.model import BaseModel, Model
 from pytext.models.module import create_module
 from pytext.models.output_layers import OutputLayerBase
@@ -96,8 +95,6 @@ class LMLSTM_Deprecated(Model):
                 feat_config.word_feat.embed_dim
                 != model.representation.representation_dim
             ):
-                print(feat_config.word_feat.embed_dim)
-                print(model.representation.representation_dim)
                 raise ValueError(
                     "Embedding dimension must be same as representation "
                     "dimensions when using tied weights"
@@ -160,6 +157,8 @@ class LMLSTM(BaseModel):
 
     """
 
+    __EXPANSIBLE__ = True
+
     class Config(BaseModel.Config):
         class ModelInput(Model.Config.ModelInput):
             tokens: TokenTensorizer.Config = TokenTensorizer.Config(
@@ -177,8 +176,12 @@ class LMLSTM(BaseModel):
         stateful: bool = False
 
     @classmethod
+    def create_embedding(cls, config, tensorizers):
+        return create_module(config.embedding, tensorizer=tensorizers["tokens"])
+
+    @classmethod
     def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):
-        embedding = create_module(config.embedding, tensorizer=tensorizers["tokens"])
+        embedding = cls.create_embedding(config, tensorizers)
         representation = create_module(
             config.representation, embed_dim=embedding.embedding_dim
         )
@@ -298,3 +301,45 @@ class LMLSTM(BaseModel):
             weight.new_zeros(bsz, num_layers, rnn_hidden_dim),
             weight.new_zeros(bsz, num_layers, rnn_hidden_dim),
         )
+
+
+class LMLSTMLiteModel(LMLSTM):
+    """
+    `LMLSTMLiteModel` implements a word-level language model that uses LSTMs to
+    represent the document and token_bytes as input.
+
+    """
+
+    class Config(LMLSTM.Config):
+        class ModelInput(LMLSTM.Config.ModelInput):
+            token_bytes: ByteTokenTensorizer.Config = ByteTokenTensorizer.Config(
+                add_bos_token=True, add_eos_token=True
+            )
+            tokens: TokenTensorizer.Config = TokenTensorizer.Config(
+                add_bos_token=True, add_eos_token=True
+            )
+
+        inputs: ModelInput = ModelInput()
+        embedding: CharacterEmbedding.Config = CharacterEmbedding.Config()
+        tied_weights: bool = False
+
+    @classmethod
+    def create_embedding(cls, config, tensorizers):
+        return CharacterEmbedding(
+            tensorizers["token_bytes"].NUM_BYTES,
+            config.embedding.embed_dim,
+            config.embedding.cnn.kernel_num,
+            config.embedding.cnn.kernel_sizes,
+            config.embedding.highway_layers,
+            config.embedding.projection_dim,
+        )
+
+    def vocab_to_export(self, tensorizers):
+        return {}
+
+    def get_export_input_names(self, tensorizers):
+        return ["token_bytes", "token_lens"]
+
+    def arrange_model_inputs(self, tensor_dict):
+        token_bytes, tokens_lens, _ = tensor_dict["token_bytes"]
+        return (token_bytes[:, 0:-1].contiguous(), tokens_lens - 1)


### PR DESCRIPTION
Summary:
Support ByteTokenTensorizer in Language Model Task:
1. adding capability to add eos,bos to byteTokenTensorizer
2. disable weight_ties since the embedding is not sharing the same vocab of output layer.

This will be useful for on device language model for two benefit:
1. input is ints intead of string, thus we can deploy on Android with extra stringTensor support
2. model size is much smaller without large vocab size

preliminary result: f126694598, ppl = 65.8171 with model size = 11M

Differential Revision: D16372553

