### PR TITLE
use output queue for report train_stats

### DIFF
--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -88,6 +88,10 @@ class DisjointMultitaskMetricReporter(MetricReporter):
             metrics_dict[name] = reporter.get_model_select_metric(metrics_dict[name])
         return metrics_dict
 
+    def report_realtime_metric(self, stage):
+        for _, reporter in self.reporters.items():
+            reporter.report_realtime_metric(stage)
+
     def get_model_select_metric(self, metrics):
         if self.target_reporter:
             metric = self.target_reporter.get_model_select_metric(metrics)

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import multiprocessing
 from typing import Dict, Optional, Type
 
 from pytext.common.constants import Stage
@@ -151,7 +152,13 @@ class _NewTask(TaskBase):
         )
         self.trainer = trainer or TaskTrainer()
 
-    def train(self, config: PyTextConfig, rank: int = 0, world_size: int = 1):
+    def train(
+        self,
+        config: PyTextConfig,
+        rank: int = 0,
+        world_size: int = 1,
+        output_queue: multiprocessing.Queue = None,
+    ):
         # TODO: move dist_init back to prepare_task in pytext/workflow.py
         # when processing time between dist_init and first loss.backward() is short
         return self.trainer.train(
@@ -161,6 +168,7 @@ class _NewTask(TaskBase):
             self.metric_reporter,
             config,
             rank=rank,
+            output_queue=output_queue,
         )
 
     def test(self, data_source):

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -135,7 +135,7 @@ class TaskBase(Component):
         self.metric_reporter: MetricReporter = metric_reporter
         self.exporter = exporter
 
-    def train(self, train_config, rank=0, world_size=1):
+    def train(self, train_config, rank=0, world_size=1, output_queue=None):
         """
         Wrapper method to train the model using :class:`~Trainer` object.
 
@@ -152,6 +152,7 @@ class TaskBase(Component):
             self.metric_reporter,
             train_config,
             rank=rank,
+            output_queue=output_queue,
         )
         return result
 

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -532,6 +532,8 @@ class TaskTrainer(Trainer):
                         *metric_data,
                         **metric_reporter.batch_context(raw_batch, batch),
                     )
+                if batch_id % self.config.num_samples_to_log_progress == 0:
+                    metric_reporter.report_realtime_metric(state.stage)
         # update gradients after #len(samples) forward & backward
         self.optimizer_step(state)
 


### PR DESCRIPTION
Summary:
use output queue for report train_stats
1. report_train_epoch_stats used to enqueue train_stats
2. TrainStatsReporter dequeue train_stats and format the flow output types
3. Explicitly check spawn_context.join so that the main process could check the queue in parallel with the subprocess

Differential Revision: D16390077

