### PR TITLE
Fix Spelling For RECALL_AT_PRECISION_THREHOLDS

### DIFF
--- a/pytext/metric_reporters/classification_metric_reporter.py
+++ b/pytext/metric_reporters/classification_metric_reporter.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from pytext.common.constants import Stage
 from pytext.data import CommonMetadata
 from pytext.metrics import (
+    RECALL_AT_PRECISION_THREHOLDS,
     LabelListPrediction,
     LabelPrediction,
     compute_classification_metrics,
@@ -58,6 +59,7 @@ class ClassificationMetricReporter(MetricReporter):
         #: columns (usually just 1 column) will be concatenated and output in
         #: the IntentModelChannel as an evaluation tsv.
         text_column_names: List[str] = ["text"]
+        recall_at_precision_thresholds: List[float] = RECALL_AT_PRECISION_THREHOLDS
 
     def __init__(
         self,
@@ -68,12 +70,16 @@ class ClassificationMetricReporter(MetricReporter):
         ),
         target_label: Optional[str] = None,
         text_column_names: List[str] = Config.text_column_names,
+        recall_at_precision_thresholds: List[float] = (
+            Config.recall_at_precision_thresholds
+        ),
     ) -> None:
         super().__init__(channels)
         self.label_names = label_names
         self.model_select_metric = model_select_metric
         self.target_label = target_label
         self.text_column_names = text_column_names
+        self.recall_at_precision_thresholds = recall_at_precision_thresholds
 
     @classmethod
     def from_config(cls, config, meta: CommonMetadata = None, tensorizers=None):
@@ -105,6 +111,7 @@ class ClassificationMetricReporter(MetricReporter):
             config.model_select_metric,
             config.target_label,
             config.text_column_names,
+            config.recall_at_precision_thresholds,
         )
 
     def batch_context(self, raw_batch, batch):
@@ -125,6 +132,7 @@ class ClassificationMetricReporter(MetricReporter):
             ],
             self.label_names,
             self.calculate_loss(),
+            recall_at_precision_thresholds=self.recall_at_precision_thresholds,
         )
 
     def get_meta(self):
@@ -168,4 +176,5 @@ class MultiLabelClassificationMetricReporter(ClassificationMetricReporter):
             ],
             self.label_names,
             self.calculate_loss(),
+            recall_at_precision_thresholds=self.recall_at_precision_thresholds,
         )

--- a/pytext/metric_reporters/classification_metric_reporter.py
+++ b/pytext/metric_reporters/classification_metric_reporter.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from pytext.common.constants import Stage
 from pytext.data import CommonMetadata
 from pytext.metrics import (
-    RECALL_AT_PRECISION_THREHOLDS,
+    RECALL_AT_PRECISION_THRESHOLDS,
     LabelListPrediction,
     LabelPrediction,
     compute_classification_metrics,
@@ -59,7 +59,7 @@ class ClassificationMetricReporter(MetricReporter):
         #: columns (usually just 1 column) will be concatenated and output in
         #: the IntentModelChannel as an evaluation tsv.
         text_column_names: List[str] = ["text"]
-        recall_at_precision_thresholds: List[float] = RECALL_AT_PRECISION_THREHOLDS
+        recall_at_precision_thresholds: List[float] = RECALL_AT_PRECISION_THRESHOLDS
 
     def __init__(
         self,

--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -20,7 +20,7 @@ from pytext.utils import cuda
 from pytext.utils.ascii_table import ascii_table, ascii_table_from_dict
 
 
-RECALL_AT_PRECISION_THREHOLDS = [0.2, 0.4, 0.6, 0.8, 0.9]
+RECALL_AT_PRECISION_THRESHOLDS = [0.2, 0.4, 0.6, 0.8, 0.9]
 
 """
 Basic metric classes and functions for single-label prediction problems.
@@ -567,7 +567,7 @@ def recall_at_precision(
 def compute_soft_metrics(
     predictions: Sequence[LabelPrediction],
     label_names: Sequence[str],
-    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THREHOLDS,
+    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THRESHOLDS,
 ) -> Dict[str, SoftClassificationMetrics]:
     """
     Computes soft classification metrics (for now, average precision) given a list of
@@ -607,7 +607,7 @@ def compute_soft_metrics(
 def compute_multi_label_soft_metrics(
     predictions: Sequence[LabelListPrediction],
     label_names: Sequence[str],
-    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THREHOLDS,
+    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THRESHOLDS,
 ) -> Dict[str, SoftClassificationMetrics]:
     """
     Computes multi-label soft classification metrics
@@ -705,7 +705,7 @@ def compute_classification_metrics(
     label_names: Sequence[str],
     loss: float,
     average_precisions: bool = True,
-    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THREHOLDS,
+    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THRESHOLDS,
 ) -> ClassificationMetrics:
     """
     A general function that computes classification metrics given a list of label
@@ -770,7 +770,7 @@ def compute_multi_label_classification_metrics(
     label_names: Sequence[str],
     loss: float,
     average_precisions: bool = True,
-    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THREHOLDS,
+    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THRESHOLDS,
 ) -> ClassificationMetrics:
     """
     A general function that computes classification metrics given a list of multi-label


### PR DESCRIPTION
Summary: Fix spelling from "...THREHOLDS" to "...THRESHOLDS"

Differential Revision: D16380904

