### PR TITLE
Sync metric reporter results on multiple gpus (#771)

### DIFF
--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -104,3 +104,7 @@ class DisjointMultitaskMetricReporter(MetricReporter):
             metric = -metrics[AVRG_LOSS]
 
         return metric
+
+    def report_realtime_metric(self, stage):
+        for _, reporter in self.reporters.items():
+            reporter.report_realtime_metric(stage)

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -532,6 +532,8 @@ class TaskTrainer(Trainer):
                         *metric_data,
                         **metric_reporter.batch_context(raw_batch, batch),
                     )
+                if batch_id % self.config.num_samples_to_log_progress == 0:
+                    metric_reporter.report_realtime_metric(state.stage)
         # update gradients after #len(samples) forward & backward
         self.optimizer_step(state)
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/pytext/pull/771

Currently metric_reporter only reports #samples, tps, ups on gpu 0. Call all_reduce to sync these values from all gpus.

Differential Revision: D16159174

