### PR TITLE
Bugfix for TrainerWorkflow doing evaluation on test set (Hive tables)

### DIFF
--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -236,8 +236,14 @@ def _get_data_source(test_path, source_config, field_names, task):
         # Cannot easily specify a single data source for multitask
         assert not test_path
         data_source = None
-    elif test_path and hasattr(source_config, "test_filename"):
-        source_config.test_filename = test_path
+    elif test_path and (
+        hasattr(source_config, "test_filename") or hasattr(source_config, "test_path")
+    ):
+        if hasattr(source_config, "test_filename"):
+            source_config.test_filename = test_path
+        elif hasattr(source_config, "test_path"):
+            source_config.test_path = test_path
+
         if field_names and hasattr(source_config, "field_names"):
             source_config.field_names = field_names
         data_source = create_component(


### PR DESCRIPTION
Summary: Current `TrainerWorkflow` runs evaluation on the test set, leading to the duplication of test and eval results. Although this was fixed when using `TSVDataSource`, this still happens when using Hive tables.

Differential Revision: D16478221

