### PR TITLE
fixed overflow error in lm reporting

### DIFF
--- a/pytext/metrics/language_model_metrics.py
+++ b/pytext/metrics/language_model_metrics.py
@@ -25,4 +25,8 @@ class LanguageModelMetric(NamedTuple):
 
 
 def compute_language_model_metric(loss_per_word: float) -> LanguageModelMetric:
-    return LanguageModelMetric(perplexity_per_word=math.exp(loss_per_word))
+    try:
+        ppl = math.exp(loss_per_word)
+    except OverflowError:
+        ppl = float("inf")
+    return LanguageModelMetric(perplexity_per_word=ppl)

--- a/pytext/models/output_layers/lm_output_layer.py
+++ b/pytext/models/output_layers/lm_output_layer.py
@@ -125,4 +125,8 @@ class LMOutputLayer(OutputLayerBase):
 
     @staticmethod
     def calculate_perplexity(sequence_loss: torch.Tensor) -> torch.Tensor:
-        return torch.exp(sequence_loss)
+        try:
+            ppl = torch.exp(sequence_loss)
+        except OverflowError:
+            ppl = float("inf")
+        return ppl


### PR DESCRIPTION
Summary: Fixes overflow error in perplexity reporting by showing "inf" instead of OverflowError

Differential Revision: D16495447

