### PR TITLE
make bos, eos configs for BERT saner

### DIFF
--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -25,12 +25,42 @@ from pytext.data.tensorizers import (
     VocabConfig,
     VocabFileConfig,
     initialize_tensorizers,
+    lookup_tokens,
 )
 from pytext.data.tokenizers import Tokenizer, WordPieceTokenizer
+from pytext.data.utils import BOS, EOS, Vocabulary
 from pytext.utils.test import import_tests_module
 
 
 tests_module = import_tests_module()
+
+
+class LookupTokensTest(unittest.TestCase):
+    def test_lookup_tokens(self):
+        text = "let's tokenize this"
+        tokenizer = Tokenizer()
+        vocab = Vocabulary(text.split() + [BOS, EOS])
+        tokens, start_idx, end_idx = lookup_tokens(
+            text,
+            tokenizer=tokenizer,
+            vocab=vocab,
+            add_bos_token=False,
+            add_eos_token=False,
+        )
+        self.assertEqual(tokens, [0, 1, 2])
+        self.assertEqual(start_idx, (0, 6, 15))
+        self.assertEqual(end_idx, (5, 14, 19))
+
+        tokens, start_idx, end_idx = lookup_tokens(
+            text,
+            tokenizer=tokenizer,
+            vocab=vocab,
+            add_bos_token=True,
+            add_eos_token=True,
+        )
+        self.assertEqual(tokens, [3, 0, 1, 2, 4])
+        self.assertEqual(start_idx, (-1, 0, 6, 15, -1))
+        self.assertEqual(end_idx, (-1, 5, 14, 19, -1))
 
 
 class ListTensorizersTest(unittest.TestCase):

--- a/pytext/data/xlm_tensorizer.py
+++ b/pytext/data/xlm_tensorizer.py
@@ -8,6 +8,7 @@ import torch
 from fairseq.data.legacy.masked_lm_dictionary import MaskedLMDictionary
 from pytext.config.component import ComponentType, create_component
 from pytext.data.bert_tensorizer import BERTTensorizer
+from pytext.data.tensorizers import lookup_tokens
 from pytext.data.tokenizers import Tokenizer
 from pytext.data.utils import BOS, EOS, MASK, PAD, UNK, Vocabulary, pad_and_tensorize
 from pytext.data.xlm_dictionary import Dictionary as XLMDictionary
@@ -137,16 +138,12 @@ class XLMTensorizer(BERTTensorizer):
             schema += [(column, str) for column in self.language_columns]
         return schema
 
-    def _lookup_tokens(self, text: str, seq_len: int) -> List[int]:
-        tokenized_text = [t.value for t in self.tokenizer.tokenize(text)]
-        truncated_text = tokenized_text[:seq_len]
-        tokens = self.vocab.lookup_all(truncated_text)
-        return tokens
-
     def _numberize_and_wrap(self, text: str, seq_len: int) -> List[List[int]]:
         sentence = (
             [self.special_token]
-            + self._lookup_tokens(text, seq_len)
+            + lookup_tokens(
+                text, tokenizer=self.tokenizer, vocab=self.vocab, max_seq_len=seq_len
+            )[0]
             + [self.special_token]
         )
         return [sentence]


### PR DESCRIPTION
Summary:
BERTTensorizer inherits from TokenTensorizer and uses it's _lookup_tokens function.  However, for this to work correctly, we set add_bos=False and add_eos=True, so that individual segments don't have bos appended.  After concatanating, we add BOS once to the beginning of the tensorized row.

This is confusing because bos token is added even though the config shows add_bos=False.  Also, add_bos and add_eos are really hard-coded and should not be configured.

I fix this confusion by making lookup_tokens a utility.  Now the add_bos and add_eos configs in BERT do what they say they do.

Differential Revision: D16505022

