### PR TITLE
Allow setting padding_idx on WordEmbedding

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -39,6 +39,7 @@ class WordFeatConfig(ModuleConfig):
     lowercase_tokens: bool = True
     min_freq: int = 1
     mlp_layer_dims: Optional[List[int]] = []
+    padding_idx: Optional[int] = None
 
 
 class DictFeatConfig(ModuleConfig):

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -92,6 +92,7 @@ class WordEmbedding(EmbeddingBase):
             init_range=config.embedding_init_range,
             unk_token_idx=unk_token_idx,
             mlp_layer_dims=config.mlp_layer_dims,
+            padding_idx=config.padding_idx,
         )
 
     def __init__(
@@ -102,13 +103,17 @@ class WordEmbedding(EmbeddingBase):
         init_range: Optional[List[int]] = None,
         unk_token_idx: int = 0,
         mlp_layer_dims: List[int] = (),
+        padding_idx: Optional[int] = None,
     ) -> None:
         output_embedding_dim = mlp_layer_dims[-1] if mlp_layer_dims else embedding_dim
         EmbeddingBase.__init__(self, embedding_dim=output_embedding_dim)
 
         # Create word embedding
         self.word_embedding = nn.Embedding(
-            num_embeddings, embedding_dim, _weight=embeddings_weight
+            num_embeddings,
+            embedding_dim,
+            _weight=embeddings_weight,
+            padding_idx=padding_idx,
         )
         if embeddings_weight is None and init_range:
             self.word_embedding.weight.data.uniform_(init_range[0], init_range[1])


### PR DESCRIPTION
Summary: Since SmartComposeLMLSTM use avg pooling on context tokens, we don't want padding_idx and the learned embedding on this token to influence the model. Therefore we add an option to WordEmbedding to allow padding_idx to be set: https://pytorch.org/docs/stable/_modules/torch/nn/modules/sparse.html#Embedding

Differential Revision: D16472708

