### PR TITLE
Update task.train and trainer.train API with QueueChannel

### DIFF
--- a/pytext/common/__init__.py
+++ b/pytext/common/__init__.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import multiprocessing
+from typing import NamedTuple, Optional
+
 from .constants import (
     BatchContext,
     DatasetFieldName,
@@ -10,3 +13,11 @@ from .constants import (
     Stage,
     VocabMeta,
 )
+
+
+class QueueChannel(NamedTuple):
+    # subprocess send trainer logging back to main process
+    logging_queue: Optional[multiprocessing.Queue] = None
+    # subprocess callback back to main process
+    # for example: start fine tuning task based on current snapshot
+    callback_queue: Optional[multiprocessing.Queue] = None

--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -105,6 +105,6 @@ class DisjointMultitaskMetricReporter(MetricReporter):
 
         return metric
 
-    def report_realtime_metric(self, stage):
+    def report_logging(self, stage, trainer_logging):
         for _, reporter in self.reporters.items():
-            reporter.report_realtime_metric(stage)
+            reporter.report_logging(stage, trainer_logging)

--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -3,6 +3,7 @@
 import math
 import operator
 import time
+from statistics import mean
 
 import torch
 import torch.nn.functional as F
@@ -177,18 +178,37 @@ class MaskedLMMetricReporter(LanguageModelMetricReporter):
         # realtime stats
         total_tokens = float(targets[2].sum())
         self.realtime_meters["tps"].update(total_tokens)
-
-        if not n_batches % 1000:
-            tps = self.realtime_meters["tps"].avg
-            print(
-                f"Tokens/s: {total_tokens / (now - self.time):.0f}, "
-                f"batch ppl: {math.exp(loss.item()):.2f}, "
-                f"agg ppl: {math.exp(self.aggregate_loss / float(self.total_num_tokens)):.2f}, "
-                f"number of batches: {n_batches}, "
-                f"accumulated tokens/s: {tps:.0f}",
-                flush=True,
-            )
+        self.last_batch_tps = total_tokens / (now - self.time)
+        self.last_loss = loss.item()
         self.time = now
+
+    def get_metric_logging(self):
+        metric_logging = super().get_metric_logging()
+        metric_logging.update(
+            {
+                "ppl": math.exp(self.calculate_loss()),
+                "batch_ppl": math.exp(self.last_loss),
+                "batch_tps": self.last_batch_tps,
+            }
+        )
+        return metric_logging
+
+    def aggregate_logging(self, metric_logging_list, trainer_logging_list):
+        output_logging = super().aggregate_logging(
+            metric_logging_list, trainer_logging_list
+        )
+        output_logging.update(
+            {
+                "ppl": round(mean(log.get("ppl", 0) for log in metric_logging_list), 2),
+                "batch_ppl": round(
+                    mean(log.get("batch_ppl", 0) for log in metric_logging_list), 2
+                ),
+                "batch_tps": round(
+                    sum(log.get("batch_tps", 0) for log in metric_logging_list), 2
+                ),
+            }
+        )
+        return output_logging
 
     def calculate_loss(self) -> float:
         return self.aggregate_loss / float(self.total_num_tokens)
@@ -197,4 +217,9 @@ class MaskedLMMetricReporter(LanguageModelMetricReporter):
         super()._reset()
         self.aggregate_loss = 0.0
         self.total_num_tokens = 0
+
+    def _reset_realtime(self):
+        super()._reset_realtime()
+        self.last_batch_tps = 0
+        self.last_loss = 0
         self.time = time.time()

--- a/pytext/metric_reporters/tests/language_model_metric_reporter_test.py
+++ b/pytext/metric_reporters/tests/language_model_metric_reporter_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from unittest import TestCase
+
+import torch
+from pytext.config.module_config import PerplexityType
+from pytext.metric_reporters.language_model_metric_reporter import (
+    MaskedLMMetricReporter,
+)
+
+
+class TestMaskedLMMetricReporter(TestCase):
+    def test_report_logging(self):
+        class MockMetadata:
+            class MockTarget:
+                pad_token_idx = 0
+
+            def __init__(self):
+                self.target = self.MockTarget()
+
+        reporter = MaskedLMMetricReporter(
+            channels=[],
+            metadata=MockMetadata(),
+            tensorizers=None,
+            aggregate_metrics=True,
+            perplexity_type=PerplexityType.MEDIAN,
+        )
+        reporter.add_batch_stats(
+            n_batches=128,
+            preds=None,
+            targets=(None, torch.tensor([1, 1]), torch.tensor([1, 1, 1, 1])),
+            scores=None,
+            loss=torch.tensor([2.4]),
+            m_input=None,
+        )
+        trainer_logging = {"n_updates": 128, "n_batches": 512}
+        metric_logging = reporter.get_metric_logging()
+
+        metric_keys = ("tps", "ppl", "batch_ppl", "batch_tps")
+        for key in metric_keys:
+            self.assertTrue(key in metric_logging)
+
+        # loss x targets[1].sum() ==> 2.4 x 2
+        self.assertEqual(round(reporter.aggregate_loss, 1), 4.8)
+        self.assertEqual(reporter.total_num_tokens, 2)
+        # math.exp(ppl) ==> math.exp(2.4) ~ 11.02
+        self.assertEqual(round(metric_logging["ppl"], 2), 11.02)
+
+        logging = reporter.aggregate_logging([metric_logging], [trainer_logging])
+        for key in metric_keys:
+            self.assertTrue(key in logging)

--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -17,8 +17,7 @@ from typing import (
 )
 
 import numpy as np
-from pytext.utils import cuda
-from pytext.utils.ascii_table import ascii_table, ascii_table_from_dict
+from pytext.utils.ascii_table import ascii_table
 
 
 RECALL_AT_PRECISION_THRESHOLDS = [0.2, 0.4, 0.6, 0.8, 0.9]
@@ -494,34 +493,6 @@ class RegressionMetrics(NamedTuple):
         print(f"Num examples: {self.num_examples}")
         print(f"Pearson correlation: {self.pearson_correlation:.3f}")
         print(f"Mean squared error: {self.mse:.3f}")
-
-
-class RealtimeMetrics(NamedTuple):
-    """
-    Realtime Metrics for tracking training progress and performance.
-
-    Attributes:
-        samples (int): number of samples
-        tps (float): tokens per second
-        ups (float): updates per second
-    """
-
-    samples: int
-    tps: float
-    ups: float
-
-    def _format(self, key, value):
-        if key in ("tps", "ups"):
-            return round(value)
-        return value
-
-    def __str__(self):
-        metrics = {"num_gpus": cuda.DISTRIBUTED_WORLD_SIZE}
-        for key, value in self._asdict().items():
-            if not value:
-                continue
-            metrics[key] = self._format(key, value)
-        return str(metrics)
 
 
 def safe_division(n: Union[int, float], d: int) -> float:

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -3,6 +3,7 @@
 
 from typing import Dict, Optional, Type, Union
 
+from pytext.common import QueueChannel
 from pytext.common.constants import Stage
 from pytext.config import ConfigBase, PyTextConfig
 from pytext.config.component import ComponentType, create_component, create_trainer
@@ -169,7 +170,13 @@ class _NewTask(TaskBase):
         )
         self.trainer = trainer or TaskTrainer()
 
-    def train(self, config: PyTextConfig, rank: int = 0, world_size: int = 1):
+    def train(
+        self,
+        config: PyTextConfig,
+        rank: int = 0,
+        world_size: int = 1,
+        queue_channel: QueueChannel = None,
+    ):
         # TODO: move dist_init back to prepare_task in pytext/workflow.py
         # when processing time between dist_init and first loss.backward() is short
         return self.trainer.train(
@@ -179,6 +186,7 @@ class _NewTask(TaskBase):
             self.metric_reporter,
             config,
             rank=rank,
+            queue_channel=queue_channel,
         )
 
     def test(self, data_source):

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -144,7 +144,7 @@ class TaskBase(Component):
         self.metric_reporter: MetricReporter = metric_reporter
         self.exporter = exporter
 
-    def train(self, train_config, rank=0, world_size=1):
+    def train(self, train_config, rank=0, world_size=1, queue_channel=None):
         """
         Wrapper method to train the model using :class:`~Trainer` object.
 
@@ -161,6 +161,7 @@ class TaskBase(Component):
             self.metric_reporter,
             train_config,
             rank=rank,
+            queue_channel=queue_channel,
         )
         return result
 


### PR DESCRIPTION
Summary:
QueueChannel is used communication between subprocess and main process, and it could also be used by single process as well.
General idea, subprocess push information or commands into QueueChannel, and main process will check regularly and respond correspondly.

It could be used in at least two cases
1. Subprocess report logging (e.g tps, number of batches, number of updates, loss, perplexity, etc)
2. Subprocess callback main process for some action (for example, main process start fine-tuning job with latest snapshot in pre-training)

Differential Revision: D16535501

