### PR TITLE
Fix issue with some tensorizers still re-initializing vocab when loaded from saved state

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -211,6 +211,7 @@ class Data(Component):
         tensorizers: Dict[str, Tensorizer],
         rank=0,
         world_size=1,
+        init_tensorizers=True,
         **kwargs,
     ):
         data_source_cls = Registry.get(ComponentType.DATA_SOURCE, type(config.source))
@@ -238,6 +239,7 @@ class Data(Component):
             batcher=batcher,
             sort_key=config.sort_key,
             in_memory=config.in_memory,
+            init_tensorizers=init_tensorizers,
             **kwargs,
         )
 
@@ -248,6 +250,7 @@ class Data(Component):
         batcher: Batcher = None,
         sort_key: Optional[str] = None,
         in_memory: Optional[bool] = False,
+        init_tensorizers: Optional[bool] = True,
     ):
         """This function should also initialize the passed in tensorizers with
         metadata they need for model construction."""
@@ -263,7 +266,13 @@ class Data(Component):
             if isinstance(data_source, ShardedDataSource)
             else data_source.train
         )
-        initialize_tensorizers(self.tensorizers, full_train_data)
+        if init_tensorizers:
+            initialize_tensorizers(self.tensorizers, full_train_data)
+        else:
+            print(
+                "Skipped initializing tensorizers since they are loaded from a "
+                "previously saved state."
+            )
 
     def numberize_rows(self, rows):
         for row in rows:

--- a/pytext/data/packed_lm_data.py
+++ b/pytext/data/packed_lm_data.py
@@ -34,6 +34,7 @@ class PackedLMData(Data):
         language: Optional[str] = None,
         rank: int = 0,
         world_size: int = 1,
+        init_tensorizers: Optional[bool] = True,
     ):
         return super(PackedLMData, cls).from_config(
             config,
@@ -43,6 +44,7 @@ class PackedLMData(Data):
             world_size,
             language=language,
             max_seq_len=config.max_seq_len,
+            init_tensorizers=init_tensorizers,
         )
 
     def __init__(
@@ -55,8 +57,11 @@ class PackedLMData(Data):
         # language is used in cross-lingual LM training
         language: Optional[str] = None,
         in_memory: Optional[bool] = False,
+        init_tensorizers: Optional[bool] = True,
     ):
-        super().__init__(data_source, tensorizers, batcher, sort_key, in_memory)
+        super().__init__(
+            data_source, tensorizers, batcher, sort_key, in_memory, init_tensorizers
+        )
         assert len(list(self.tensorizers.items())) == 1
         self.tensorizer_name, self.tensorizer = list(self.tensorizers.items())[0]
         self.remainder: Dict[str, List[int]] = {"tokens": [], "segment_labels": []}

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -60,7 +60,7 @@ class WordEmbedding(EmbeddingBase):
         if tensorizer is not None:
             if config.vocab_from_pretrained_embeddings:
                 raise ValueError(
-                    "In new data design, to adda tokens from a pretrained embeddings "
+                    "In new data design, to add tokens from a pretrained embeddings "
                     "file to the vocab, specify `vocab_file` in the token tensorizer."
                 )
 

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -125,8 +125,10 @@ class _NewTask(TaskBase):
                 column: str for column in config.metric_reporter.text_column_names
             }
 
-        if not tensorizers:
+        init_tensorizers = not tensorizers
+        if init_tensorizers:
             tensorizers = create_tensorizers(config.model.inputs)
+
         schema = create_schema(tensorizers, extra_schema)
 
         # This initializes the tensorizers
@@ -137,6 +139,7 @@ class _NewTask(TaskBase):
             tensorizers,
             rank=rank,
             world_size=world_size,
+            init_tensorizers=init_tensorizers,
         )
         return tensorizers, data
 


### PR DESCRIPTION
Summary:
Not all tensorizers have the

```
if self.vocab:
    return
```
logic in their `initialize()` method. So, some tensorizers will still re-initialize, and load the full training data set, which defeats the purpose of pickling them in the first place.

Expecting every tensorizer author to include that logic in `initialize()` seems very redundant. The platform should be smart enough to support skipping the full pass of training data if the tensorizers were loaded from a saved state. This diff implements that.

Differential Revision: D16533827

