### PR TITLE
Force tensor type of `dense_feat` to be a float in DocModel forward function.

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -168,7 +168,7 @@ class DocModel(Model):
                 logits = self.model(
                     torch.tensor(word_ids),
                     torch.tensor(seq_lens),
-                    torch.tensor(dense_feat),
+                    torch.tensor(dense_feat, dtype=torch.float),
                 )
                 return self.output_layer(logits)
 
@@ -320,7 +320,7 @@ class ByteTokensDocumentModel(DocModel):
                     torch.tensor(word_ids),
                     token_bytes,
                     torch.tensor(seq_lens),
-                    torch.tensor(dense_feat),
+                    torch.tensor(dense_feat, dtype=torch.float),
                 )
                 return self.output_layer(logits)
 


### PR DESCRIPTION
Summary:
Developing a PyText `DocModel` as a TorchScript model causes the following error to be thrown (despite training and publishing successfully) when calling it:

{P75435136}

This occurs because without explicitly setting the `dtype` of the `dense_feat` tensor, it infers it to be a tensor of doubles (likely because the data arrives via a [`Generic Value`](https://fburl.com/epi2r0x7) union that holds the data as doubles). This then gets concatenated to a separate tensor of floats, and this results in the above type error.

It's not feasible to change this union to accept a float field because it gets used in many other places, so instead this diff forces the tensor to be a tensor of floats, resolving this type error. It's also more robust if we force the tensor to be of the correct type here, as this is what we'll need later on when we concatenate it.

Differential Revision: D16540752

