### PR TITLE
Add the ability to pass parameter values to gen-default-config

### DIFF
--- a/pytext/config/utils.py
+++ b/pytext/config/utils.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Union
+
+
+def is_component_class(obj):
+    first = obj.__class__.__name__[0]
+    return first.upper() == first
+
+
+def find_param(root, suffix, parent=""):
+    """
+        Recursively look at all fields in config to find where `suffix` would fit.
+        This is used to change configs so that they don't use default values.
+        Return the list of field paths matching.
+    """
+    ret = []
+    for k in getattr(root.__class__, "__annotations__", []):
+        here = parent + k
+        if here.endswith(suffix):
+            ret += [here]
+
+        v = getattr(root, k)
+        if v is not None and is_component_class(type(v)):
+            ret += find_param(v, suffix, parent=here + ".")
+
+    return ret
+
+
+def resolve_optional(type_v):
+    """Deal with Optional implemented as Union[type, None]"""
+    if getattr(type_v, "__origin__", None) == Union and len(type_v.__args__) == 2:
+        if type_v.__args__[0] != type(None):
+            return type_v.__args__[0]
+        return type_v.__args__[1]
+    return type_v
+
+
+def cast_str(to_type, value):
+    if to_type == int:
+        return int(value)
+    elif to_type == float:
+        return float(value)
+    elif to_type == str:
+        return value
+    elif to_type == bool:
+        if value.lower() in ("yes", "true", "t", "1"):
+            return True
+        elif value.lower() in ("no", "false", "f", "0", ""):
+            return False
+        else:
+            raise Exception(f'Not a boolean value: "{value}"')
+    elif getattr(to_type, "__origin__", None) == list:
+        return [cast_str(to_type.__args__[0], v.strip()) for v in value.split(",")]
+    elif getattr(to_type, "__origin__", None) == dict:
+        key_type, value_type = to_type.__args__
+        ret = {}
+        for entry in value.split(","):
+            k, v = entry.split(":")
+            typed_k = cast_str(key_type, k)
+            typed_v = cast_str(value_type, v)
+            ret[typed_k] = typed_v
+        return ret
+    else:
+        raise Exception(f"Unsupported type: {to_type}")
+
+
+def replace_param(root, path_list, value):
+    for here in path_list[:-1]:
+        root = getattr(root, here)
+
+    param_name = path_list[-1]
+    annotation = root.__class__.__annotations__[param_name]
+    type_root = resolve_optional(annotation)
+    setattr(root, param_name, cast_str(type_root, value))

--- a/pytext/utils/documentation.py
+++ b/pytext/utils/documentation.py
@@ -53,10 +53,13 @@ def get_config_fields(obj):
         if k not in members:
             members[k] = None
     if issubclass(obj.__class__, Enum):
-        opt = members["_member_names_"]
-        typing = obj.__name__
-        ret[typing] = (opt[0], typing, set(opt))
-        return ret
+        opt = members.get("_member_names_")
+        if opt is not None:
+            typing = obj.__name__
+            ret[typing] = (opt[0], typing, set(opt))
+            return ret
+        else:
+            return obj
 
     for k, v in sorted(members.items()):
         if k.startswith("_"):
@@ -88,7 +91,7 @@ def pretty_print_config_class(obj):
     else:
         print(f"=== {obj.__module__}.{obj.__name__} ===")
     if obj.__doc__:
-        print(f'"""{obj.__doc__.strip()}"""')
+        print(f'"""\n{obj.__doc__.strip()}\n"""')
 
     config_help = get_config_fields(obj)
     if issubclass(obj, Enum):


### PR DESCRIPTION
  > pytext gen-default-config DocumentClassificationTask field_names=text,label column_mapping=a:1,b:2

When there's possible conflicts finding the exact parameter, you get a nice error message with the possible paths

  > pytext gen-default-config DocumentClassificationTask freeze=0
  ...
  Exception: Multiple possibilities for freeze=1: task.model.embedding.freeze, task.model.representation.freeze, task.model.representation.lstm.freeze, task.model.decoder.freeze, task.model.output_layer.freeze

Choose the parameter you want by passing the unambiguous suffix of one of the paths

  > pytext gen-default-config DocumentClassificationTask decoder.freeze=0

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
