### PR TITLE
removed lm labels exporting

### DIFF
--- a/pytext/models/output_layers/lm_output_layer.py
+++ b/pytext/models/output_layers/lm_output_layer.py
@@ -4,15 +4,12 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
-from caffe2.python import core
 from pytext.config.component import create_loss
-from pytext.data.utils import PAD, Vocabulary
+from pytext.data.utils import Vocabulary
 from pytext.fields import FieldMeta
 from pytext.loss import CrossEntropyLoss, Loss
 
 from .output_layer_base import OutputLayerBase
-from .utils import OutputLayerUtils
 
 
 class LMOutputLayer(OutputLayerBase):
@@ -106,22 +103,6 @@ class LMOutputLayer(OutputLayerBase):
 
         """
         return (logits, None)
-
-    def export_to_caffe2(
-        self,
-        workspace: core.workspace,
-        init_net: core.Net,
-        predict_net: core.Net,
-        model_out: torch.Tensor,
-        output_name: str,
-    ) -> List[core.BlobReference]:
-        prob_out = predict_net.Softmax(output_name, axis=model_out.dim() - 1)
-        # prepend an underscore to target_names to avoid conflicts between
-        # existing cell names and target names
-        edited_target_names = [f"_{name}" for name in self.target_names]
-        return OutputLayerUtils.gen_additional_blobs(
-            predict_net, prob_out, model_out, output_name, edited_target_names
-        )
 
     @staticmethod
     def calculate_perplexity(sequence_loss: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Summary:
Removes caffe2 labels exporting for the language model output layer. Labels overhead adds a lot of latency overhead due to the log softmax operation and loading/splitting scores into the output blobs. This is especially problematic for language models as they have large vocabularies -- performing 8-15k splits/loads can be very expensive. Shreyan has observed that processing the output blobs alone takes ~300ms, which is well over what it takes the model to process the original sequence.

The original motivation for including output layer blobs was that the client would have a copy of the vocabulary. However, it looks like this is unnecessary as the vocabulary can be obtained from the init net using the exporter created in D16268693. The `tokens_vals_index_vocab` blob contains a binarized version of the vocab. Each binarized string can be decoded as utf-8 to recover the original string.

Differential Revision: D16617730

