### PR TITLE
implemented cnn pooling for doc classification

### DIFF
--- a/pytext/config/module_config.py
+++ b/pytext/config/module_config.py
@@ -33,6 +33,7 @@ class CNNParams(ConfigBase):
 class PoolingType(Enum):
     MEAN = "mean"
     MAX = "max"
+    NONE = "none"
 
 
 class SlotAttentionType(Enum):

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -38,6 +38,7 @@ from pytext.models.output_layers.doc_classification_output_layer import (
     MultiLabelOutputLayer,
 )
 from pytext.models.representations.bilstm_doc_attention import BiLSTMDocAttention
+from pytext.models.representations.deepcnn import DeepCNNRepresentation
 from pytext.models.representations.docnn import DocNNRepresentation
 from pytext.models.representations.pure_doc_attention import PureDocAttention
 from pytext.models.representations.representation_base import RepresentationBase
@@ -68,6 +69,7 @@ class DocModel_Deprecated(Model):
             PureDocAttention.Config,
             BiLSTMDocAttention.Config,
             DocNNRepresentation.Config,
+            DeepCNNRepresentation.Config,
         ] = BiLSTMDocAttention.Config()
         decoder: MLPDecoder.Config = MLPDecoder.Config()
         output_layer: ClassificationOutputLayer.Config = (
@@ -93,6 +95,7 @@ class DocModel(Model):
             PureDocAttention.Config,
             BiLSTMDocAttention.Config,
             DocNNRepresentation.Config,
+            DeepCNNRepresentation.Config,
         ] = BiLSTMDocAttention.Config()
         decoder: MLPDecoder.Config = MLPDecoder.Config()
         output_layer: ClassificationOutputLayer.Config = (


### PR DESCRIPTION
Summary: Implements max and average pooling for DeepCNNRepresentation -- this allows it to be used in tasks where each word in a sequence doesn't necessarily need to have its own representation. Attention is commonly used in NLP to attend to important parts of the sequence, but max and average pooling are simpler (but strong) baselines that can compress sequential representations. The resulting representation can be used in tasks such as document classification, which we perform experiments with.

Differential Revision: D16631634

