### PR TITLE
Fix OOM for large model in GPU training:move best model to GPU

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -284,6 +284,8 @@ class Trainer(TrainerBase):
             state.model.load_state_dict(
                 {k: v.cuda() for k, v in state.best_model_state.items()}
             )
+            # Move model back to GPU
+            state.model.cuda()
         else:
             state.model.load_state_dict(state.best_model_state)
 


### PR DESCRIPTION
Summary:
state.model stays in CPU after load_best_model leads to some unexpected behavior when the return object state.model needs to be reuse on GPU. if one needs to reuse the returned state.model, it has to move state.model() back to GPU outside of trainer.

This diff moves best model back to GPU at the end of load_best_model()

Differential Revision: D16649728

