### PR TITLE
Remove "pytext/" from paths in demo json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Now you can export your model as a caffe2 net:
 You can use the exported caffe2 model to predict the class of raw utterances like this:
 
 ```
-  (venv) $ pytext --config-file demo/configs/docnn.json predict <<< '{"raw_text": "create an alarm for 1:30 pm"}'
+  (venv) $ pytext --config-file demo/configs/docnn.json predict <<< '{"text": "create an alarm for 1:30 pm"}'
 ```
 
 More examples and tutorials can be found in [Full Documentation](https://pytext.readthedocs.io/en/master/).

--- a/demo/configs/docnn.json
+++ b/demo/configs/docnn.json
@@ -6,9 +6,9 @@
         "source": {
           "TSVDataSource": {
             "field_names": ["label", "slots", "text"],
-            "train_filename": "pytext/tests/data/train_data_tiny.tsv",
-            "test_filename": "pytext/tests/data/test_data_tiny.tsv",
-            "eval_filename": "pytext/tests/data/test_data_tiny.tsv"
+            "train_filename": "tests/data/train_data_tiny.tsv",
+            "test_filename": "tests/data/test_data_tiny.tsv",
+            "eval_filename": "tests/data/test_data_tiny.tsv"
           }
         }
       },

--- a/pytext/docs/source/train_your_first_model.rst
+++ b/pytext/docs/source/train_your_first_model.rst
@@ -73,9 +73,9 @@ To get our feet wet, let's run one of the demo configurations included with PyTe
           "source": {
             "TSVDataSource": {
               "field_names": ["label", "slots", "text"],
-              "train_filename": "pytext/tests/data/train_data_tiny.tsv",
-              "test_filename": "pytext/tests/data/test_data_tiny.tsv",
-              "eval_filename": "pytext/tests/data/test_data_tiny.tsv"
+              "train_filename": "tests/data/train_data_tiny.tsv",
+              "test_filename": "tests/data/test_data_tiny.tsv",
+              "eval_filename": "tests/data/test_data_tiny.tsv"
             }
           }
         },


### PR DESCRIPTION
## Motivation and Context

This addresses issue#364. Fix the paths in `docnn.json` file so you can follow the tutorial to train your first model. Also updated corresponding doc and the command to test model in README.

## How Has This Been Tested

Follow the "train_your_first_model" tutorial.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
