### PR TITLE
Read ARRAY<float> densefeat from hive

### DIFF
--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -328,6 +328,8 @@ def load_json(s):
 
 @RootDataSource.register_type(List[float])
 def load_float_list(s):
+    if isinstance(s, List) and all(isinstance(x, float) for x in s):
+        return s
     # replace spaces between float numbers with commas (regex101.com/r/C2705x/1)
     processed = re.sub(r"(?<=[\d.])\s*,?\s+(?=[+-]?[\d.])", ",", s)
     # remove dot not followed with a digit (regex101.com/r/goSmuG/1/)


### PR DESCRIPTION
Summary: Dense feature is literally a list of float type. To read densefeat, we will call a function `load_float_list`, which only takes string as input. However, in hive data, the densefeat can be `ARRAY<FLOAT>`. So we first do type check and then process the densefeat.

Reviewed By: snisarg

Differential Revision: D16635113

