### PR TITLE
print log messages to stderr

### DIFF
--- a/pytext/builtin_task.py
+++ b/pytext/builtin_task.py
@@ -6,6 +6,7 @@ import importlib
 import inspect
 import os
 
+from pytext.common.utils import eprint
 from pytext.config.component import register_tasks
 from pytext.task.disjoint_multitask import DisjointMultitask, NewDisjointMultitask
 from pytext.task.new_task import NewTask
@@ -35,7 +36,6 @@ from pytext.task.tasks import (
     WordTaggingTask,
     WordTaggingTask_Deprecated,
 )
-from pytext.utils.documentation import eprint
 
 
 USER_TASKS_DIR = "user_tasks"

--- a/pytext/common/utils.py
+++ b/pytext/common/utils.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from sys import stderr
+
+
+def eprint(*args, **kwargs):
+    print(file=stderr, *args, **kwargs)

--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pytext.common.utils import eprint
+
 from .pytext_config import LATEST_VERSION
 
 
@@ -537,6 +539,10 @@ def upgrade_one_version(json_config):
     if not adapter:
         raise Exception(f"no adapter found for version {current_version}")
     json_config = adapter(json_config)
+    eprint(
+        f"WARNING - Applying old config adapter for version={current_version}. "
+        "Please consider migrating your old configs to the latest version."
+    )
     json_config["version"] = current_version + 1
     return json_config
 

--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -4,6 +4,8 @@
 from enum import Enum
 from typing import Dict, List, Tuple, Union
 
+from pytext.common.utils import eprint
+
 from .component import Registry
 from .config_adapter import upgrade_to_latest
 from .pytext_config import PyTextConfig
@@ -67,9 +69,9 @@ def _union_from_json(subclasses, json_obj):
         json_obj = next(iter(json_obj.values()))
     else:
         type_name = next(iter(subclasses_dict))
-        print(
-            f"can not find class type in json, trying with first class "
-            + f"{type_name} in the union"
+        eprint(
+            "WARNING - Can not find class type in json: "
+            f"trying with first class {type_name} in the union."
         )
     try:
         return _value_from_json(subclasses_dict[type_name], json_obj)

--- a/pytext/config/test/config_adapter_test.py
+++ b/pytext/config/test/config_adapter_test.py
@@ -25,6 +25,8 @@ class ConfigAdapterTest(unittest.TestCase):
             self.assertEqual(i, v, f"Missing adapter for version {i}")
 
     def test_upgrade_one_version(self):
+        # Always show the full diff, easier to debug when getting a failed log
+        self.maxDiff = None
         for p in glob.iglob(
             os.path.join(os.path.dirname(__file__), "json_config/*.json")
         ):

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -13,6 +13,7 @@ import click
 import torch
 from pytext import create_predictor
 from pytext.builtin_task import add_include
+from pytext.common.utils import eprint
 from pytext.config import LATEST_VERSION, PyTextConfig
 from pytext.config.component import register_tasks
 from pytext.config.serialize import (
@@ -26,7 +27,6 @@ from pytext.metric_reporters.channel import Channel, TensorBoardChannel
 from pytext.task import load
 from pytext.utils.documentation import (
     ROOT_CONFIG,
-    eprint,
     find_config_class,
     get_subclasses,
     pretty_print_config_class,
@@ -208,7 +208,7 @@ def main(context, config_file, config_json, config_module, include):
                 elif config_json:
                     config = json.loads(config_json)
                 else:
-                    click.echo("No config file specified, reading from stdin")
+                    eprint("No config file specified, reading from stdin")
                     config = json.load(sys.stdin)
                 context.obj.config = parse_config(config)
         return context.obj.config

--- a/pytext/utils/documentation.py
+++ b/pytext/utils/documentation.py
@@ -3,7 +3,7 @@
 
 from enum import Enum
 from inspect import getmembers, isclass, isfunction
-from sys import modules, stderr
+from sys import modules
 from typing import Union
 
 from pytext.config.component import Component, get_component_name
@@ -12,10 +12,6 @@ from pytext.models.module import Module
 
 
 ROOT_CONFIG = "PyTextConfig"
-
-
-def eprint(*args, **kwargs):
-    print(file=stderr, *args, **kwargs)
 
 
 def get_class_members_recursive(obj):


### PR DESCRIPTION
Summary:
we use the function eprint to print to stderr. This diff moves this
function to a utils class and we change a few (stdout) print to (stderr) eprint.
This gives a cleaner output when piping to files.

Differential Revision: D16749170

