### PR TITLE
Remove useless log message, update doc

### DIFF
--- a/pytext/docs/source/train_your_first_model.rst
+++ b/pytext/docs/source/train_your_first_model.rst
@@ -110,28 +110,35 @@ Let's train the model!
   ... [snip]
 
   Stage.TEST
-  loss: 2.072155
-  Accuracy: 20.00
-
-  Macro P/R/F1 Scores:
-	  Label                   Precision       Recall          F1              Support
-
-	  reminder/set_reminder   20.00           100.00          33.33           1
-	  alarm/time_left_on_alarm        0.00            0.00            0.00            1
-	  alarm/show_alarms       0.00            0.00            0.00            1
-	  alarm/set_alarm         0.00            0.00            0.00            2
-	  Overall macro scores    5.00            25.00           8.33
+  Epoch:1
+  loss: 1.646484
+  Accuracy: 50.00
 
   Soft Metrics:
-	  Label           Average precision
-	  alarm/set_alarm 40.00
-	  alarm/time_left_on_alarm        100.00
-	  reminder/set_reminder   25.00
-	  alarm/show_alarms       25.00
-	  weather/find    nan
-	  alarm/modify_alarm      nan
-	  alarm/snooze_alarm      nan
-	  reminder/show_reminders nan
+  +--------------------------+-------------------+---------+
+  | Label                    | Average precision | ROC AUC |
+  +--------------------------+-------------------+---------+
+  |       alarm/modify_alarm |               nan |   0.000 |
+  |          alarm/set_alarm |             1.000 |   1.000 |
+  |       alarm/snooze_alarm |               nan |   0.000 |
+  | alarm/time_left_on_alarm |             0.333 |   0.333 |
+  |    reminder/set_reminder |             1.000 |   1.000 |
+  |  reminder/show_reminders |               nan |   0.000 |
+  |             weather/find |               nan |   0.000 |
+  +--------------------------+-------------------+---------+
+
+  Recall at Precision
+  +--------------------------+---------+---------+---------+---------+---------+
+  | Label                    | R@P 0.2 | R@P 0.4 | R@P 0.6 | R@P 0.8 | R@P 0.9 |
+  +--------------------------+---------+---------+---------+---------+---------+
+  | alarm/modify_alarm       |   0.000 |   0.000 |   0.000 |   0.000 |   0.000 |
+  | alarm/set_alarm          |   1.000 |   1.000 |   1.000 |   1.000 |   1.000 |
+  | alarm/snooze_alarm       |   0.000 |   0.000 |   0.000 |   0.000 |   0.000 |
+  | alarm/time_left_on_alarm |   1.000 |   0.000 |   0.000 |   0.000 |   0.000 |
+  | reminder/set_reminder    |   1.000 |   1.000 |   1.000 |   1.000 |   1.000 |
+  | reminder/show_reminders  |   0.000 |   0.000 |   0.000 |   0.000 |   0.000 |
+  | weather/find             |   0.000 |   0.000 |   0.000 |   0.000 |   0.000 |
+  +--------------------------+---------+---------+---------+---------+---------+
   saving result to file /tmp/test_out.txt
 
 The model ran over the training set 10 times. This output is the result of evaluating the model on the test set, and tracking how well it did. If you're not familiar with these accuracy measurements,

--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -226,8 +226,7 @@ class ClassificationMetrics(NamedTuple):
     loss: float
 
     def print_metrics(self, report_pep=False) -> None:
-        print(f"Accuracy: {self.accuracy * 100:.2f}\n")
-        print("Macro P/R/F1 Scores:")
+        print(f"Accuracy: {self.accuracy * 100:.2f}")
         print("\nSoft Metrics:")
         if self.per_label_soft_scores:
             soft_scores = [


### PR DESCRIPTION
## Motivation and Context

A follow-up change regarding issue #364. I noticed that we stopped to print "Macro P/R/F1 Scores" as part of test metrics. Remove the log message so people will not get confused.

## How Has This Been Tested

In terminal it looks like this:

<img width="760" alt="Screen Shot 2019-08-12 at 2 52 46 PM" src="https://user-images.githubusercontent.com/5126317/62901220-1707ed80-bd11-11e9-836e-8966a79d486a.png">

Also updated doc:

![Screen Shot 2019-08-12 at 2 47 58 PM](https://user-images.githubusercontent.com/5126317/62901231-1d966500-bd11-11e9-9d92-4b5be29796c5.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
