### PR TITLE
parse additional_column_names from metric_reporter to _init_tensorizers in new_task

### DIFF
--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -194,20 +194,10 @@ class RootDataSource(DataSource):
         #: to not map directly to the column names in the schema. This mapping will
         #: remap names from the raw data source to names in the schema.
         column_mapping: Dict[str, str] = {}
-        #: An optional additional_colname (such as post_id, page_id, page_url)
-        #: to be read into context so that it can be included in model output
-        #: file with other saving results
-        additional_colnames: List[str] = []
 
-    def __init__(
-        self,
-        schema: Schema,
-        column_mapping: Dict[str, str] = (),
-        additional_colnames: List[str] = (),
-    ):
+    def __init__(self, schema: Schema, column_mapping: Dict[str, str] = ()):
         super().__init__(schema)
         self.column_mapping = dict(column_mapping)
-        self.additional_colnames = list(additional_colnames)
 
     def _read_example(self, row):
         example = RawExample()
@@ -216,14 +206,8 @@ class RootDataSource(DataSource):
             if name in self.schema:
                 example[name] = self.load(value, self.schema[name])
             else:
-                if name in self.additional_colnames:
-                    # default data type for additional_colname is string
-                    example[name] = self.load(value, str)
-                else:
-                    continue
-        if len(example) != len(self.schema) and not set(
-            self.additional_colnames
-        ).issubset(set(example)):
+                continue
+        if len(example) != len(self.schema):
             # We might need to re-evaluate this for multi-task training
             logging.warning(
                 "Skipping row missing values: row {} -> schema {}".format(

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -119,11 +119,12 @@ class _NewTask(TaskBase):
 
     @classmethod
     def _init_tensorizers(cls, config: Config, tensorizers=None, rank=0, world_size=1):
-        extra_schema = {}
-        if hasattr(config.metric_reporter, "text_column_names"):
-            extra_schema = {
-                column: str for column in config.metric_reporter.text_column_names
-            }
+        # Pull extra columns from the metric reporter config to pass into
+        # the data source schema.
+        extra_columns = list(
+            getattr(config.metric_reporter, "text_column_names", ())
+        ) + list(getattr(config.metric_reporter, "additional_column_names", ()))
+        extra_schema = {column: str for column in extra_columns}
 
         init_tensorizers = not tensorizers
         if init_tensorizers:


### PR DESCRIPTION
Summary: [PyText] parse additional_column_names (corresponding to raw input data columns) from metric_reporter to _init_tensorizers in new_task, so that data source can read these columns by default data type str, similar to text_column_names but without concantenation.

Differential Revision: D16786252

