### PR TITLE
Propagate min_freq for vocab correctly

### DIFF
--- a/pytext/data/data_handler.py
+++ b/pytext/data/data_handler.py
@@ -484,7 +484,12 @@ class DataHandler(Component):
             if label.use_vocab:
                 if not hasattr(label, "vocab"):  # Don't rebuild vocab
                     print("Building vocab for label {}".format(name))
-                    label.build_vocab(train_data, eval_data, test_data)
+                    label.build_vocab(
+                        train_data,
+                        eval_data,
+                        test_data,
+                        min_freq=getattr(label, "min_freq", 1),
+                    )
                 else:
                     print(f"Vocab for label {name} has been built. Not rebuilding.")
                 print(


### PR DESCRIPTION
Summary: Propogate min_freq to build_vocab. Note, `vocab_size` param does not work, torchtext fields have no support for it.

Differential Revision: D16795720

