### PR TITLE
move fairseq dependency from master code to current release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-fairseq @ git+https://github.com/pytorch/fairseq.git@master#egg=fairseq-0
+fairseq
 future
 hypothesis<4.0
 joblib


### PR DESCRIPTION
Summary:
We cannot release pytext with an editable dependency.

The code dependency was added because we frequently depend on the latest fairseq code.  I suggest we go back to the code dependency after we do the release.  We can coordinate releases with fairseq and follow this procedure in the future.

Differential Revision: D16807150

