### PR TITLE
EASY [PyText] fix OSS release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.2.1
+## v0.2.2
 
 *Note:* this is the last release with _Deprecated classes. Those classes will be removed in the next release.
 
@@ -74,6 +74,11 @@
 - Fix issue with some tensorizers still re-initializing vocab when loaded from saved state (#848)
 - fixed overflow error in lm reporting (#831)
 - fix BlockShardedTSVDataSource (#832)
+
+
+## v0.2.1
+
+(skipped because of packaging issues)
 
 
 ## v0.2.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(REQUIREMENTS) as f:
 
 setuptools.setup(
     name="pytext-nlp",
-    version="0.2.1",
+    version="0.2.2",
     description="pytorch modeling framework and model zoo for text models",
     url="https://github.com/facebookresearch/PyText",
     author="Facebook",


### PR DESCRIPTION
Summary:
this is a reconciliation diff to match what was just released to
as v0.2.2. There was several issues during this release, and I uploaded to
pypi a package that was broken. Pypi does not allow overwriting, so I had to
increase the version number.

I manually fixed the source (because it was minor packaging and dependency
problems) and pushed package 0.2.2.  This diff includes those fixes after
the fact to make the sources consistent with the release.

Changes are:
- fix fairseq requirement (separate diff, landing now)
- add __init__.py to make qna a module included in the release
- amend CHANGELOG to match version numbers

Reviewed By: neo315

Differential Revision: D16809591

