### PR TITLE
Add `ConsistentXLMModel`

### DIFF
--- a/pytext/metric_reporters/__init__.py
+++ b/pytext/metric_reporters/__init__.py
@@ -9,7 +9,7 @@ from .classification_metric_reporter import (
 from .compositional_metric_reporter import CompositionalMetricReporter
 from .intent_slot_detection_metric_reporter import IntentSlotMetricReporter
 from .language_model_metric_reporter import LanguageModelMetricReporter
-from .metric_reporter import MetricReporter
+from .metric_reporter import MetricReporter, PureLossMetricReporter
 from .pairwise_ranking_metric_reporter import PairwiseRankingMetricReporter
 from .regression_metric_reporter import RegressionMetricReporter
 from .squad_metric_reporter import SquadMetricReporter
@@ -32,4 +32,5 @@ __all__ = [
     "CompositionalMetricReporter",
     "PairwiseRankingMetricReporter",
     "SequenceTaggingMetricReporter",
+    "PureLossMetricReporter",
 ]

--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -11,6 +11,8 @@ from pytext.metrics import RealtimeMetrics
 from pytext.utils import cuda
 from pytext.utils.meter import TimeMeter
 
+from .channel import ConsoleChannel
+
 
 class MetricReporter(Component):
     """
@@ -268,3 +270,14 @@ class MetricReporter(Component):
         if new == old:
             return False
         return (new < old) == self.lower_is_better
+
+
+class PureLossMetricReporter(MetricReporter):
+    lower_is_better = True
+
+    @classmethod
+    def from_config(cls, config, *args, **kwargs):
+        return cls([ConsoleChannel()], config.pep_format)
+
+    def calculate_metric(self):
+        return self.calculate_loss()

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -29,6 +29,7 @@ from pytext.metric_reporters import (
     LanguageModelMetricReporter,
     MultiLabelClassificationMetricReporter,
     PairwiseRankingMetricReporter,
+    PureLossMetricReporter,
     RegressionMetricReporter,
     SequenceTaggingMetricReporter,
     SquadMetricReporter,
@@ -154,9 +155,9 @@ class DocClassificationTask_Deprecated(Task_Deprecated):
 class DocumentClassificationTask(NewTask):
     class Config(NewTask.Config):
         model: BaseModel.Config = DocModel.Config()
-        metric_reporter: ClassificationMetricReporter.Config = (
-            ClassificationMetricReporter.Config()
-        )
+        metric_reporter: Union[
+            ClassificationMetricReporter.Config, PureLossMetricReporter.Config
+        ] = (ClassificationMetricReporter.Config())
         #   for multi-label classification task,
         #   choose MultiLabelClassificationMetricReporter
 


### PR DESCRIPTION
Summary: Add an XLM model that accepts two text columns (and no label columns) as input. The model will evaluate (soft) predictions on the reference text input and treat that as the target distribution for the text in the "tokens" text input. This can be used for example when the two text columns are translations of each other (possibly multi-tasked with a regular labeled task).

Differential Revision: D16786687

