### PR TITLE
Make FileChannel generic

### DIFF
--- a/pytext/common/constants.py
+++ b/pytext/common/constants.py
@@ -76,7 +76,7 @@ class VocabMeta:
 
 class BatchContext:
     IGNORE_LOSS = "ignore_loss"
-    INDEX = "index"
+    INDEX = "row_index"
     TASK_NAME = "task_name"
 
 

--- a/pytext/config/doc_classification.py
+++ b/pytext/config/doc_classification.py
@@ -35,4 +35,4 @@ class ModelInput:
 
 
 class ExtraField:
-    RAW_TEXT = "utterance"
+    RAW_TEXT = "text"

--- a/pytext/data/compositional_data_handler.py
+++ b/pytext/data/compositional_data_handler.py
@@ -86,7 +86,7 @@ class CompositionalDataHandler(DataHandler):
 
         extra_fields: Dict[str, Field] = {
             DatasetFieldName.TOKENS: RawField(),
-            DatasetFieldName.UTTERANCE_FIELD: RawField(),
+            "text": RawField(),
         }
 
         return cls(
@@ -221,6 +221,6 @@ class CompositionalDataHandler(DataHandler):
             ACTION_FEATURE_FIELD: actions,
             ACTION_LABEL_FIELD: copy.deepcopy(actions),
             DatasetFieldName.TOKENS: features.tokens,
-            DatasetFieldName.UTTERANCE_FIELD: utterance,
+            "text": utterance,
             DatasetFieldName.CONTEXTUAL_TOKEN_EMBEDDING: contextual_token_embedding,
         }

--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -36,7 +36,7 @@ def get_perplexity_func(perplexity_type):
 
 
 class LanguageModelChannel(FileChannel):
-    def get_title(self):
+    def get_title(self, context_keys=()):
         return ("text", "perplexity")
 
     def gen_content(self, metrics, loss, preds, targets, scores, contexts):

--- a/pytext/metric_reporters/squad_metric_reporter.py
+++ b/pytext/metric_reporters/squad_metric_reporter.py
@@ -13,7 +13,7 @@ from pytext.metrics.squad_metrics import SquadMetrics
 
 
 class SquadFileChannel(FileChannel):
-    def get_title(self):
+    def get_title(self, context_keys=()):
         return (
             "index",
             "ques",
@@ -153,12 +153,12 @@ class SquadMetricReporter(MetricReporter):
         )
         self._add_decoded_answer_batch_stats(m_input, preds, **contexts)
 
-    def aggregate_preds(self, new_batch):
+    def aggregate_preds(self, new_batch, context=None):
         self.aggregate_data(self.all_start_pos_preds, new_batch[0])
         self.aggregate_data(self.all_end_pos_preds, new_batch[1])
         self.aggregate_data(self.all_has_answer_preds, new_batch[2])
 
-    def aggregate_targets(self, new_batch):
+    def aggregate_targets(self, new_batch, context=None):
         self.aggregate_data(self.all_start_pos_targets, new_batch[0])
         self.aggregate_data(self.all_end_pos_targets, new_batch[1])
         self.aggregate_data(self.all_has_answer_targets, new_batch[2])

--- a/pytext/metric_reporters/tests/intent_slot_metric_reporter_test.py
+++ b/pytext/metric_reporters/tests/intent_slot_metric_reporter_test.py
@@ -4,12 +4,14 @@
 from unittest import TestCase
 
 from pytext.metric_reporters.intent_slot_detection_metric_reporter import (
-    IntentSlotChannel,
+    create_frame,
+    frame_to_str,
 )
+from pytext.utils.data import byte_length
 
 
 class TestIntentSlotMetricReporter(TestCase):
-    def test_create_annotation(self):
+    def test_create_node(self):
         TEXT_EXAMPLES = [
             ("exit", "device/close_app", "", "[device/close_app exit ]"),
             (
@@ -52,7 +54,7 @@ class TestIntentSlotMetricReporter(TestCase):
             slot_names_str,
             expected_annotation_str,
         ) in TEXT_EXAMPLES:
-            annotation_str = IntentSlotChannel.create_annotation(
-                utterance, intent_label, slot_names_str
+            frame = create_frame(
+                utterance, intent_label, slot_names_str, byte_length(utterance)
             )
-            self.assertEqual(annotation_str, expected_annotation_str)
+            self.assertEqual(frame_to_str(frame), expected_annotation_str)

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -595,6 +595,8 @@ class TaskTrainer(Trainer):
                     metric_reporter.add_batch_stats(
                         batch_id,
                         *metric_data,
+                        # TODO merge this step into add_batch_stats once all data
+                        # migration is done
                         **metric_reporter.batch_context(raw_batch, batch),
                     )
                 if batch_id % self.config.num_samples_to_log_progress == 0:

--- a/pytext/utils/embeddings.py
+++ b/pytext/utils/embeddings.py
@@ -164,7 +164,10 @@ class PretrainedEmbedding(object):
             )
 
         assert self.embedding_vectors is not None and self.embed_vocab is not None
-        assert pretrained_embeds_weight.shape[-1] == self.embedding_vectors.shape[-1]
+        assert (
+            pretrained_embeds_weight.shape[-1] == self.embedding_vectors.shape[-1]
+        ), f"shape of pretrained_embeds_weight {pretrained_embeds_weight.shape[-1]} \
+        and embedding_vectors {self.embedding_vectors.shape[-1]} doesn't match!"
         unk_idx = str_to_idx[unk]
         oov_count = 0
         for word, idx in str_to_idx.items():


### PR DESCRIPTION
Summary:
This diff is the implementation of the discussion in https://fb.workplace.com/groups/1941258842562334/permalink/2486120098076203/

Currently different Channel classes are bound to specific tasks, which makes it hard to share the logic in new Channel (e.g HiveChannel). With the change in this diff:

1 Channel classes are model/task agnostic now, all special data processing logic happens in MetricReporter. IntentSlotFileChanel and ClassificationFileChannel classes are removed.
2 Two functions (predictions_to_report and targets_to_report) are added in MetricReporter to convert predictions and targets to human readable format, which was done in Channel before.
3 FileChannel dumps predictions, targets, scores, and all batch context to file now
4 The hacky extra lines of meta data in FileChannel is removed, this is also important for channels that can only write tabular data, like Hive

Differential Revision: D16736109

