### PR TITLE
Make PerLabelConfusions output in a deterministic order.

### DIFF
--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -367,7 +367,7 @@ class PerLabelConfusions:
     def compute_metrics(self) -> MacroPRF1Metrics:
         per_label_scores: Dict[str, PRF1Scores] = {}
         precision_sum, recall_sum, f1_sum = 0.0, 0.0, 0.0
-        for label, confusions in self.label_confusions_map.items():
+        for label, confusions in sorted(self.label_confusions_map.items()):
             scores = confusions.compute_metrics()
             per_label_scores[label] = scores
             if confusions.TP + confusions.FN > 0:


### PR DESCRIPTION
Summary:
When outputting the per label confusions, the `compute_metrics` method iterates through an unordered dictionary, this makes it non-deterministic which order these labels are printed. This becomes a problem when we want to consistently refer to an output value, for instance when setting the objective_attribute in a param sweep where we might use an argument like `outputs.doc_results_pair.test.per_label_prf1_scores[X].f1` to refer to a particular index `X` of the output labels.

This diff sorts the labels before computing the stats, so that they will always appear in the same order for consecutive runs.

Differential Revision: D16915421

