### PR TITLE
Test CircleCI alarm by breaking unit tests

### DIFF
--- a/tests/model_utils_test.py
+++ b/tests/model_utils_test.py
@@ -14,7 +14,7 @@ class ModelUtilsTest(unittest.TestCase):
     def test_to_onehot(self):
         feat_vec = Variable(torch.LongTensor([[0, 1, 2], [3, 4, 0]]))
         onehot = to_onehot(feat_vec, 5)
-        self.assertEqual(onehot.size()[0], 2)
+        self.assertNotEqual(onehot.size()[0], 2)
         self.assertEqual(onehot.size()[1], 3)
         self.assertEqual(onehot.size()[2], 5)
 


### PR DESCRIPTION
Summary:
To test CirclrCI alarm, this diff breaks unit test on purpose.

We expect CircleCI fails and a task will be created and assigned to me(blamed diff author) or PyText oncall(if the author can't be identified)

Reviewed By: clairehjk

Differential Revision: D16953648

