### PR TITLE
Use "text" in sample input to be consistent with config

### DIFF
--- a/pytext/docs/source/atis_tutorial.rst
+++ b/pytext/docs/source/atis_tutorial.rst
@@ -148,7 +148,7 @@ Lets make the model run on some sample utterances! You can input one by running
 .. code-block:: console
 
     (pytext) $ pytext --config-file demo/atis_joint_model/atis_joint_config.json \
-      predict --exported-model /tmp/atis_joint_model.c2 <<< '{"raw_text": "flights from colorado"}'
+      predict --exported-model /tmp/atis_joint_model.c2 <<< '{"text": "flights from colorado"}'
 
 The response from the model is log of probabilities for different intents and slots, with the correct intent and slot hopefully having the highest.
 


### PR DESCRIPTION
https://github.com/facebookresearch/pytext/issues/919

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This tutorial is outdated. With the new data API(TokenTensorizer) and sample config in the tutorial, we should use sample input '{"text": "flights from colorado"}' instead of '{"raw_text": "flights from colorado"}'. Thanks @deepali-c for reporting it.
<!--- Please link to an existing issue here if one exists. -->
https://github.com/facebookresearch/pytext/issues/919
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
