### PR TITLE
Clean up dependency on Github repo and binary(FairSeq, PyTorch)

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,6 +1,5 @@
-https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
 click
-fairseq @ git+https://github.com/pytorch/fairseq.git@master#egg=fairseq-0
+fairseq
 future
 hypothesis<4.0
 joblib


### PR DESCRIPTION
Summary: CirclCI build_docs failed due to latest commit in FairSeq repo. We should depend on released version only https://github.com/pytorch/fairseq/commit/4fc39538aec5141aa41f5d6d7dc0097e7c0f7b48

Differential Revision: D17055317

