### PR TITLE
Use torch.equal() instead of "==" in Custom Tensorizer tutorial

### DIFF
--- a/pytext/docs/source/tensorizer.rst
+++ b/pytext/docs/source/tensorizer.rst
@@ -148,5 +148,5 @@ We can test our tensorizer with the following code that initializes the vocab, t
     numberized_rows = (tensorizer.numberize(r) for r in rows)
     words_tensors, seq_len_tensors = tensorizer.tensorize(numberized_rows))
     # Notice the padding (1) of the 2nd tensor to match the dimension
-    assert words_tensors == tensor([[2, 3, 4, 5], [6, 7, 8, 1]])
-    assert seq_len_tensors == tensor([4, 3])
+    assert words_tensors.equal(torch.tensor([[2, 3, 4, 5], [6, 7, 8, 1]]))
+    assert seq_len_tensors.equal(torch.tensor([4, 3]))


### PR DESCRIPTION
#528  Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
1. "==" is equivalent to torch.eq() which returns multi-dimensional Tensor and causes "RuntimeError: bool value of Tensor with more than one value is ambiguous" 
2. torch.equal(): returns True if two tensors have the same size and elements, False otherwise.

<!--- Please link to an existing issue here if one exists. -->
https://github.com/facebookresearch/pytext/issues/934
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
N/A, tutorial update
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
