### PR TITLE
Expose more special tokens & simplify

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -76,8 +76,8 @@ class BERTTensorizer(TokenTensorizer):
             text,
             tokenizer=self.tokenizer,
             vocab=self.vocab,
-            add_bos_token=False,
-            add_eos_token=self.add_eos_token,
+            bos_token=None,
+            eos_token=EOS,
             max_seq_len=self.max_seq_len,
         )
 

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -41,22 +41,14 @@ class LookupTokensTest(unittest.TestCase):
         tokenizer = Tokenizer()
         vocab = Vocabulary(text.split() + [BOS, EOS])
         tokens, start_idx, end_idx = lookup_tokens(
-            text,
-            tokenizer=tokenizer,
-            vocab=vocab,
-            add_bos_token=False,
-            add_eos_token=False,
+            text, tokenizer=tokenizer, vocab=vocab, bos_token=None, eos_token=None
         )
         self.assertEqual(tokens, [0, 1, 2])
         self.assertEqual(start_idx, (0, 6, 15))
         self.assertEqual(end_idx, (5, 14, 19))
 
         tokens, start_idx, end_idx = lookup_tokens(
-            text,
-            tokenizer=tokenizer,
-            vocab=vocab,
-            add_bos_token=True,
-            add_eos_token=True,
+            text, tokenizer=tokenizer, vocab=vocab, bos_token=BOS, eos_token=EOS
         )
         self.assertEqual(tokens, [3, 0, 1, 2, 4])
         self.assertEqual(start_idx, (-1, 0, 6, 15, -1))

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 import torch
 from pytext.config.field_config import WordFeatConfig
 from pytext.data.tensorizers import Tensorizer
-from pytext.data.utils import UNK
 from pytext.fields import FieldMeta
 from pytext.utils.embeddings import PretrainedEmbedding
 from torch import nn
@@ -74,12 +73,12 @@ class WordEmbedding(EmbeddingBase):
                 )
                 embeddings_weight = pretrained_embedding.initialize_embeddings_weights(
                     tensorizer.vocab.idx,
-                    UNK,
+                    tensorizer.vocab.unk_token,
                     config.embed_dim,
                     config.embedding_init_strategy,
                 )
             num_embeddings = len(tensorizer.vocab)
-            unk_token_idx = tensorizer.vocab.idx[UNK]
+            unk_token_idx = tensorizer.vocab.get_unk_index()
         else:  # This else condition should go away after metadata goes away.
             num_embeddings = metadata.vocab_size
             embeddings_weight = metadata.pretrained_embeds_weight


### PR DESCRIPTION
Summary:
`VocabBuilder` already exposed a `pad_token`, with the rationale that some tokenization libraries use a special pad token, and it should be configurable. This diff does the same for UNK/BOS/EOS.

The changes to the public interface are minimal.

Differential Revision: D17053103

