### PR TITLE
Scalars returned from dict in TorchScript

### DIFF
--- a/pytext/models/output_layers/doc_classification_output_layer.py
+++ b/pytext/models/output_layers/doc_classification_output_layer.py
@@ -118,7 +118,7 @@ class ClassificationScores(jit.ScriptModule):
             example_scores = example_scores.squeeze(dim=0)
             example_response = jit.annotate(Dict[str, float], {})
             for i in range(len(self.classes)):
-                example_response[self.classes[i]] = example_scores[i].item()
+                example_response[self.classes[i]] = float(example_scores[i].item())
             results.append(example_response)
         return results
 


### PR DESCRIPTION
Summary:
We were unable to jit.load() a model because of an error coming from the changed code.

A scalar value from the dictionary, and needs explicit type-cast.

If you're working at FB: https://our.intern.facebook.com/intern/qa/21039/trouble-using-jitload-in-bento-to-load-and-run-tor

Differential Revision: D17207285

