### PR TITLE
config implicit class should be the default value

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -552,64 +552,74 @@ def flatten_deprecated_ensemble_config(json_config):
     return json_config
 
 
+def migrate_to_new_data_handler(task, columns):
+    create_parameter(task, "data.source", {"TSVDataSource": {}})
+    rename_parameter(task, "data_handler.eval_path", "data.source.eval_filename")
+    rename_parameter(task, "data_handler.test_path", "data.source.test_filename")
+    rename_parameter(task, "data_handler.train_path", "data.source.train_filename")
+    _, _, columns_to_read = find_parameter(task, "task.featurizer.convert_to_bytes")
+    if columns_to_read:
+        rename_parameter(
+            task, "data_handler.columns_to_read", "data.source.field_names"
+        )
+    else:
+        create_parameter(task, "data.source.field_names", columns)
+
+    rename_parameter(
+        task, "data_handler.append_bos", "model.inputs.tokens.add_bos_token"
+    )
+    rename_parameter(
+        task, "data_handler.append_eos", "model.inputs.tokens.add_eos_token"
+    )
+    rename_parameter(
+        task, "data_handler.max_seq_len", "model.inputs.tokens.max_seq_len"
+    )
+
+    rename_parameter(
+        task, "features.shared_module_key", "model.embedding.shared_module_key"
+    )
+    rename_parameter(task, "features.word_feat.embed_dim", "model.embedding.embed_dim")
+    rename_parameter(task, "features.dense_feat", "model.inputs.dense")
+
+    create_parameter(task, "data.batcher", {"PoolingBatcher": {}})
+    rename_parameter(
+        task, "data_handler.eval_batch_size", "data.batcher.eval_batch_size"
+    )
+    rename_parameter(
+        task, "data_handler.test_batch_size", "data.batcher.test_batch_size"
+    )
+    rename_parameter(
+        task, "data_handler.train_batch_size", "data.batcher.train_batch_size"
+    )
+
+    rename_parameter(
+        task,
+        "features.word_feat.vocab_size",
+        "model.inputs.tokens.vocab.size_from_data",
+    )
+    rename_parameter(
+        task,
+        "features.word_feat.vocab_from_train_data",
+        "model.inputs.tokens.vocab.build_from_data",
+    )
+
+    rename_parameter(
+        task,
+        "features.word_feat.vocab_file",
+        "model.inputs.tokens.vocab.vocab_files",
+        lambda x: [{"filepath": x}],
+    )
+
+    delete_parameter(task, "data_handler")
+    delete_parameter(task, "features")
+    delete_parameter(task, "featurizer")
+
+
 @register_adapter(from_version=15)
 def remove_lmtask_deprecated(json_config):
     for section in find_dicts_containing_key(json_config, "LMTask_Deprecated"):
         task = section.pop("LMTask_Deprecated")
-
-        create_parameter(task, "data.source", {"TSVDataSource": {}})
-        rename_parameter(task, "data_handler.eval_path", "data.source.eval_filename")
-        rename_parameter(task, "data_handler.test_path", "data.source.test_filename")
-        rename_parameter(task, "data_handler.train_path", "data.source.train_filename")
-        create_parameter(task, "data.source.field_names", ["text"])
-
-        rename_parameter(
-            task, "data_handler.append_bos", "model.inputs.tokens.add_bos_token"
-        )
-        rename_parameter(
-            task, "data_handler.append_eos", "model.inputs.tokens.add_eos_token"
-        )
-
-        rename_parameter(
-            task, "features.shared_module_key", "model.embedding.shared_module_key"
-        )
-        rename_parameter(
-            task, "features.word_feat.embed_dim", "model.embedding.embed_dim"
-        )
-
-        create_parameter(task, "data.batcher", {"PoolingBatcher": {}})
-        rename_parameter(
-            task, "data_handler.eval_batch_size", "data.batcher.eval_batch_size"
-        )
-        rename_parameter(
-            task, "data_handler.test_batch_size", "data.batcher.test_batch_size"
-        )
-        rename_parameter(
-            task, "data_handler.train_batch_size", "data.batcher.train_batch_size"
-        )
-
-        rename_parameter(
-            task,
-            "features.word_feat.vocab_size",
-            "model.inputs.tokens.vocab.size_from_data",
-        )
-        rename_parameter(
-            task,
-            "features.word_feat.vocab_from_train_data",
-            "model.inputs.tokens.vocab.build_from_data",
-        )
-
-        rename_parameter(
-            task,
-            "features.word_feat.vocab_file",
-            "model.inputs.tokens.vocab.vocab_files",
-            lambda x: [{"filepath": x}],
-        )
-
-        delete_parameter(task, "data_handler")
-        delete_parameter(task, "features")
-        delete_parameter(task, "featurizer")
-
+        migrate_to_new_data_handler(task, ["text"])
         section["LMTask"] = task
 
     return json_config

--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -175,7 +175,10 @@ def config_from_json(cls, json_obj, ignore_fields=()):
         value = None
         is_optional = _is_optional(f_cls)
 
-        if field not in json_obj:
+        if (
+            field not in json_obj
+            or getattr(f_cls, "__name__", None) == "BaseModel.Config"
+        ):
             if field in cls._field_defaults:
                 # if using default value, no conversion is needed
                 value = cls._field_defaults.get(field)

--- a/pytext/config/utils.py
+++ b/pytext/config/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import Union
+from typing import Dict, List, Union
 
 
 def is_component_class(obj):
@@ -38,6 +38,8 @@ def resolve_optional(type_v):
 
 
 def cast_str(to_type, value):
+    if type(value) != str:
+        return value
     if to_type == int:
         return int(value)
     elif to_type == float:
@@ -51,9 +53,9 @@ def cast_str(to_type, value):
             return False
         else:
             raise Exception(f'Not a boolean value: "{value}"')
-    elif getattr(to_type, "__origin__", None) == list:
+    elif getattr(to_type, "__origin__", None) in (list, List):
         return [cast_str(to_type.__args__[0], v.strip()) for v in value.split(",")]
-    elif getattr(to_type, "__origin__", None) == dict:
+    elif getattr(to_type, "__origin__", None) in (dict, Dict):
         key_type, value_type = to_type.__args__
         ret = {}
         for entry in value.split(","):


### PR DESCRIPTION
Summary:
DocumentClassificationTask.Config declares

    model: BaseModel.Config = DocModel.Config()

When a config references "model" without specifying the class name (like in the example below), we expect it to use DocModel.

  {
    "task": {
      "DocumentClassificationTask": {
        "model": {
          "representation": {
            "DocNNRepresentation": {}
          }
        }
    ...

But what really happens is it uses BaseModel and fails with the error message:

  pytext.config.serialize.ConfigParseError: Unknown fields for class BaseModel.Config with fields {'inputs'}
  detected in config json: {'representation'}"

If your json does not reference "model", it works because in this case we use the default value.

This diff fixes this problem by always using the default value when present, whether the parameter name is in the config or not.

Differential Revision: D17208598

