### PR TITLE
Reduce MaskedLM memory usage

### DIFF
--- a/pytext/models/masked_lm.py
+++ b/pytext/models/masked_lm.py
@@ -127,7 +127,7 @@ class MaskedLanguageModel(BaseModel):
 
     def forward(self, *inputs) -> List[torch.Tensor]:
         encoded_layers, _ = self.encoder(inputs)
-        return self.decoder(encoded_layers[-1])
+        return self.decoder(encoded_layers[-1][self.mask.bool(), :])
 
     def _select_tokens_to_mask(
         self, tokens: torch.Tensor, mask_prob: float
@@ -165,4 +165,4 @@ class MaskedLanguageModel(BaseModel):
         return tokens * (1 - mask) + replacement * mask
 
     def _mask_output(self, tokens, mask):
-        return tokens * mask + self.vocab.get_pad_index() * (1 - mask)
+        return torch.masked_select(tokens, mask.bool())


### PR DESCRIPTION
Summary:
For MaskedLM, we only need to compute the logits (and targets) for the masked tokens (since the rest are ignored in the loss anyways). To do this, pass just the masked token hidden states to the decoder.

This saves

1) quite a bit of memory: .85 * batch_size * num_tokens_per_packed_sample * output_vocab_size (* a small number for the logits, log_softmaxes, etc)

2) some computation, since we don't need to compute the full softmax distribution from the final states for all those masked tokens

Differential Revision: D17241503

