### PR TITLE
make multilingual TrainAndTestWorkflow work with joint model

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -96,7 +96,7 @@ class PyTextConfig(ConfigBase):
     # Where to save the trained pytorch model
     save_snapshot_path: str = "/tmp/model.pt"
     # Exported caffe model will be stored here
-    export_caffe2_path: Optional[str] = "/tmp/model.caffe2.predictor"
+    export_caffe2_path: Optional[str] = None
     # Exported onnx model will be stored here
     export_onnx_path: str = "/tmp/model.onnx"
     # Exported torchscript model will be stored here


### PR DESCRIPTION
Summary:
This diff:
1. makes multilingual TrainAndTestWorkflow work for joint model
2. add an optional language for user to specify language for XLM
3. note that I have to move the definition of MULTILINGUAL_TASK_CONFIG to another file for tests to pass since I called get_py2_flow_type_config, which would break pytext TrainWorkflow

Differential Revision: D17173712

