### PR TITLE
Fix bug in copy_unk

### DIFF
--- a/pytext/utils/torch.py
+++ b/pytext/utils/torch.py
@@ -123,7 +123,7 @@ class Vocabulary(torch.jit.ScriptModule):
 
     @torch.jit.script_method
     def lookup_word(self, idx: int, possible_unk_token: Optional[str] = None):
-        if idx < len(self.vocab):
+        if idx < len(self.vocab) and idx != self.unk_idx:
             return self.vocab[idx]
         else:
             return (


### PR DESCRIPTION
Summary:
When the copy_unk flag is set to true. Any unk that is produced in the output of the Seq2Seq model is replaced by the token that was mapped to unk from the utterance. This is a easy way to get gains since outputs with unk are always wrong.

Looking at the old code for copying the unk token we see that TorchScript optimizes out the actual search of the unk token in utterance:

{F207887831}

This diff updates the code to produce the correct TorchScript Graph

{F207888470}

Differential Revision: D17213086

