### PR TITLE
force print important training stage for each worker

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -342,7 +342,7 @@ class Data(Component):
             if numberized_rows is None:
                 numberized_rows = self.cache(self.numberize_rows(indexed_rows), stage)
             else:
-                print(f"Get numberized rows from cache in stage: {stage}", flush=True)
+                print(f"Get numberized rows from cache in stage: {stage}")
         else:
             numberized_rows = self.numberize_rows(indexed_rows)
         sort_key = self.sort_key

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -12,7 +12,7 @@ from pytext.data.tensorizers import Tensorizer
 from pytext.metric_reporters import MetricReporter
 from pytext.models.model import BaseModel
 from pytext.trainers import TaskTrainer, TrainingState
-from pytext.utils import cuda, precision
+from pytext.utils import cuda, distributed, precision
 from torch import jit
 
 from .task import TaskBase
@@ -97,6 +97,7 @@ class _NewTask(TaskBase):
         rank=0,
         world_size=1,
     ):
+        distributed.force_print(f"Creating task: {cls.__name__}...", flush=True)
         tensorizers, data = cls._init_tensorizers(config, tensorizers, rank, world_size)
 
         # Initialized tensorizers can be used to create the model

--- a/pytext/task/serialize.py
+++ b/pytext/task/serialize.py
@@ -11,6 +11,7 @@ from pytext.data import CommonMetadata
 from pytext.data.tensorizers import Tensorizer
 from pytext.models import Model
 from pytext.trainers.training_state import TrainingState
+from pytext.utils import distributed
 
 
 DATA_STATE = "data_state"
@@ -90,6 +91,7 @@ def load_v3(state):
 
 def load_checkpoint(f: io.IOBase):
     state = torch.load(f, map_location=lambda storage, loc: storage)
+    distributed.force_print(f"Loaded checkpoint...", flush=True)
     if SERIALIZE_VERSION_KEY not in state:
         return load_v1(state)
     else:
@@ -197,7 +199,7 @@ class CheckpointManager:
         """
         if not (load_path and os.path.isfile(load_path)):
             raise ValueError(f"Invalid snapshot path{load_path}")
-        print(f"Loading model from {load_path}...")
+        distributed.force_print(f"Loading model from {load_path}...", flush=True)
         with open(load_path, "rb") as checkpoint_f:
             return load_checkpoint(checkpoint_f)
 

--- a/pytext/utils/distributed.py
+++ b/pytext/utils/distributed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import pytext.utils.cuda as cuda
 import torch
 import torch.distributed as dist_c10d
 
@@ -46,6 +47,17 @@ def suppress_output():
             builtin_print(*args, **kwargs)
 
     __builtin__.print = print
+
+
+def force_print(*args, **kwargs):
+    if cuda.CUDA_ENABLED and cuda.DISTRIBUTED_WORLD_SIZE > 1:
+        try:
+            device_info = f" [device:{torch.cuda.current_device()}]"
+            print(*args, device_info, **kwargs, force=True)
+        except TypeError:
+            pass
+    else:
+        print(*args, **kwargs)
 
 
 def get_shard_range(dataset_size: int, rank: int, world_size: int):

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -106,8 +106,8 @@ def prepare_task(
     metric_channels: Optional[List[Channel]] = None,
     metadata: CommonMetadata = None,
 ) -> Tuple[Task_Deprecated, TrainingState]:
-
-    print("\nParameters: {}\n".format(config))
+    if rank == 0:
+        print("\nParameters: {}\n".format(config), flush=True)
     _set_cuda(config.use_cuda_if_available, device_id, world_size)
     _set_fp16(config.use_fp16)
     _set_distributed(rank, world_size, dist_init_url, device_id)


### PR DESCRIPTION
Summary:
force print important training stage for each worker
DistributedTraining suppress buildin_print unless add flag force=True, to better understanding each worker stage, we add force_print for some important logging.

Differential Revision: D17278000

