### PR TITLE
Cosine similarity support for BERT pairwise model training

### DIFF
--- a/pytext/loss/__init__.py
+++ b/pytext/loss/__init__.py
@@ -4,6 +4,7 @@
 from .loss import (
     AUCPRHingeLoss,
     BinaryCrossEntropyLoss,
+    CosineEmbeddingLoss,
     CrossEntropyLoss,
     KLDivergenceBCELoss,
     KLDivergenceCELoss,
@@ -20,6 +21,7 @@ __all__ = [
     "AUCPRHingeLoss",
     "Loss",
     "CrossEntropyLoss",
+    "CosineEmbeddingLoss",
     "BinaryCrossEntropyLoss",
     "MultiLabelSoftMarginLoss",
     "KLDivergenceBCELoss",

--- a/pytext/models/bert_classification_models.py
+++ b/pytext/models/bert_classification_models.py
@@ -138,6 +138,10 @@ class BertPairwiseModel(BasePairwiseModel):
         encoder: TransformerSentenceEncoderBase.Config = (
             HuggingFaceBertSentenceEncoder.Config()
         )
+        # Decoder is a fully connected layer that expects concatenated encodings.
+        # So, if decoder is provided we will concatenate the encodings from the
+        # encoders and then pass to the decoder.
+        decoder: Optional[MLPDecoder.Config] = MLPDecoder.Config()
         shared_encoder: bool = True
 
     def __init__(
@@ -190,8 +194,7 @@ class BertPairwiseModel(BasePairwiseModel):
         encodings = [self.encoder1(input_tuple1)[0], self.encoder2(input_tuple2)[0]]
         if self.encode_relations:
             encodings = self._encode_relations(encodings)
-        encoding = torch.cat(encodings, -1)
-        return self.decoder(encoding)
+        return self.decoder(torch.cat(encodings, -1)) if self.decoder else encodings
 
     def save_modules(self, base_path: str = "", suffix: str = ""):
         self._save_modules(self.encoders, base_path, suffix)

--- a/pytext/models/decoders/mlp_decoder.py
+++ b/pytext/models/decoders/mlp_decoder.py
@@ -54,7 +54,7 @@ class MLPDecoder(DecoderBase):
             if config.dropout > 0:
                 layers.append(nn.Dropout(config.dropout))
             in_dim = dim
-        if config.out_dim:
+        if config.out_dim is not None:
             out_dim = config.out_dim
         if out_dim > 0:
             layers.append(nn.Linear(in_dim, out_dim))

--- a/pytext/models/output_layers/__init__.py
+++ b/pytext/models/output_layers/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from .distance_output_layer import PairwiseCosineDistanceOutputLayer
 from .doc_classification_output_layer import ClassificationOutputLayer
 from .doc_regression_output_layer import RegressionOutputLayer
 from .output_layer_base import OutputLayerBase
@@ -16,5 +17,6 @@ __all__ = [
     "RegressionOutputLayer",
     "WordTaggingOutputLayer",
     "PairwiseRankingOutputLayer",
+    "PairwiseCosineDistanceOutputLayer",
     "OutputLayerUtils",
 ]

--- a/pytext/models/output_layers/distance_output_layer.py
+++ b/pytext/models/output_layers/distance_output_layer.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import List, Optional
+
+import torch
+import torch.nn.functional as F
+from pytext.config.component import create_loss
+from pytext.data.utils import Vocabulary
+from pytext.fields import FieldMeta
+from pytext.loss import CosineEmbeddingLoss
+from pytext.models.output_layers.output_layer_base import OutputLayerBase
+
+
+class PairwiseCosineDistanceOutputLayer(OutputLayerBase):
+    class Config(OutputLayerBase.Config):
+        loss: CosineEmbeddingLoss.Config = CosineEmbeddingLoss.Config()
+        cosine_distance_threshold: float = 0.9
+
+    @classmethod
+    def from_config(
+        cls,
+        config,
+        metadata: Optional[FieldMeta] = None,
+        labels: Optional[Vocabulary] = None,
+    ):
+        return cls(
+            list(labels), create_loss(config.loss), config.cosine_distance_threshold
+        )
+
+    def __init__(
+        self,
+        target_names: Optional[List[str]] = None,
+        loss_fn: CosineEmbeddingLoss = None,
+        cosine_distance_threshold=Config.cosine_distance_threshold,
+    ):
+        super().__init__(target_names, loss_fn)
+        self.cosine_distance_threshold = cosine_distance_threshold
+
+    def get_pred(self, logits: torch.Tensor, targets: torch.Tensor, *args, **kwargs):
+        distances = F.cosine_similarity(logits[0], logits[1], dim=1)
+        preds = (distances >= self.cosine_distance_threshold).to(dtype=torch.long)
+
+        # Since metric reporting depends on returning a distribution over labels,
+        # we will fake a distribution over two labels. We will insert the distance
+        # at pred_index (pred_index = 0 or 1) in the scores tensor.
+        scores = torch.zeros(logits[0].size(0), 2, device=logits[0].device)
+        scores = scores.scatter(
+            dim=1, index=preds.unsqueeze(1), src=distances.unsqueeze(1)
+        )
+
+        return preds, scores

--- a/pytext/models/output_layers/output_layer_base.py
+++ b/pytext/models/output_layers/output_layer_base.py
@@ -5,8 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from caffe2.python import core
-from pytext.config.component import create_loss
-from pytext.fields import FieldMeta
 from pytext.loss import Loss
 from pytext.models.module import Module
 

--- a/pytext/models/representations/transformer_sentence_encoder.py
+++ b/pytext/models/representations/transformer_sentence_encoder.py
@@ -105,6 +105,17 @@ class TransformerSentenceEncoder(TransformerSentenceEncoderBase):
             else None
         )
 
+    def load_state_dict(self, state_dict):
+        # "projection" must be be in sync with the name of member variable projection.
+        has_projection = any("projection" in key for key in state_dict.keys())
+        if self.projection is not None and not has_projection:
+            projection_temp = self.projection
+            self.projection = None
+            super().load_state_dict(state_dict)
+            self.projection = projection_temp
+        else:
+            super().load_state_dict(state_dict)
+
     def _encoder(
         self, input_tuple: Tuple[torch.Tensor, ...]
     ) -> Tuple[torch.Tensor, ...]:

--- a/pytext/optimizer/activations.py
+++ b/pytext/optimizer/activations.py
@@ -45,7 +45,7 @@ def get_activation(name):
     elif name == Activation.LEAKYRELU:
         return nn.LeakyReLU()
     elif name == Activation.TANH:
-        return torch.tanh
+        return nn.Tanh()
     elif name == Activation.GELU:
         return GeLU()
     elif name == Activation.GLU:


### PR DESCRIPTION
Summary: Change to support to train against cosine similarity as target for `BasePairwiseModel`.

Differential Revision: D17292065

