### PR TITLE
Division by Zero bug in MLM Metric Reporter

### DIFF
--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -190,7 +190,7 @@ class MaskedLMMetricReporter(LanguageModelMetricReporter):
         if not n_batches % 1000:
             tps = self.realtime_meters["tps"].avg
             print(
-                f"Tokens/s: {total_tokens / (now - self.time):.0f}, "
+                f"Tokens/s: {total_tokens / ((now - self.time) + 0.000001):.0f}, "
                 f"batch ppl: {math.exp(loss.item()):.2f}, "
                 f"agg ppl: {math.exp(self.aggregate_loss / float(self.total_num_tokens)):.2f}, "
                 f"number of batches: {n_batches}, "


### PR DESCRIPTION
Summary:
While using fp16 during MLM training there's a weird bug during metric reporting that causes a division by zero failure while computing the training speed (an example is below). Preventing this failure by adding a small value to the denominator.

Example: f136667996

Reviewed By: chenyangyu1988

Differential Revision: D17293910

