### PR TITLE
add use_config_from_snapshot option(load config from snapshot or current task)

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -95,6 +95,8 @@ class PyTextConfig(ConfigBase):
     load_snapshot_path: str = ""
     # Where to save the trained pytorch model
     save_snapshot_path: str = "/tmp/model.pt"
+    # True: use the config saved in snapshot. False: use config from current task
+    use_config_from_snapshot: bool = True
     # Exported caffe model will be stored here
     export_caffe2_path: Optional[str] = None
     # Exported onnx model will be stored here

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -117,7 +117,12 @@ def prepare_task(
 
     training_state = None
     if config.load_snapshot_path and os.path.isfile(config.load_snapshot_path):
-        task, _config, training_state = load(config.load_snapshot_path)
+        if config.use_config_from_snapshot:
+            task, _, training_state = load(config.load_snapshot_path)
+        else:
+            task, _, training_state = load(
+                config.load_snapshot_path, overwrite_config=config
+            )
         if training_state:
             training_state.rank = rank
     else:


### PR DESCRIPTION
Summary:
Problem:
Currently when we call load() from a snapshot, it will construct task with the config saved in the snapshot. However, sometimes, we want to overwrite the config by current task's config

Solution:
add "use_config_from_snapshot" to PyTextConfig. By default, it use the config saved in snapshot. If we set use_config_from_snapshot=false, it will overwrite the config by current task's config

Differential Revision: D17299252

