### PR TITLE
save/load state_dict for optimizer and scheduler

### DIFF
--- a/pytext/models/test/personalized_doc_model_test.py
+++ b/pytext/models/test/personalized_doc_model_test.py
@@ -96,8 +96,11 @@ class PersonalizationTrainerTest(unittest.TestCase):
 
         orig_p13n_model = copy.deepcopy(p13n_task.model)
 
-        baseline_model, baseline_metrics = baseline_task.train(baseline_config)
-        p13n_model, p13n_metrics = p13n_task.train(p13n_config)
+        baseline_training_state = baseline_task.train(baseline_config)
+        baseline_metrics = baseline_training_state.best_model_metric
+        p13n_training_state = p13n_task.train(p13n_config)
+        p13n_model = p13n_training_state.model
+        p13n_metrics = p13n_training_state.best_model_metric
 
         # Verify that the training changes the p13n_model.
         self.assertNotEqual(get_mismatched_param([orig_p13n_model, p13n_model]), "")
@@ -122,7 +125,8 @@ class PersonalizationTrainerTest(unittest.TestCase):
         orig_user_embedding_weights = copy.deepcopy(
             p13n_task.model.user_embedding.weight
         )
-        p13n_model, _ = p13n_task.train(pytext_config)
+        training_state = p13n_task.train(pytext_config)
+        p13n_model = training_state.model
         trained_user_embedding_weights = p13n_model.user_embedding.weight
 
         self.assertEqual(

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -100,6 +100,8 @@ class _NewTask(TaskBase):
         tensorizers=None,
         rank=0,
         world_size=1,
+        optimizer_state_dict: Dict = None,
+        scheduler_state_dict: Dict = None,
     ):
         distributed.force_print(f"Creating task: {cls.__name__}...", flush=True)
         tensorizers, data = cls._init_tensorizers(config, tensorizers, rank, world_size)
@@ -111,7 +113,9 @@ class _NewTask(TaskBase):
         # features and tensors are being used. This is a strong tie between
         # the implementation of the model and the metric reporter.
         metric_reporter = cls.create_metric_reporter(config, tensorizers)
-        trainer = create_trainer(config.trainer, model)
+        trainer = create_trainer(
+            config.trainer, model, optimizer_state_dict, scheduler_state_dict
+        )
         return cls(data, model, metric_reporter, trainer)
 
     @classmethod

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pytext.common.constants import BatchContext
 from pytext.config import ConfigBase
@@ -27,7 +27,14 @@ from pytext.utils import cuda, precision
 
 
 def create_task(
-    task_config, metadata=None, model_state=None, tensorizers=None, rank=0, world_size=1
+    task_config,
+    metadata=None,
+    model_state=None,
+    tensorizers=None,
+    rank=0,
+    world_size=1,
+    optimizer_state_dict: Dict = None,
+    scheduler_state_dict: Dict = None,
 ):
     """
     Create a task by finding task class in registry and invoking the from_config
@@ -41,6 +48,8 @@ def create_task(
         tensorizers=tensorizers,
         rank=rank,
         world_size=world_size,
+        optimizer_state_dict=optimizer_state_dict,
+        scheduler_state_dict=scheduler_state_dict,
     )
 
 
@@ -69,6 +78,8 @@ class TaskBase(Component):
         tensorizers=None,
         rank=1,
         world_size=0,
+        optimizer_state_dict: Dict = None,
+        scheduler_state_dict: Dict = None,
     ):
         """
         Create the task from config, and optionally load metadata/model_state
@@ -123,7 +134,9 @@ class TaskBase(Component):
             else None
         )
         return cls(
-            trainer=create_trainer(task_config.trainer, model),
+            trainer=create_trainer(
+                task_config.trainer, model, optimizer_state_dict, scheduler_state_dict
+            ),
             data_handler=data_handler,
             model=model,
             metric_reporter=metric_reporter,

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -84,17 +84,17 @@ def train_model(
     world_size: int = 1,
     metric_channels: Optional[List[Channel]] = None,
     metadata: CommonMetadata = None,
-) -> Tuple:
+) -> TrainingState:
     task, training_state = prepare_task(
         config, dist_init_url, device_id, rank, world_size, metric_channels, metadata
     )
-    trained_model, best_metric = task.train(config, rank, world_size, training_state)
+    training_state = task.train(config, rank, world_size, training_state)
     # Only rank 0 gets to finalize the job and export the model
     if rank == 0:
-        save_and_export(config, task, metric_channels)
+        save_and_export(config, task, metric_channels, training_state)
     print("Training timings")
     timing.report()
-    return trained_model, best_metric
+    return training_state
 
 
 def prepare_task(
@@ -139,16 +139,14 @@ def prepare_task(
 def save_and_export(
     config: PyTextConfig,
     task: Task_Deprecated,
+    trainingstate: TrainingState,
     metric_channels: Optional[List[Channel]] = None,
 ) -> None:
     print("\n=== Saving model to: " + config.save_snapshot_path)
     meta = None
-    tensorizers = None
     if hasattr(task, "data_handler"):
         meta = task.data_handler.metadata_to_save()
-    else:
-        tensorizers = task.data.tensorizers
-    save(config, task.model, meta, tensorizers=tensorizers)
+    save(config=config, training_state=trainingstate, meta=meta)
     if config.export_caffe2_path:
         task.export(
             task.model,


### PR DESCRIPTION
Summary:
Instead of saving optimizer and scheduler object directly. We should instead save state_dict.

Existing logic: load training_state directly

Instead we should: load optimizer and scheduler state_dict, and calling load_state_dict in trainer constructor

reference: https://pytorch.org/tutorials/beginner/saving_loading_models.html

Differential Revision: D17354171

