### PR TITLE
Sparsification for CRF transition matrix

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -204,9 +204,8 @@ class Trainer(TrainerBase):
         if state.stage != Stage.TRAIN:
             return
 
-        if state.epoch >= state.sparsifier.starting_epoch:
-            if state.step_counter % state.sparsifier.frequency == 0:
-                state.sparsifier.sparsify(state.model)
+        if state.sparsifier.sparsification_condition(state):
+            state.sparsifier.sparsify(state)
 
         if state.rank == 0:
             current_sparsity = state.sparsifier.get_current_sparsity(state.model)


### PR DESCRIPTION
Summary:
1. added sparsification support for CRF. Two sparsification methods are supported a) l1-regularization via soft-thresholding method to update the transition matrix
b) magnitude-based, which keeps top elements in each column of the transition matrix until sparsity is met.

2. small refactoring on how sparsifier is called in trainer.py. Sparsifier in effect only after a step if sparsification_condition returns true.

Differential Revision: D17408540

