### PR TITLE
Migrate NLGSeq2Seq to new PyText interface

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -297,7 +297,6 @@ def old_tasks_deprecated(json_config):
     deprecate(json_config, "FLQueryDocumentPairwiseRankingTask")
     deprecate(json_config, "KDDocClassificationTask")
     deprecate(json_config, "LMTask")
-    deprecate(json_config, "NLGSeq2SeqTask")
     deprecate(json_config, "PairClassificationTask")
     deprecate(json_config, "PairwiseAttentionClassificationTask")
     deprecate(json_config, "QueryDocumentPairwiseRankingTask")


### PR DESCRIPTION
Summary:
- 20% reduction in p50 latency, and p99 is just below 100 on our benchmarking set now
- Free two point increase in tree acc while training
- No regressions in exported model accuracies (which is good since we're doing more aggressive quantization, as well as the beam search implementation has changed).

Differential Revision: D17376671

