### PR TITLE
Add dense feature normalization to Char-LSTM TorchScript model.

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -300,6 +300,7 @@ class ByteTokensDocumentModel(DocModel):
             def __init__(self):
                 super().__init__()
                 self.vocab = Vocabulary(input_vocab, unk_idx=input_vocab.idx[UNK])
+                self.normalizer = tensorizers["dense"].normalizer
                 self.max_byte_len = jit.Attribute(max_byte_len, int)
                 self.byte_offset_for_non_padding = jit.Attribute(
                     byte_offset_for_non_padding, int
@@ -316,6 +317,7 @@ class ByteTokensDocumentModel(DocModel):
                 token_bytes, _ = make_byte_inputs(
                     tokens, self.max_byte_len, self.byte_offset_for_non_padding
                 )
+                dense_feat = self.normalizer.normalize(dense_feat)
                 logits = self.model(
                     torch.tensor(word_ids),
                     token_bytes,


### PR DESCRIPTION
Summary:
In D16357113 we added dense feature tokenisation to the `DocModel` architecture. As the `ByteTokensDocumentModel` extends the `DocModel` class and uses the `FloatListTensorizer` class, feature normalisation was already supported at training time after this diff was landed, however it was not supported at production time because the normalisation was not performed during the `torchscriptify` forward function. This presents a problem because the model can be trained on normalized data, but then won't be able to normalize fresh data at inference time, producing unusual results.

This diff adds normalisation in the `torchscriptify` forward function so that it can be used at inference time on Char-LSTM models.

Just like with the `DocModel`, if `normalize` is set to `false` in the config, then the normalization method just becomes the identity function, this is useful because we don't need to add any extra control flow directly in the forward function.

Reviewed By: snisarg

Differential Revision: D17358479

