### PR TITLE
remove multi gpu print

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -12,7 +12,7 @@ from pytext.data.tensorizers import Tensorizer
 from pytext.metric_reporters import MetricReporter
 from pytext.models.model import BaseModel
 from pytext.trainers import TaskTrainer, TrainingState
-from pytext.utils import cuda, distributed, precision
+from pytext.utils import cuda, precision
 from torch import jit
 
 from .task import TaskBase
@@ -101,7 +101,7 @@ class _NewTask(TaskBase):
         rank=0,
         world_size=1,
     ):
-        distributed.force_print(f"Creating task: {cls.__name__}...", flush=True)
+        print(f"Creating task: {cls.__name__}...")
         tensorizers, data = cls._init_tensorizers(config, tensorizers, rank, world_size)
 
         # Initialized tensorizers can be used to create the model

--- a/pytext/task/serialize.py
+++ b/pytext/task/serialize.py
@@ -11,7 +11,6 @@ from pytext.data import CommonMetadata
 from pytext.data.tensorizers import Tensorizer
 from pytext.models import Model
 from pytext.trainers.training_state import TrainingState
-from pytext.utils import distributed
 
 
 DATA_STATE = "data_state"
@@ -72,10 +71,10 @@ def load_v3(state, overwrite_config=None):
     saved_config = pytext_config_from_json(state[CONFIG_JSON])
     if overwrite_config:
         config = overwrite_config
-        distributed.force_print(f"Use config from current task", flush=True)
+        print(f"Use config from current task")
     else:
         config = saved_config
-        distributed.force_print(f"Use config saved in snapshot", flush=True)
+        print(f"Use config saved in snapshot")
 
     model_state = state[MODEL_STATE]
     training_state = state[TRAINING_STATE]
@@ -125,7 +124,7 @@ def load_v3(state, overwrite_config=None):
 
 def load_checkpoint(f: io.IOBase, overwrite_config=None):
     state = torch.load(f, map_location=lambda storage, loc: storage)
-    distributed.force_print(f"Loaded checkpoint...", flush=True)
+    print(f"Loaded checkpoint...")
     if SERIALIZE_VERSION_KEY not in state:
         return load_v1(state)
     else:
@@ -233,7 +232,7 @@ class CheckpointManager:
         """
         if not (load_path and os.path.isfile(load_path)):
             raise ValueError(f"Invalid snapshot path{load_path}")
-        distributed.force_print(f"Loading model from {load_path}...", flush=True)
+        print(f"Loading model from {load_path}...")
         with open(load_path, "rb") as checkpoint_f:
             return load_checkpoint(checkpoint_f, overwrite_config)
 

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -26,7 +26,7 @@ from pytext.optimizer.scheduler import Scheduler
 from pytext.optimizer.sparsifier import Sparsifier
 from pytext.task.serialize import save
 from pytext.trainers.training_state import TrainingState
-from pytext.utils import cuda, distributed, precision, timing
+from pytext.utils import cuda, precision, timing
 
 
 class TrainerBase(Component):
@@ -389,17 +389,13 @@ class Trainer(TrainerBase):
             state.epoch += 1
             state.epochs_since_last_improvement += 1
             lrs = learning_rates(state.optimizer)
-            distributed.force_print(
-                f"\nWorker {state.rank} starting epoch {state.epoch}", flush=True
-            )
+            print(f"\nWorker {state.rank} starting epoch {state.epoch}")
             print(f"Learning rate(s): {', '.join(map(str, lrs))}")
 
             with timing.time("train epoch"):
                 state.stage = Stage.TRAIN
                 state.model.train()
-                distributed.force_print(
-                    f"start training epoch {state.epoch}", flush=True
-                )
+                print(f"start training epoch {state.epoch}")
                 epoch_data = training_data
                 if self.config.num_batches_per_epoch:
                     # We want to limit the number of batches in the epoch;
@@ -418,9 +414,7 @@ class Trainer(TrainerBase):
             with timing.time("eval epoch"):
                 state.stage = Stage.EVAL
                 model.eval(Stage.EVAL)
-                distributed.force_print(
-                    f"start evaluating epoch {state.epoch}", flush=True
-                )
+                print(f"start evaluating epoch {state.epoch}")
                 with torch.no_grad():
                     eval_metric = self.run_epoch(state, eval_data, metric_reporter)
 
@@ -443,7 +437,7 @@ class Trainer(TrainerBase):
         if self.optimizer.finalize():
             state.stage = Stage.EVAL
             model.eval(Stage.EVAL)
-            distributed.force_print(f"start evaluating finalized state", flush=True)
+            print(f"start evaluating finalized state")
             with torch.no_grad():
                 eval_metric = self.run_epoch(state, eval_data, metric_reporter)
             better_model = metric_reporter.compare_metric(

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -29,30 +29,32 @@ def _set_cuda(
     elif cuda.CUDA_ENABLED:
         torch.cuda.set_device(device_id)
 
-    print(
-        """
-    # for debug of GPU
-    use_cuda_if_available: {}
-    device_id: {}
-    world_size: {}
-    torch.cuda.is_available(): {}
-    cuda.CUDA_ENABLED: {}
-    cuda.DISTRIBUTED_WORLD_SIZE: {}
-    """.format(
-            use_cuda_if_available,
-            device_id,
-            world_size,
-            torch.cuda.is_available(),
-            cuda.CUDA_ENABLED,
-            cuda.DISTRIBUTED_WORLD_SIZE,
+    if device_id == 0:
+        print(
+            """
+        # for debug of GPU
+        use_cuda_if_available: {}
+        device_id: {}
+        world_size: {}
+        torch.cuda.is_available(): {}
+        cuda.CUDA_ENABLED: {}
+        cuda.DISTRIBUTED_WORLD_SIZE: {}
+        """.format(
+                use_cuda_if_available,
+                device_id,
+                world_size,
+                torch.cuda.is_available(),
+                cuda.CUDA_ENABLED,
+                cuda.DISTRIBUTED_WORLD_SIZE,
+            )
         )
-    )
 
 
-def _set_fp16(use_fp16: bool) -> None:
+def _set_fp16(use_fp16: bool, rank: int) -> None:
     # only support single GPU training at this moment.
     precision.set_fp16(fp16_enabled=use_fp16)
-    print(f"# for debug of FP16: fp16_enabled={precision._FP16_ENABLED}")
+    if rank == 0:
+        print(f"# for debug of FP16: fp16_enabled={precision._FP16_ENABLED}")
 
 
 def _set_distributed(
@@ -109,7 +111,7 @@ def prepare_task(
     if rank == 0:
         print("\nParameters: {}\n".format(config), flush=True)
     _set_cuda(config.use_cuda_if_available, device_id, world_size)
-    _set_fp16(config.use_fp16)
+    _set_fp16(config.use_fp16, rank)
     _set_distributed(rank, world_size, dist_init_url, device_id)
 
     if config.random_seed is not None:


### PR DESCRIPTION
Summary:
flush print from different processes could cause logging out of order.
We will remove force_print force and came up a better logging mechanism for important training messages.

Differential Revision: D17440678

