### PR TITLE
Add decision thresholds to pytext metrics

### DIFF
--- a/pytext/metrics/tests/basic_metrics_test.py
+++ b/pytext/metrics/tests/basic_metrics_test.py
@@ -18,10 +18,10 @@ LABEL_NAMES1 = ["label1", "label2", "label3"]
 PREDICTIONS1 = [
     LabelPrediction(scores, predicted, expected)
     for scores, predicted, expected in [
-        ([0.5, 0.3, 0.2], 0, 0),
-        ([0.1, 0.8, 0.1], 1, 0),
-        ([0.3, 0.6, 0.1], 1, 1),
-        ([0.2, 0.1, 0.7], 2, 1),
+        ([-0.5, -0.7, -0.8], 0, 0),
+        ([-0.9, -0.2, -0.9], 1, 0),
+        ([-0.7, -0.4, -0.9], 1, 1),
+        ([-0.8, -0.9, -0.3], 2, 1),
     ]
 ]
 
@@ -29,11 +29,11 @@ LABEL_NAMES2 = ["label1", "label2"]
 PREDICTIONS2 = [
     LabelPrediction(scores, predicted, expected)
     for scores, predicted, expected in [
-        ([0.4, 0.6], 1, 0),
-        ([0.3, 0.2], 0, 0),
-        ([0.4, 0.8], 1, 1),
-        ([0.5, 0.2], 0, 1),
-        ([0.4, 0.2], 0, 0),
+        ([-0.6, -0.4], 1, 0),
+        ([-0.7, -0.8], 0, 0),
+        ([-0.6, -0.2], 1, 1),
+        ([-0.5, -0.8], 0, 1),
+        ([-0.6, -0.8], 0, 0),
     ]
 ]
 
@@ -67,17 +67,33 @@ class BasicMetricsTest(MetricsTestBase):
     def test_soft_metrics_computation(self) -> None:
         recall_at_precision_dict_l1 = {0.9: 0.0, 0.8: 0.0, 0.6: 1.0, 0.4: 1.0, 0.2: 1.0}
         recall_at_precision_dict_l2 = {0.9: 0.5, 0.8: 0.5, 0.6: 0.5, 0.4: 1.0, 0.2: 1.0}
+        decision_thresh_at_precision_dict_l1 = {
+            0.9: 0.0,
+            0.8: 0.0,
+            0.6: -0.7,
+            0.4: -0.7,
+            0.2: -0.7,
+        }
+        decision_thresh_at_precision_dict_l2 = {
+            0.9: -0.2,
+            0.8: -0.2,
+            0.6: -0.2,
+            0.4: -0.8,
+            0.2: -0.8,
+        }
         self.assertMetricsAlmostEqual(
             compute_soft_metrics(PREDICTIONS2, LABEL_NAMES2),
             {
                 "label1": SoftClassificationMetrics(
                     average_precision=8.0 / 15,
                     recall_at_precision=recall_at_precision_dict_l1,
+                    decision_thresh_at_precision=decision_thresh_at_precision_dict_l1,
                     roc_auc=1.0 / 6,
                 ),
                 "label2": SoftClassificationMetrics(
                     average_precision=0.7,
                     recall_at_precision=recall_at_precision_dict_l2,
+                    decision_thresh_at_precision=decision_thresh_at_precision_dict_l2,
                     roc_auc=4.0 / 6,
                 ),
             },


### PR DESCRIPTION
Summary: add decision thresholds to "per_label_soft_scores" for classification tasks. These are thresholds that a model score needs to be above to achieve a certain precision. Note: these model scores (and thus thresholds) are log-probabilities.

Differential Revision: D17532452

