### PR TITLE
--include is remembered in generated configs and can automatically load custom components.

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -119,6 +119,8 @@ class PyTextConfig(ConfigBase):
     use_deterministic_cudnn: bool = False
     # Run eval set after model has been trained - for hyperparameter search
     report_eval_results: bool = False
+    # include components from custom directories
+    include_dirs: Optional[List[str]] = None
     # config version
     version: int
 

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -197,6 +197,7 @@ def main(context, config_file, config_json, config_module, include):
         add_include(path.rstrip("/"))
 
     context.obj = Attrs()
+    context.obj.include = include
 
     def load_config():
         # Cache the config object so it can be accessed multiple times
@@ -212,6 +213,9 @@ def main(context, config_file, config_json, config_module, include):
                 else:
                     eprint("No config file specified, reading from stdin")
                     config = json.load(sys.stdin)
+                # before parsing the config, include the custom components
+                for path in config.get("include_dirs", []):
+                    add_include(path.rstrip("/"))
                 context.obj.config = parse_config(config)
         return context.obj.config
 
@@ -254,6 +258,14 @@ def gen_default_config(context, task_name, options):
             ex,
         )
         sys.exit(-1)
+
+    # add the --include to the config generated
+    if context.obj.include:
+        if cfg.include_dirs is None:
+            cfg.include_dirs = []
+        for path in context.obj.include:
+            cfg.include_dirs.append(path.rstrip("/"))
+
     cfg_json = config_to_json(PyTextConfig, cfg)
     print(json.dumps(cfg_json, sort_keys=True, indent=2))
 


### PR DESCRIPTION
## Motivation and Context

Until now, you had to use `--include <my_directory>` in every command if
your config uses custom components.  This diff stores the custom directories
in the config in `include_dirs`, and this is loaded automatically before
parsing the config.

## How Has This Been Tested

first create the config using --include with the path of the custom component AtisIntentDataSource

```
  > pytext --include demo/datasource gen-default-config DocumentClassificationTask AtisIntentDataSource > my_config.json
  Including: demo/datasource
  ... importing module: demo.datasource.source
  ... importing: <class 'demo.datasource.source.AtisIntentDataSource'>
  INFO - Applying task option: DocumentClassificationTask
  INFO - Applying class option: task.data.source = AtisIntentDataSource
```

verify that my_config.json contains `"include_dirs": ["demo/datasource"]`

then run `train` without --include and verify that custom component AtisIntentDataSource is imported

```
  > pytext train < my_config.json
  Including: demo/datasource
  ... importing module: demo.datasource.source
  ... importing: <class 'demo.datasource.source.AtisIntentDataSource'>

  ===Starting training...
  [...task using AtisIntentDataSource]
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
