### PR TITLE
Skip tree validation in metric reporting for RNNG

### DIFF
--- a/pytext/data/data_structures/annotation.py
+++ b/pytext/data/data_structures/annotation.py
@@ -488,17 +488,22 @@ class Node_Info:
 
 class Tree:
     def __init__(
-        self, root: Root, combination_labels: bool, utterance: str = ""
+        self,
+        root: Root,
+        combination_labels: bool,
+        utterance: str = "",
+        validate_tree: bool = True,
     ) -> None:
         self.root = root
         self.combination_labels = combination_labels
-        try:
-            self.validate_tree()
-        except ValueError as v:
-            raise ValueError(
-                "Tree validation failed: {}. \n".format(v)
-                + "Utterance is: {}".format(utterance)
-            )
+        if validate_tree:
+            try:
+                self.validate_tree()
+            except ValueError as v:
+                raise ValueError(
+                    "Tree validation failed: {}. \n".format(v)
+                    + "Utterance is: {}".format(utterance)
+                )
 
     def validate_tree(self):
         """
@@ -632,8 +637,8 @@ class TreeBuilder:
         else:
             raise ValueError("Don't understand action %s" % (action))
 
-    def finalize_tree(self):
-        return Tree(self.root, self.combination_labels)
+    def finalize_tree(self, validate_tree=True):
+        return Tree(self.root, self.combination_labels, validate_tree=validate_tree)
 
 
 def list_from_actions(


### PR DESCRIPTION
Summary:
To get train loss curves for RNNG we need to disable tree validation in the metric reporter as during training RNNG can output malformed trees.

This skips the validation and also bypasses a few other error locations and turns on train metric reporting for the nightly

Differential Revision: D17539113

