### PR TITLE
Add dense input to XLMModel

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -822,6 +822,9 @@ class FloatListTensorizer(Tensorizer):
         return [(self.column, List[float])]
 
     def initialize(self):
+        if not self.normalizer.do_normalization:
+            self.normalizer.calculate_feature_stats()
+            return
         try:
             while True:
                 row = yield


### PR DESCRIPTION
Summary: Enable dense input in XLMModel for training (torchscript export not implemented). Also skip initialization for dense tensorizer if normalization is not needed.

Differential Revision: D17167469

