### PR TITLE
EASY [PyText] fix datasource tutorial example

### DIFF
--- a/demo/datasource/source.py
+++ b/demo/datasource/source.py
@@ -87,7 +87,7 @@ class AtisIntentDataSource(RootDataSource):
     ):
         super().__init__(**kwargs)
 
-        field_names = field_names or Config.field_names
+        field_names = field_names or AtisIntentDataSource.Config.field_names
         assert (
             len(field_names or []) == 2
         ), "AtisIntentDataSource only handles 2 field_names: {}".format(field_names)


### PR DESCRIPTION
Summary:
there's a bug in the tutorial example when field_names is not
provided. This diff fixes it.

Reviewed By: rutyrinott

Differential Revision: D17557578

