### PR TITLE
Replace tensorboardX with torch.utils.tensorboard

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -8,3 +8,5 @@ onnx
 pytorch-pretrained-bert
 requests
 torchtext
+tensorboard==1.14
+torch

--- a/pytext/docs/source/conf.py
+++ b/pytext/docs/source/conf.py
@@ -118,7 +118,7 @@ html_static_path = ["_static"]
 # autodoc_mock_imports = ['scipy', 'tensorboardX']
 
 # Manually mocking out the libraries to prevent requiring these modules
-MOCK_MODULES = ["scipy", "scipy.special", "tensorboardX"]
+MOCK_MODULES = ["scipy", "scipy.special", "torch.utils.tensorboard"]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()
 

--- a/pytext/docs/source/visualize_your_model.rst
+++ b/pytext/docs/source/visualize_your_model.rst
@@ -2,7 +2,7 @@ Visualize Model Training with TensorBoard
 ======================================================
 
 Visualizations can be helpful in allowing you to better understand, debug and optimize your models during training.
-By default, all models trained using PyText can be visualized using `TensorBoard <https://www.tensorflow.org/guide/summaries_and_tensorboard>`_, thanks to the `TensorBoardX <https://github.com/lanpa/tensorboardX>`_ library.
+By default, all models trained using PyText can be visualized using `TensorBoard <https://www.tensorflow.org/guide/summaries_and_tensorboard>`.
 
 Here, we will explore how to visualize the model from the tutorial :doc:`atis_tutorial`.
 

--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -6,7 +6,7 @@ import traceback
 from typing import Tuple
 
 from pytext.common.constants import Stage
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 
 class Channel:
@@ -143,9 +143,9 @@ class TensorBoardChannel(Channel):
     job to TensorBoard.
 
     Attributes:
-        summary_writer: An instance of the TensorBoardX SummaryWriter class, or
+        summary_writer: An instance of the TensorBoard SummaryWriter class, or
             an object that implements the same interface.
-            https://tensorboardx.readthedocs.io/en/latest/tensorboard.html
+            https://pytorch.org/docs/stable/tensorboard.html
         metric_name: The name of the default metric to display on the
             TensorBoard dashboard, defaults to "accuracy"
         train_step: The training step count

--- a/pytext/models/embeddings/embedding_base.py
+++ b/pytext/models/embeddings/embedding_base.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 import torch.nn as nn
 from pytext.models.module import Module
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 
 class EmbeddingBase(Module):

--- a/pytext/models/embeddings/embedding_list.py
+++ b/pytext/models/embeddings/embedding_list.py
@@ -5,8 +5,8 @@ from typing import Dict, Iterable, List, Tuple, Union
 
 import torch
 import torch.nn as nn
-from tensorboardX import SummaryWriter
 from torch.nn import ModuleList
+from torch.utils.tensorboard import SummaryWriter
 
 from .embedding_base import EmbeddingBase
 

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -9,8 +9,8 @@ from pytext.config.field_config import WordFeatConfig
 from pytext.data.tensorizers import Tensorizer
 from pytext.fields import FieldMeta
 from pytext.utils.embeddings import PretrainedEmbedding
-from tensorboardX import SummaryWriter
 from torch import nn
+from torch.utils.tensorboard import SummaryWriter
 
 from .embedding_base import EmbeddingBase
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ pytorch-pretrained-bert
 requests
 scipy
 torchtext
-tensorboardX
+tensorboard==1.14
+torch


### PR DESCRIPTION
Summary: Migrates all instances of `tensorboardX` to `torch.utils.tensorboard`.

Differential Revision: D17565805

