### PR TITLE
(Easy) Rename FL trainers, remove 'NewDoc' from name

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -641,6 +641,17 @@ def remove_docclassificationtask_deprecated(json_config):
     return json_config
 
 
+@register_adapter(from_version=17)
+def rename_fl_task(json_config):
+    # remove 'NewDoc' from FL task names
+    for trainer_suffix in ["SyncTrainer", "AsyncTrainer"]:
+        old_trainer_name = f"FLNewDoc{trainer_suffix}"
+        new_trainer_name = f"FL{trainer_suffix}"
+        for section in find_dicts_containing_key(json_config, old_trainer_name):
+            section[new_trainer_name] = section.pop(old_trainer_name)
+    return json_config
+
+
 def upgrade_one_version(json_config):
     current_version = json_config.get("version", 0)
     adapter = ADAPTERS.get(current_version)

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -146,4 +146,4 @@ class TestConfig(ConfigBase):
     test_out_path: str = ""
 
 
-LATEST_VERSION = 17
+LATEST_VERSION = 18


### PR DESCRIPTION
Summary:
Follow up to D17370068, renamed:
- FLNewDocSyncTrainer --> FLSyncTrainer
- FLNewDocAsyncTrainer --> FLAsyncTrainer

Also added config_adapter section for backwards compatibility of existing configs.

Reviewed By: psuzhanhy

Differential Revision: D17461127

