### PR TITLE
unify FP16&FP32 API

### DIFF
--- a/pytext/data/test/data_test.py
+++ b/pytext/data/test/data_test.py
@@ -155,11 +155,11 @@ class DataTest(unittest.TestCase):
         expected_lists = [[1, 2, 3], [4, 5, 0]]
         self.assertEqual(padded_lists, expected_lists)
 
-        precision._FP16_ENABLED = True
+        precision.FP16_ENABLED = True
         padded_lists = pad(nested_lists, pad_token=0)
         expected_lists = [[1, 2, 3, 0, 0, 0, 0, 0], [4, 5, 0, 0, 0, 0, 0, 0]]
         self.assertEqual(padded_lists, expected_lists)
-        precision._FP16_ENABLED = False
+        precision.FP16_ENABLED = False
 
 
 class BatcherTest(unittest.TestCase):

--- a/pytext/fields/test/char_field_test.py
+++ b/pytext/fields/test/char_field_test.py
@@ -113,7 +113,7 @@ class CharFieldTest(unittest.TestCase):
             numericalized_minibatch.numpy().tolist(), expected_numericalized_chars
         )
 
-        precision._FP16_ENABLED = True
+        precision.FP16_ENABLED = True
         padded_minibatch = char_field.pad(minibatch)
         self.assertTrue(len(padded_minibatch[0]) % 8 == 0)
-        precision._FP16_ENABLED = False
+        precision.FP16_ENABLED = False

--- a/pytext/fields/test/dict_field_test.py
+++ b/pytext/fields/test/dict_field_test.py
@@ -100,11 +100,11 @@ class DictFieldTest(unittest.TestCase):
         )
         np.testing.assert_array_equal(feats.data.numpy(), NUMERICAL_FEATS)
 
-        precision._FP16_ENABLED = True
+        precision.FP16_ENABLED = True
         padded_feats, padded_weights, padded_lengths = self.dict_field.pad(minibatch)
         self.assertTrue(len(padded_feats[0]) % 8 == 0)
         self.assertTrue(len(padded_weights[0]) % 8 == 0)
-        precision._FP16_ENABLED = False
+        precision.FP16_ENABLED = False
 
     def test_left_pad_numericalize(self):
         minibatch = [dict_feat for dict_feat in zip(DICT_FEATS_STR, WEIGHTS, LENGTHS)]
@@ -119,8 +119,8 @@ class DictFieldTest(unittest.TestCase):
         )
         np.testing.assert_array_equal(feats.data.numpy(), LEFT_NUMERICAL_FEATS)
 
-        precision._FP16_ENABLED = True
+        precision.FP16_ENABLED = True
         padded_feats, padded_weights, padded_lengths = self.dict_field.pad(minibatch)
         self.assertTrue(len(padded_feats[0]) % 8 == 0)
         self.assertTrue(len(padded_weights[0]) % 8 == 0)
-        precision._FP16_ENABLED = False
+        precision.FP16_ENABLED = False

--- a/pytext/optimizer/optimizers.py
+++ b/pytext/optimizer/optimizers.py
@@ -13,6 +13,18 @@ class Optimizer(Component):
     class Config(ConfigBase):
         pass
 
+    def backward(self, loss):
+        loss.backward()
+
+    def clip_grad_norm(self, model, max_norm):
+        if max_norm is not None:
+            return torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+        else:
+            return None
+
+    def pre_export(self, model):
+        pass
+
     def finalize(self) -> bool:
         return False
 

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -55,7 +55,7 @@ def maybe_accumulate_gradients(exit_stack, model, index, sample_size):
         """
         exit_stack.enter_context(model.no_sync())
 
-    if precision._FP16_ENABLED and index < sample_size - 1:
+    if precision.FP16_ENABLED and index < sample_size - 1:
         """
         Whenever *samples* contains more than one mini-batch (e.g sample_size > 1),
         we want to accumulate gradients in FP16 parameters (e.g delay unscale)

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -62,7 +62,7 @@ def _set_fp16(use_fp16: bool, rank: int) -> None:
     # only support single GPU training at this moment.
     precision.set_fp16(fp16_enabled=use_fp16)
     if rank == 0:
-        print(f"# for debug of FP16: fp16_enabled={precision._FP16_ENABLED}")
+        print(f"# for debug of FP16: fp16_enabled={precision.FP16_ENABLED}")
 
 
 def _set_distributed(


### PR DESCRIPTION
Summary:
1. use optimizer.backward() and optimizer.clip_grad_norm() to replace existing precision.backward and clip_grad_norm
2. remove underscore for FP16_ENABLED, OPT_LEVEL, DELAY_UNSCALE

Differential Revision: D17535126

