### PR TITLE
set onnx==1.5.0 to fix CircleCI build temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ future
 hypothesis<4.0
 joblib
 numpy
-onnx
+onnx==1.5.0
 pandas
 pytorch-pretrained-bert
 requests


### PR DESCRIPTION
Summary: ONNX release v1.6.0 on 09/27 which broke "new_text_model_exporter_test" in CircleCI

Differential Revision: D17682768

