### PR TITLE
make RoBERTa usable in more tasks including QA

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -83,7 +83,7 @@ class BERTTensorizer(TokenTensorizer):
             tokenizer=self.tokenizer,
             vocab=self.vocab,
             bos_token=None,
-            eos_token=EOS,
+            eos_token=self.vocab.eos_token,
             max_seq_len=self.max_seq_len,
         )
 
@@ -91,7 +91,11 @@ class BERTTensorizer(TokenTensorizer):
         """Tokenize, look up in vocabulary."""
         sentences = [self._lookup_tokens(row[column])[0] for column in self.columns]
         if self.add_bos_token:
-            bos_token = EOS if self.use_eos_token_for_bos else BOS
+            bos_token = (
+                self.vocab.eos_token
+                if self.use_eos_token_for_bos
+                else self.vocab.bos_token
+            )
             sentences[0] = [self.vocab.idx[bos_token]] + sentences[0]
         seq_lens = (len(sentence) for sentence in sentences)
         segment_labels = ([i] * seq_len for i, seq_len in enumerate(seq_lens))

--- a/pytext/data/squad_for_bert_tensorizer.py
+++ b/pytext/data/squad_for_bert_tensorizer.py
@@ -44,7 +44,8 @@ class SquadForBERTTensorizer(BERTTensorizer):
         question_column, doc_column = self.columns
         doc_tokens, start_idx, end_idx = self._lookup_tokens(row[doc_column])
         question_tokens, _, _ = self._lookup_tokens(row[question_column])
-        question_tokens = [self.vocab.idx[BOS]] + question_tokens
+        if self.add_bos_token:
+            question_tokens = [self.vocab.get_bos_index()] + question_tokens
         seq_lens = (len(question_tokens), len(doc_tokens))
         segment_labels = ([i] * seq_len for i, seq_len in enumerate(seq_lens))
         tokens = list(itertools.chain(question_tokens, doc_tokens))

--- a/pytext/models/qna/bert_squad_qa.py
+++ b/pytext/models/qna/bert_squad_qa.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import torch
 from pytext.common.constants import Stage
+from pytext.data.bert_tensorizer import BERTTensorizer
 from pytext.data.squad_for_bert_tensorizer import SquadForBERTTensorizer
 from pytext.data.tensorizers import LabelTensorizer
 from pytext.data.utils import Vocabulary
@@ -21,7 +22,7 @@ from pytext.models.representations.transformer_sentence_encoder_base import (
 class BertSquadQAModel(NewBertModel):
     class Config(NewBertModel.Config):
         class ModelInput(BaseModel.Config.ModelInput):
-            squad_input: SquadForBERTTensorizer.Config = SquadForBERTTensorizer.Config(
+            squad_input: BERTTensorizer.Config = SquadForBERTTensorizer.Config(
                 max_seq_len=256
             )
             # is_impossible label


### PR DESCRIPTION
Summary:
Currently Roberta encoder, model and tensorizer are pretty stand-alone, not conforming to other PyText tasks.  This diff is an attempt to better integrate it.

It involves the following:
- Make GPT-2 BPE act like a proper tokenizer and also return char indices.  This makes Roberta tensorizer more modular so code can be re-used
- Make Roberta tensorizer conform more closely to BERTTensorizer so that the TransformerSentenceEncoder interfaces are better aligned.
- Add a Roberta tensorizer for question answering

Differential Revision: D17690805

