### PR TITLE
Native Torchscript Wordpiece Tokenizer Op for BERTSquadQA, Torchscriptify BertSQUADQAModel

### DIFF
--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -145,6 +145,9 @@ class WordPieceTokenizer(Tokenizer):
                     if not sub_token.startswith("##")
                     else (len(sub_token) - 2)  # account for ##
                 )
+                if sub_token == "[UNK]":
+                    # this fixes the bug wherein piece_len = 5 for all [UNK]
+                    piece_len = len(token.value)
                 end = start + piece_len
                 tokens.append(Token(sub_token, start, end))
                 start = end

--- a/pytext/models/output_layers/squad_output_layer.py
+++ b/pytext/models/output_layers/squad_output_layer.py
@@ -57,7 +57,7 @@ class SquadOutputLayer(OutputLayerBase):
             self.false_idx = 1 if has_answer_labels[1] == false_label else 0
             self.true_idx = 1 - self.false_idx
 
-    def _get_position_preds(
+    def get_position_preds(
         self,
         start_pos_logits: torch.Tensor,
         end_pos_logits: torch.Tensor,
@@ -97,7 +97,11 @@ class SquadOutputLayer(OutputLayerBase):
         _, start_positions = vals.max(-1)
         end_positions = ids.gather(-1, start_positions.unsqueeze(-1)).squeeze(-1)
 
-        return start_positions, end_positions
+        return (
+            start_positions,
+            end_positions,
+            logit_sum_matrix[0, start_positions, end_positions],
+        )
 
     def get_pred(
         self,
@@ -106,7 +110,7 @@ class SquadOutputLayer(OutputLayerBase):
         contexts: Dict[str, List[Any]],
     ) -> Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]:
         start_pos_logits, end_pos_logits, has_answer_logits = logits
-        start_pos_preds, end_pos_preds = self._get_position_preds(
+        start_pos_preds, end_pos_preds, _ = self.get_position_preds(
             start_pos_logits, end_pos_logits, self.max_answer_len
         )
         has_answer_preds = has_answer_logits.argmax(-1)

--- a/pytext/models/qna/bert_squad_qa.py
+++ b/pytext/models/qna/bert_squad_qa.py
@@ -24,6 +24,9 @@ from pytext.models.representations.transformer_sentence_encoder_base import (
 
 
 class BertSquadQAModel(NewBertModel):
+
+    __EXPANSIBLE__ = True
+
     class Config(NewBertModel.Config):
         class ModelInput(BaseModel.Config.ModelInput):
             squad_input: Union[


### PR DESCRIPTION
Summary:
Added a new native op that does wordpiece tokenization while additionally returning token start and end indices in the raw text as required by BertSquadQA. Includes Unit Tests for the native op and also to check its parity with the PyText Wordpiece Tokenizer.

Also combined is a torchscript implementation of the Bert SQUAD QA Model.

There are scripts for evaluation and testing of the torchscript code as well.

Reviewed By: borguz

Differential Revision: D17455985

