### PR TITLE
Minor transformer tweaks

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -24,32 +24,56 @@ class BERTTensorizer(TokenTensorizer):
         tokenizer: Tokenizer.Config = WordPieceTokenizer.Config()
         add_bos_token: bool = True
         add_eos_token: bool = True
+
+        #: The special tokens in the WordPiece vocab
         bos_token: str = "[CLS]"
         eos_token: str = "[SEP]"
         pad_token: str = "[PAD]"
         unk_token: str = "[UNK]"
         mask_token: str = "[MASK]"
+
         vocab_file: str = WordPieceTokenizer.Config().wordpiece_vocab_path
+
+        #: What the special tokens should be converted into
+        bos_token_replacement: str = ""
+        eos_token_replacement: str = ""
+        pad_token_replacement: str = ""
+        unk_token_replacement: str = ""
+        mask_token_replacement: str = ""
 
     @classmethod
     def from_config(cls, config: Config, **kwargs):
         tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
+        unk_token = config.unk_token_replacement or UNK
+        pad_token = config.pad_token_replacement or PAD
+        bos_token = config.bos_token_replacement or BOS
+        eos_token = config.eos_token_replacement or EOS
         replacements = {
-            config.unk_token: UNK,
-            config.pad_token: PAD,
-            config.bos_token: BOS,
-            config.eos_token: EOS,
-            config.mask_token: MASK,
+            config.unk_token: unk_token,
+            config.pad_token: pad_token,
+            config.bos_token: bos_token,
+            config.eos_token: eos_token,
+            config.mask_token: config.mask_token_replacement or MASK,
         }
         if isinstance(tokenizer, WordPieceTokenizer):
             vocab = Vocabulary(
                 [token for token, _ in tokenizer.vocab.items()],
                 replacements=replacements,
+                unk_token=unk_token,
+                pad_token=pad_token,
+                bos_token=bos_token,
+                eos_token=eos_token,
             )
         else:
             dictionary = BertDictionary.load(config.vocab_file)
             vocab = Vocabulary(
-                dictionary.symbols, dictionary.count, replacements=replacements
+                dictionary.symbols,
+                dictionary.count,
+                replacements=replacements,
+                unk_token=unk_token,
+                pad_token=pad_token,
+                bos_token=bos_token,
+                eos_token=eos_token,
             )
         return cls(
             columns=config.columns,
@@ -91,13 +115,13 @@ class BERTTensorizer(TokenTensorizer):
         """Tokenize, look up in vocabulary."""
         sentences = [self._lookup_tokens(row[column])[0] for column in self.columns]
         if self.add_bos_token:
-            bos_token = (
-                self.vocab.eos_token
+            bos_index = (
+                self.vocab.get_eos_index()
                 if self.use_eos_token_for_bos
-                else self.vocab.bos_token
+                else self.vocab.get_bos_index()
             )
-            sentences[0] = [self.vocab.idx[bos_token]] + sentences[0]
-        seq_lens = (len(sentence) for sentence in sentences)
+            sentences[0] = [bos_index] + sentences[0]
+            seq_lens = (len(sentence) for sentence in sentences)
         segment_labels = ([i] * seq_len for i, seq_len in enumerate(seq_lens))
         tokens = list(itertools.chain(*sentences))
         segment_labels = list(itertools.chain(*segment_labels))


### PR DESCRIPTION
Summary:
Couple of tweaks to improve the flexibility of transformer tensorizers:

1. The `counts` variable for `XLMTensorizer` was just a list rather than an actual `collections.Counter`.
2. The BERT/XLM tensorizers had not been updated to handle special tokens correctly. Fixing this also allows them being used with workflows that require custom special tokens.

Differential Revision: D17695519

