### PR TITLE
ReadTheDocs OOM fix with CPU Torch

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,3 +1,4 @@
+https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp37-cp37m-manylinux1_x86_64.whl
 click
 fairseq
 future
@@ -9,4 +10,3 @@ pytorch-pretrained-bert
 requests
 torchtext
 tensorboard==1.14
-torch


### PR DESCRIPTION
Summary: Reverting back to use CPU version of Torch so other packages don't download torch which is the main cause of OOM on ReadTheDocs

Differential Revision: D17732331

