### PR TITLE
Rename borc as fvcore

### DIFF
--- a/pytext/task/serialize.py
+++ b/pytext/task/serialize.py
@@ -13,9 +13,9 @@ from pytext.trainers.training_state import TrainingState
 from pytext.utils.data import patch_path_manager_with_python_builtins
 
 
-# TODO: @stevenliu remove try statement after borc becomes available in pypi
+# TODO: @stevenliu remove try statement after fvcore becomes available in pypi
 try:
-    from borc.common.file_io import PathManager
+    from fvcore.common.file_io import PathManager
 except ImportError:
     print("Patch PathManager with python builtins")
     PathManager = patch_path_manager_with_python_builtins()

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -18,9 +18,9 @@ from pytext.utils import cuda, distributed, precision, set_random_seeds, timing
 from pytext.utils.data import patch_path_manager_with_python_builtins
 
 
-# TODO: @stevenliu remove try statement after borc becomes available in pypi
+# TODO: @stevenliu remove try statement after fvcore becomes available in pypi
 try:
-    from borc.common.file_io import PathManager
+    from fvcore.common.file_io import PathManager
 except ImportError:
     print("Patch PathManager with python builtins")
     PathManager = patch_path_manager_with_python_builtins()


### PR DESCRIPTION
Summary: Renaming borc as fvcore for OSS, see T53591829

Reviewed By: ppwwyyxx

Differential Revision: D17674700

