### PR TITLE
DocNN as a Lazy Module, better constructor

### DIFF
--- a/pytext/models/representations/docnn.py
+++ b/pytext/models/representations/docnn.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from typing import List
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pytext.config import ConfigBase
 from pytext.config.module_config import CNNParams
+from pytext.utils import lazy
 
 from .representation_base import RepresentationBase
 
@@ -17,19 +19,40 @@ class DocNNRepresentation(RepresentationBase):
         dropout: float = 0.4
         cnn: CNNParams = CNNParams()
 
-    def __init__(self, config: Config, embed_dim: int) -> None:
-        super().__init__(config)
-        self.max_kernel = max(config.cnn.kernel_sizes)
+    @classmethod
+    def from_config(cls, config: Config, embed_dim: int = None):
+        # Lazy so we don't need the embed_dim
+        return cls(config.cnn.kernel_num, config.cnn.kernel_sizes, config.dropout)
+
+    def __init__(
+        self,
+        kernel_num: int = 100,
+        kernel_sizes: List[int] = (3, 4),
+        dropout: float = 0.4,
+    ) -> None:
+        """
+        Args:
+            kernel_num: Number of feature maps for each Conv1d kernel
+            kernel_sizes: A Conv1d kernel will be created with the corresponding size
+                for each kernel in this list; the results will be concatenated together
+                to form the final representation
+            dropout: Dropout ratio applied to the final representation during training
+        """
+        nn.Module.__init__(self)
+        self.max_kernel = max(kernel_sizes)
         self.convs = nn.ModuleList(
-            [
-                nn.Conv1d(embed_dim, config.cnn.kernel_num, K, padding=K)
-                for K in config.cnn.kernel_sizes
-            ]
+            [lazy.Conv1d(kernel_num, K, padding=K) for K in kernel_sizes]
         )
-        self.dropout = nn.Dropout(config.dropout)
-        self.representation_dim = len(config.cnn.kernel_sizes) * config.cnn.kernel_num
+        self.dropout = nn.Dropout(dropout)
+
+        self.representation_dim = len(kernel_sizes) * kernel_num
 
     def forward(self, embedded_tokens: torch.Tensor, *args) -> torch.Tensor:
+        """Accepts a token embedding of size
+            (batch, sequence_length, embedding)
+        and returns a representation of size
+            (batch, (len(kernel_sizes) * kernel_num))
+        """
         # embedded_tokens of size (N,W,D)
         rep = embedded_tokens
         # nn.Conv1d expects a tensor of dim (batch_size x embed_dim x seq_len)

--- a/pytext/models/representations/test/docnn_test.py
+++ b/pytext/models/representations/test/docnn_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import random
+import unittest
+
+import torch
+from pytext.models.representations.docnn import DocNNRepresentation as DocNN
+from pytext.utils import lazy
+from torch import nn
+
+
+class DocNNTest(unittest.TestCase):
+    def test_constructor_api(self):
+        docnn = DocNN()
+        self.assertIsInstance(docnn, DocNN)
+        docnn_small_kernel = DocNN(kernel_num=10)
+        self.assertIsInstance(docnn_small_kernel, DocNN)
+        docnn_many_small_kernels = DocNN(kernel_num=5, kernel_sizes=list(range(1, 50)))
+        self.assertIsInstance(docnn_many_small_kernels, DocNN)
+        docnn_no_dropout = DocNN(dropout=0.0)
+        self.assertIsInstance(docnn_no_dropout, DocNN)
+
+    def test_from_config(self):
+        docnn = DocNN.from_config(DocNN.Config(), embed_dim=None)
+        self._test_docnn_component_with_variable_embedding(docnn)
+
+        docnn_ignore_embed_dim = DocNN.from_config(DocNN.Config(), embed_dim=50)
+        self._test_docnn_component_with_variable_embedding(docnn_ignore_embed_dim)
+
+    def test_should_infer_embedding_dimension(self):
+        docnn = DocNN()
+        self._test_docnn_component_with_variable_embedding(docnn)
+
+        docnn_small_kernel = DocNN(kernel_num=10)
+        self._test_docnn_component_with_variable_embedding(docnn_small_kernel)
+
+        docnn_many_small_kernels = DocNN(kernel_num=5, kernel_sizes=list(range(1, 50)))
+        self._test_docnn_component_with_variable_embedding(docnn_many_small_kernels)
+
+    def _test_docnn_component_with_variable_embedding(self, docnn):
+        vocab_size = random.randint(50, 100)
+        embedding_size = random.randint(15, 20)
+        embedding = nn.Embedding(vocab_size, embedding_size)
+        model = nn.Sequential(embedding, docnn)
+        inputs_length_1 = random.randint(10, 25)
+        inputs_1 = torch.LongTensor(
+            [[random.randint(0, vocab_size - 1) for _ in range(inputs_length_1)]]
+        )
+
+        model = lazy.init_lazy_modules(model, inputs_1)
+
+        results_1 = model(inputs_1)
+        self.assertEqual([1, docnn.representation_dim], list(results_1.size()))
+
+        # test that it's fine with different batch sizes
+        inputs_length_2 = random.randint(10, 25)
+        inputs_2 = torch.LongTensor(
+            [
+                [random.randint(0, vocab_size - 1) for _ in range(inputs_length_2)],
+                [random.randint(0, vocab_size - 1) for _ in range(inputs_length_2)],
+            ]
+        )
+
+        results_2 = model(inputs_2)
+        self.assertEqual([2, docnn.representation_dim], list(results_2.size()))

--- a/pytext/task/task.py
+++ b/pytext/task/task.py
@@ -23,7 +23,7 @@ from pytext.loss import KLDivergenceBCELoss, KLDivergenceCELoss
 from pytext.metric_reporters import MetricReporter
 from pytext.models import Model
 from pytext.trainers import Trainer
-from pytext.utils import cuda
+from pytext.utils import cuda, lazy
 
 
 def create_task(
@@ -104,6 +104,12 @@ class TaskBase(Component):
         metadata = data_handler.metadata
 
         model = create_model(task_config.model, task_config.features, metadata)
+
+        if lazy.is_lazy(model):
+            # finalize any lazy modules before loading weights
+            inputs, _, _ = next(iter(data_handler.get_train_iter()))
+            lazy.init_lazy_modules(model, inputs)
+
         if model_state:
             model.load_state_dict(model_state)
 

--- a/pytext/utils/lazy.py
+++ b/pytext/utils/lazy.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import functools
+from typing import Tuple
+
+import torch
+from torch import nn
+
+
+class UninitializedLazyModuleError(Exception):
+    """A lazy module was used improperly."""
+
+
+class Infer:
+    """A value which can be inferred from a forward pass. Infer objects should
+    be passed as arguments or keyword arguments to Lazy objects; see Lazy
+    documentation for more details.
+    """
+
+    def __init__(self, resolve_fn):
+        """resolve_fn is called by Lazy on the arguments of the first forward pass
+        to the Lazy module, and the Infer object will be replaced in the call by the
+        output of this function. It should have the same signature as the
+        Lazy-wrapped Module's forward function."""
+        self.resolve = resolve_fn
+
+    @classmethod
+    def dimension(cls, dim):
+        """A helper for creating Infer arguments looking at specific dimensions."""
+        return cls(lambda input: input.size()[dim])
+
+
+class Lazy(nn.Module):
+    """
+    A module which is able to infer some of its parameters from the inputs to
+    its first forward pass. Lazy wraps any other nn.Module, and arguments can be passed
+    that will be used to construct that wrapped Module after the first forward pass.
+    If any of these arguments are Infer objects, those arguments will be replaced by
+    calling the callback of the Infer object on the forward pass input.
+
+    For instance,
+    >>> Lazy(nn.Linear, Infer(lambda input: input.size(-1)), 4)
+    Lazy()
+
+    takes its in_features dimension from the last dimension of the input to its forward
+    pass. This can be simplified to
+
+    >>> Lazy(nn.Linear, Infer.dimension(-1), 4)
+
+    or a partial can be created, for instance
+
+    >>> LazyLinear = Lazy.partial(nn.Linear, Infer.dimension(-1))
+    >>> LazyLinear(4)
+    Lazy()
+
+    Finally, these Lazy objects explicitly forbid treating themselves normally;
+    they must instead be replaced by calling `init_lazy_modules`
+    on your model before training. For instance,
+
+    >>> ll = lazy.Linear(4)
+    >>> seq = nn.Sequential(ll)
+    >>> seq
+    Sequential(
+        0: Lazy(),
+    )
+    >>> init_lazy_modules(seq, torch.rand(1, 2)
+    Sequential(
+        0: Linear(in_features=2, out_features=4, bias=True)
+    )
+    """
+
+    def __init__(self, module_class, *args, **kwargs):
+        super().__init__()
+        self._module = None
+        self._module_class = module_class
+        self._args = args
+        self._kwargs = kwargs
+
+    @classmethod
+    def partial(cls, module_class, *args, **kwargs):
+        return functools.partial(cls, module_class, *args, **kwargs)
+
+    @property
+    def _parameters(self):
+        raise UninitializedLazyModuleError(
+            "Must call init_lazy_modules before getting parameters"
+        )
+
+    @_parameters.setter
+    def _parameters(self, value):
+        return None
+
+    def __setattr__(self, name, value):
+        return object.__setattr__(self, name, value)
+
+    def forward(self, *args, **kwargs):
+        if not self._module:
+            constructor_args = [
+                (arg if not isinstance(arg, Infer) else arg.resolve(*args, **kwargs))
+                for arg in self._args
+            ]
+            constructor_kwargs = {
+                key: arg if not isinstance(arg, Infer) else arg.resolve(*args, **kwargs)
+                for key, arg in self._kwargs.items()
+            }
+            self._module = self._module_class(*constructor_args, **constructor_kwargs)
+        return self._module(*args, **kwargs)
+
+    def resolve(self):
+        """Must make a call to forward before calling this function; returns the
+        full nn.Module object constructed using inferred arguments/dimensions."""
+        if not self._module:
+            raise UninitializedLazyModuleError(
+                "Must call forward before calling resolve on a lazy module"
+            )
+        return self._module
+
+
+def replace_lazy_modules(module):
+    if isinstance(module, Lazy):
+        module = module.resolve()
+    children = list(module.named_children())
+    for name, child in children:
+        module.add_module(name, replace_lazy_modules(child))
+    return module
+
+
+def init_lazy_modules(
+    module: nn.Module, dummy_input: Tuple[torch.Tensor, ...]
+) -> nn.Module:
+    """Finalize an nn.Module which has Lazy components. This will both mutate internal
+    modules which have Lazy elements, and return a new non-lazy nn.Module (in case
+    the top-level module itself is Lazy).
+
+    Args:
+        module: An nn.Module which may be lazy or contain Lazy subcomponents
+        dummy_input: module is called with this input to ensure that Lazy subcomponents
+            have been able to infer any parameters they need
+    Returns:
+        The full nn.Module object constructed using inferred arguments/dimensions.
+    """
+    module(*dummy_input)
+    return replace_lazy_modules(module)
+
+
+Linear = Lazy.partial(nn.Linear, Infer.dimension(-1))
+LayerNorm = Lazy.partial(nn.LayerNorm, Infer.dimension(-1))
+Conv1d = Lazy.partial(nn.Conv1d, Infer.dimension(-2))

--- a/pytext/utils/lazy.py
+++ b/pytext/utils/lazy.py
@@ -117,6 +117,21 @@ class Lazy(nn.Module):
         return self._module
 
 
+def is_lazy(module, seen=None):
+    """Returns True if a module is Lazy or has any Lazy modules in its graph."""
+    seen = seen or set()
+    unseen = [module]
+    while unseen:
+        mod, *unseen = unseen
+        if mod in seen:
+            continue
+        seen.add(mod)
+        if isinstance(mod, Lazy):
+            return True
+        unseen += [m for m in mod.children() if m not in seen]
+    return False
+
+
 def replace_lazy_modules(module):
     if isinstance(module, Lazy):
         module = module.resolve()
@@ -140,6 +155,8 @@ def init_lazy_modules(
     Returns:
         The full nn.Module object constructed using inferred arguments/dimensions.
     """
+    if not isinstance(dummy_input, tuple):
+        dummy_input = (dummy_input,)
     module(*dummy_input)
     return replace_lazy_modules(module)
 

--- a/pytext/utils/tests/lazy_test.py
+++ b/pytext/utils/tests/lazy_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+import torch
+from pytext.utils import lazy
+from torch import nn
+
+
+class LazyTest(unittest.TestCase):
+    def test_parameters_throws_exception_before_init(self):
+        linear = lazy.Linear(4)
+        with self.assertRaises(lazy.UninitializedLazyModuleError):
+            list(linear.parameters())
+
+        seq = nn.Sequential(linear)
+        with self.assertRaises(lazy.UninitializedLazyModuleError):
+            list(seq.parameters())
+
+    def test_parameters_after_init(self):
+        linear = lazy.Linear(4)
+        linear = lazy.init_lazy_modules(linear, torch.rand(1, 2))
+        self.assertEqual(2, len(list(linear.parameters())))
+
+        seq = nn.Sequential(lazy.Linear(4))
+        seq = lazy.init_lazy_modules(seq, torch.rand(1, 2))
+        self.assertEqual(2, len(list(seq.parameters())))
+        self.assertIsInstance(seq[0], nn.Linear)
+
+    def test_lazy_linear(self):
+        linear = lazy.Linear(4)
+        input = torch.rand(1, 2)
+        out = linear(input)
+        self.assertEqual((1, 4), out.size())
+        resolved = lazy.init_lazy_modules(linear, input)
+        self.assertIsInstance(resolved, nn.Linear)
+        self.assertEqual(2, resolved.in_features)
+        self.assertEqual(4, resolved.out_features)
+        self.assertIsNotNone(resolved.bias)
+        self.assertTrue(torch.equal(out, resolved(input)))
+
+    def test_lazy_linear_without_bais(self):
+        linear = lazy.Linear(4, bias=False)
+        input = torch.rand(1, 2)
+        out = linear(input)
+        self.assertEqual((1, 4), out.size())
+        resolved = lazy.init_lazy_modules(linear, input)
+        self.assertIsInstance(resolved, nn.Linear)
+        self.assertEqual(2, resolved.in_features)
+        self.assertEqual(4, resolved.out_features)
+        self.assertFalse(resolved.bias)
+        self.assertTrue(torch.equal(out, resolved(input)))


### PR DESCRIPTION
Summary:
Update DocNN to use Lazy modules to be able to infer the passed in Embedding dimension.

Simplify its constructor arguments to not take in a Config or Embedding dim. Add unit tests covering the constructor semantics and verifying that it correctly executes after being initialized.

Differential Revision: D17841296

