### PR TITLE
Simple Transformer module components for RoBERTa

### DIFF
--- a/pytext/models/representations/test/transformer_test.py
+++ b/pytext/models/representations/test/transformer_test.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import unittest
+
+import torch
+from pytext.models.representations.transformer import SentenceEncoder
+
+
+class SentenceEncoderTest(unittest.TestCase):
+    def test_extract_features(self):
+        encoder = SentenceEncoder()
+        tokens = torch.LongTensor([5, 10, 20])
+        encoder.extract_features(tokens)
+
+    def test_forward(self):
+        encoder = SentenceEncoder()
+        tokens = torch.LongTensor([5, 10, 20])
+        encoder(tokens)
+
+    def test_script(self):
+        encoder = SentenceEncoder()
+        scripted = torch.jit.script(encoder)
+        tokens = torch.LongTensor([5, 10, 20])
+        scripted.extract_features(tokens)
+        encoder.eval()
+        scripted.eval()
+        self.assertTrue(torch.equal(encoder(tokens), scripted(tokens)))

--- a/pytext/models/representations/transformer/__init__.py
+++ b/pytext/models/representations/transformer/__init__.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+
+"""
+This directory contains modules for implementing a productionized RoBERTa model.
+These modules implement the same Transformer components that are implemented in
+the fairseq library, however they're distilled down to just the elements which
+are used in the final RoBERTa model, and within that are restructured and
+rewritten to be able to be compiled by TorchScript for production use cases.
+
+The SentenceEncoder specifically can be used to load model weights directly from
+the publicly release RoBERTa weights, and it will translate these weights to
+the corresponding values in this implementation.
+"""
+
+
+from .multihead_attention import MultiheadSelfAttention
+from .positional_embedding import PositionalEmbedding
+from .residual_mlp import ResidualMLP
+from .sentence_encoder import SentenceEncoder
+from .transformer import Transformer, TransformerLayer
+
+
+__all__ = [
+    "MultiheadSelfAttention",
+    "PositionalEmbedding",
+    "ResidualMLP",
+    "SentenceEncoder",
+    "Transformer",
+    "TransformerLayer",
+]

--- a/pytext/models/representations/transformer/multihead_attention.py
+++ b/pytext/models/representations/transformer/multihead_attention.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class MultiheadSelfAttention(nn.Module):
+    """
+    This is a TorchScriptable implementation of MultiheadAttention from fairseq
+    for the purposes of creating a productionized RoBERTa model. It distills just
+    the elements which are required to implement the RoBERTa use cases of
+    MultiheadAttention, and within that is restructured and rewritten to be able
+    to be compiled by TorchScript for production use cases.
+
+    The default constructor values match those required to import the public
+    RoBERTa weights. Unless you are pretraining your own model, there's no need to
+    change them.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        scaling: float = 0.125,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.scaling = scaling
+        self.dropout = nn.Dropout(dropout)
+        self.input_projection = nn.Linear(embed_dim, 3 * embed_dim)
+        self.output_projection = nn.Linear(embed_dim, embed_dim)
+
+    def forward(self, query, key_padding_mask):
+        """Input shape: Time x Batch x Channel
+        Timesteps can be masked by supplying a T x T mask in the
+        `attn_mask` argument. Padding elements can be excluded from
+        the key by passing a binary ByteTensor (`key_padding_mask`) with shape:
+        batch x source_length, where padding elements are indicated by 1s.
+        """
+        target_length, batch_size, embed_dim = query.size()
+        mask_batch_size, source_length = key_padding_mask.size()
+
+        assert embed_dim == self.embed_dim
+        assert (
+            batch_size == mask_batch_size
+        ), "query and key_padding_mask batch sizes differed"
+
+        # input projection
+        projection = self.input_projection(query)
+        q, k, v = projection.chunk(3, dim=-1)
+        q *= self.scaling
+
+        batch_heads = batch_size * self.num_heads
+
+        q = q.contiguous().view(-1, batch_heads, self.head_dim).transpose(0, 1)
+        k = k.contiguous().view(-1, batch_heads, self.head_dim).transpose(0, 1)
+        v = v.contiguous().view(-1, batch_heads, self.head_dim).transpose(0, 1)
+
+        assert k.size(1) == source_length
+
+        attn_weights = torch.bmm(q, k.transpose(1, 2))
+
+        assert list(attn_weights.shape) == [batch_heads, target_length, source_length]
+
+        # don't attend to padding symbols
+        attn_weights = attn_weights.view(
+            batch_size, self.num_heads, target_length, source_length
+        )
+        attn_weights = attn_weights.masked_fill(
+            key_padding_mask.unsqueeze(1).unsqueeze(2), float("-inf")
+        )
+        attn_weights = attn_weights.view(batch_heads, target_length, source_length)
+
+        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).type_as(
+            attn_weights
+        )
+        attn_weights = self.dropout(attn_weights)
+
+        attn = torch.bmm(attn_weights, v)
+        assert list(attn.shape) == [batch_heads, target_length, self.head_dim]
+        attn = (
+            attn.transpose(0, 1).contiguous().view(target_length, batch_size, embed_dim)
+        )
+        attn = self.output_projection(attn)
+
+        return attn

--- a/pytext/models/representations/transformer/positional_embedding.py
+++ b/pytext/models/representations/transformer/positional_embedding.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+def make_positions(tensor, pad_index: int):
+    """Replace non-padding symbols with their position numbers.
+    Position numbers begin at pad_index+1. Padding symbols are ignored.
+    """
+    masked = tensor.ne(pad_index).long()
+    return torch.cumsum(masked, dim=1) * masked + pad_index
+
+
+class PositionalEmbedding(nn.Module):
+    """
+    This module learns positional embeddings up to a fixed maximum size.
+    Padding ids are ignored by either offsetting based on pad_index
+    or by setting pad_index to None and ensuring that the appropriate
+    position ids are passed to the forward function.
+
+    This is a TorchScriptable implementation of PositionalEmbedding from fairseq
+    for the purposes of creating a productionized RoBERTa model. It distills just
+    the elements which are required to implement the RoBERTa use cases of
+    MultiheadAttention, and within that is restructured and rewritten to be able
+    to be compiled by TorchScript for production use cases.
+    """
+
+    def __init__(
+        self, num_embeddings: int, embedding_dim: int, pad_index: Optional[int] = None
+    ):
+        super().__init__()
+        self.embedding = nn.Embedding(num_embeddings, embedding_dim, pad_index)
+        self.pad_index = pad_index
+
+    def forward(self, input):
+        """Input is expected to be of size [batch_size x sequence_length]."""
+        positions = make_positions(input, self.pad_index)
+        return self.embedding(positions)
+
+    def max_positions(self):
+        """Maximum number of supported positions."""
+        if self.pad_index is not None:
+            return self.num_embeddings - self.pad_index - 1
+        else:
+            return self.num_embeddings

--- a/pytext/models/representations/transformer/residual_mlp.py
+++ b/pytext/models/representations/transformer/residual_mlp.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import List
+
+from torch import nn
+from torch.nn import functional as F
+
+
+class GeLU(nn.Module):
+    """Component class to wrap F.gelu."""
+
+    def forward(self, input):
+        return F.gelu(input.float()).type_as(input)
+
+
+class ResidualMLP(nn.Module):
+    """A square MLP component which can learn a bias on an input vector.
+    This MLP in particular defaults to using GeLU as its activation function
+    (this can be changed by passing a different activation function),
+    and retains a residual connection to its original input to help with gradient
+    propogation.
+
+    Unlike pytext's MLPDecoder it doesn't currently allow adding a LayerNorm
+    in between hidden layers.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dims: List[int],
+        dropout: float = 0.1,
+        activation=GeLU,
+    ):
+        super().__init__()
+        modules = []
+        for last_dim, dim in zip([input_dim] + hidden_dims, hidden_dims):
+            modules.extend(
+                [nn.Linear(last_dim, dim), activation(), nn.Dropout(dropout)]
+            )
+
+        last_dim = hidden_dims[-1] if hidden_dims else input_dim
+        # Unlike normal PyText mlp, we don't put an activation layer at the end.
+        modules.extend([nn.Linear(last_dim, input_dim), nn.Dropout(dropout)])
+
+        self.mlp = nn.Sequential(*modules)
+
+    def forward(self, input):
+        bias = self.mlp(input)
+        return input + bias

--- a/pytext/models/representations/transformer/sentence_encoder.py
+++ b/pytext/models/representations/transformer/sentence_encoder.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import re
+from typing import Optional
+
+from torch import nn
+
+from .transformer import Transformer
+
+
+class SentenceEncoder(nn.Module):
+    """
+    This is a TorchScriptable implementation of RoBERTa from fairseq
+    for the purposes of creating a productionized RoBERTa model. It distills just
+    the elements which are required to implement the RoBERTa model, and within that
+    is restructured and rewritten to be able to be compiled by TorchScript for
+    production use cases.
+
+    This SentenceEncoder can load in the public RoBERTa weights directly with
+    `load_roberta_state_dict`, which will translate the keys as they exist in
+    the publicly released RoBERTa to the correct structure for this implementation.
+    The default constructor value will have the same size and shape as that model.
+
+    To use RoBERTa with this, download the RoBERTa public weights as `roberta.weights`
+
+    >>> encoder = SentenceEncoder()
+    >>> weights = torch.load("roberta.weights")
+    >>> encoder.load_roberta_state_dict(weights)
+
+    Within this you will still need to preprocess inputs using fairseq and the publicly
+    released vocabs, and finally place this encoder in a model alongside say an MLP
+    output layer to do classification.
+    """
+
+    def __init__(self, transformer: Optional[Transformer] = None):
+        super().__init__()
+        self.transformer = transformer or Transformer()
+
+    def forward(self, tokens):
+        all_layers = self.extract_features(tokens)
+        last_layer = all_layers[-1]  # T x B x C
+        return last_layer.transpose(0, 1)
+
+    def extract_features(self, tokens):
+        # support passing in a single sentence
+        if tokens.dim() == 1:
+            tokens = tokens.unsqueeze(0)
+
+        return self.transformer(tokens)
+
+    def load_roberta_state_dict(self, state_dict):
+        return self.load_state_dict(translate_roberta_state_dict(state_dict))
+
+
+def remove_state_keys(state, keys_regex):
+    """Remove keys from state that match a regex"""
+    regex = re.compile(keys_regex)
+    return {k: v for k, v in state.items() if not regex.findall(k)}
+
+
+def rename_state_keys(state, keys_regex, replacement):
+    """Rename keys from state that match a regex; replacement can use capture groups"""
+    regex = re.compile(keys_regex)
+    return {
+        (k if not regex.findall(k) else regex.sub(replacement, k)): v
+        for k, v in state.items()
+    }
+
+
+def rename_component_from_root(state, old_name, new_name):
+    """Rename keys from state using full python paths"""
+    return rename_state_keys(
+        state, "^" + old_name.replace(".", r"\.") + ".?(.*)$", new_name + r".\1"
+    )
+
+
+def translate_roberta_state_dict(state_dict):
+    """Translate the public RoBERTa weights to ones which match SentenceEncoder."""
+    new_state = rename_component_from_root(
+        state_dict, "decoder.sentence_encoder", "transformer"
+    )
+    new_state = rename_state_keys(new_state, "embed_tokens", "token_embedding")
+    # TODO: segment_embeddings?
+    new_state = rename_state_keys(
+        new_state, "embed_positions", "positional_embedding.embedding"
+    )
+    new_state = rename_state_keys(new_state, "emb_layer_norm", "embedding_layer_norm")
+    new_state = rename_state_keys(new_state, "self_attn", "attention")
+    new_state = rename_state_keys(new_state, "_proj.(.*)", r"put_projection.\1")
+    new_state = rename_state_keys(new_state, "fc1", "residual_mlp.mlp.0")
+    new_state = rename_state_keys(new_state, "fc2", "residual_mlp.mlp.3")
+
+    new_state = remove_state_keys(new_state, "^sentence_")
+    new_state = remove_state_keys(new_state, r"^decoder\.lm_head")
+    new_state = remove_state_keys(new_state, r"segment_embedding")
+    return new_state

--- a/pytext/models/representations/transformer/transformer.py
+++ b/pytext/models/representations/transformer/transformer.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import List, Optional
+
+import torch
+from torch import nn
+
+from .multihead_attention import MultiheadSelfAttention
+from .positional_embedding import PositionalEmbedding
+from .residual_mlp import ResidualMLP
+
+
+DEFAULT_EMBEDDING_DIM = 768
+DEFAULT_VOCAB_SIZE = 50265
+DEFAULT_PADDING_IDX = 1
+DEFAULT_NUM_LAYERS = 12
+DEFAULT_MAX_SEQUENCE_LENGTH = 514
+DEFAULT_NUM_ATTENTION_HEADS = 12
+
+
+class TransformerLayer(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int = DEFAULT_EMBEDDING_DIM,
+        attention: Optional[MultiheadSelfAttention] = None,
+        residual_mlp: Optional[ResidualMLP] = None,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.dropout = nn.Dropout(dropout)
+        self.attention = attention or MultiheadSelfAttention(
+            embedding_dim, num_heads=DEFAULT_NUM_ATTENTION_HEADS
+        )
+        self.residual_mlp = residual_mlp or ResidualMLP(
+            embedding_dim, hidden_dims=[embedding_dim * 4]
+        )
+
+        self.attention_layer_norm = nn.LayerNorm(embedding_dim)
+        self.final_layer_norm = nn.LayerNorm(embedding_dim)
+
+    def forward(self, input, key_padding_mask):
+        attention = self.attention(input, key_padding_mask)
+        attention = self.dropout(attention)
+        biased_input = input + attention
+        biased_input = self.attention_layer_norm(biased_input)
+
+        biased = self.residual_mlp(biased_input)
+        return self.final_layer_norm(biased)
+
+
+class Transformer(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int = DEFAULT_VOCAB_SIZE,
+        embedding_dim: int = DEFAULT_EMBEDDING_DIM,
+        padding_idx: int = DEFAULT_PADDING_IDX,
+        max_seq_len: int = DEFAULT_MAX_SEQUENCE_LENGTH,
+        layers: List[TransformerLayer] = (),
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.padding_idx = padding_idx
+        self.token_embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx)
+        self.layers = nn.ModuleList(
+            layers
+            or [TransformerLayer(embedding_dim) for _ in range(DEFAULT_NUM_LAYERS)]
+        )
+        self.positional_embedding = PositionalEmbedding(
+            max_seq_len, embedding_dim, padding_idx
+        )
+        self.embedding_layer_norm = nn.LayerNorm(embedding_dim)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, tokens: torch.Tensor) -> List[torch.Tensor]:
+        # compute padding mask. This is needed for multi-head attention
+        padding_mask = tokens.eq(self.padding_idx)
+
+        embedded = self.token_embedding(tokens)
+        embedded_positions = self.positional_embedding(tokens)
+
+        normed = self.embedding_layer_norm(embedded + embedded_positions)
+        normed = self.dropout(normed)
+        # account for padding while computing the representation
+        padded_normed = normed * (1 - padding_mask.unsqueeze(-1).type_as(normed))
+
+        # B x T x C -> T x B x C
+        encoded = padded_normed.transpose(0, 1)
+
+        states = [encoded]
+
+        for layer in self.layers:
+            encoded = layer(encoded, padding_mask)
+            states.append(encoded)
+
+        # states are returned as T x B x C
+        # commonly you can retrieve a single "sentence representation" as
+        # states[-1].transpose(0, 1)
+        return states


### PR DESCRIPTION
Summary: Simple Transformer module components that can fully implement RoBERTa. These are fully scriptable, and were used to create a single TorchScript instance of the RoBERTa encoder, but might be useful again in the future. For now I'm not adding Configs to them, I'm curious whether and how reviewers think these might be made most useful.

Differential Revision: D16976484

