### PR TITLE
auto resume from latest checkpoint for FBLearner retry job

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -98,6 +98,9 @@ class PyTextConfig(ConfigBase):
     save_snapshot_path: str = "/tmp/model.pt"
     # True: use the config saved in snapshot. False: use config from current task
     use_config_from_snapshot: bool = True
+    # if there are existing snapshots in parent directory of save_snapshot_path
+    # resume training from the latest snapshot automatically
+    auto_resume_from_snapshot: bool = False
     # Exported caffe model will be stored here
     export_caffe2_path: Optional[str] = None
     # Exported onnx model will be stored here

--- a/pytext/task/__init__.py
+++ b/pytext/task/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .new_task import NewTask, _NewTask
-from .serialize import load, save
+from .serialize import get_latest_checkpoint_path, load, save
 from .task import Task_Deprecated, TaskBase, create_task
 
 
@@ -14,4 +14,5 @@ __all__ = [
     "save",
     "load",
     "create_task",
+    "get_latest_checkpoint_path",
 ]


### PR DESCRIPTION
Summary:
## Problem:
When a job fail at epoch X, FBLearner will retry it 3 times, from scratch(epoch1)
It wastes time and resources

## Solution:
1. The "retry" shares the same FBLearner job_id
2. we save all checkpoints at "manifold://pytext_training/tree/jobs/<JOB_ID>/checkpoint-<EPOCH>"
3. so there is a mapping (job_id --> latest checkpoint)
4. before training start, we check if there are already checkpoints saved for the current job_id.
Yes: load the latest checkpoint and resume training
No: start training from scratch
5. add config "auto_resume_from_snapshot" to turn this feature on/off.

Differential Revision: D17874151

