### PR TITLE
Switch to new beamsearch and reporter

### DIFF
--- a/pytext/data/data.py
+++ b/pytext/data/data.py
@@ -92,9 +92,9 @@ class PoolingBatcher(Batcher):
 
     class Config(Batcher.Config):
         #: Size of a pool expressed in number of batches
-        pool_num_batches: int = 10000
+        pool_num_batches: int = 1
         #: How many pool-sized chunks to load at a time for shuffling
-        num_shuffled_pools: int = 1
+        num_shuffled_pools: int = 10000
 
     @classmethod
     def from_config(cls, config: Config):


### PR DESCRIPTION
Summary:
- Config adapted from the decoupled model used in A/B testing: f142765785
- The default config for `PoolingBatcher` has issues. We correct that here.
- Minor changes in the workflow to make config work.

Differential Revision: D17494930

