### PR TITLE
Implement Blockwise Sparsification

### DIFF
--- a/pytext/optimizer/sparsifiers/__init__.py
+++ b/pytext/optimizer/sparsifiers/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pytext.optimizer.sparsifiers.blockwise_sparsifier import (  # noqa
+    BlockwiseMagnitudeSparsifier,
+)

--- a/pytext/optimizer/sparsifiers/blockwise_sparsifier.py
+++ b/pytext/optimizer/sparsifiers/blockwise_sparsifier.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import math
+from typing import List
+
+import torch
+import torch.nn as nn
+from pytext.optimizer.sparsifiers.sparsifier import L0_projection_sparsifier
+
+
+class BlockwiseMagnitudeSparsifier(L0_projection_sparsifier):
+    """
+    running blockwise magnitude-based sparsification
+
+    Args:
+        block_size: define the size of each block
+
+        columnwise_blocking: define columnwise block if true
+
+        starting_epoch: sparsification_condition returns true only after starting_epoch
+
+        frequency: sparsification_condition only if number of steps devides frequency
+
+        accumulate_mask: if true, the mask obtain after each .sparisfy() will store in
+        memory, and apply to the parameters in the rest of the training steps.
+        In order words, once a param is masked, the connection is set to zero
+        permanently.
+        If false, a param that is masked as 0 in the current
+        iteration may be resurrect in later iterations. For example, in stochasic
+        projected gradient descent, we have
+                x_new = Projection(x_old - lr * grad),
+        components in x_new may be zero after this update by updated (become
+        non-zero) later.
+
+        sparsity: percentage of zeros among the **UNPRUNED** parameters. When
+        accumulate_mask is false, we do not store the masks permanently so sparsity
+        is computed on all the parameters. When accumulate_mask is true, sparsity
+        is computed only on the parameters that weren't previously masked as zeros.
+
+
+    Examples on how the sparsifier work:
+
+    2D matrix:
+    [
+      0  1  2  3  4
+      5  6  7  8  9
+      10 11 12 13 14
+      15 16 17 18 19
+      20 21 22 23 24
+    ]
+
+    define 3 X 1 block
+    [
+      *********  *******
+      *0  1  2*  *3   4*
+      ********** *******
+      *5  6  7*  *8   9*
+      ********** *******
+      *10 11 12* *13 14*
+      ********** *******
+      *15 16 17* *18 19*
+      ********** *******
+      *20 21 22* *23 24*
+      ********** *******
+    ]
+
+    compute l1 norm of each block and sort them. Retain blocks with largest
+    absolute values until sparsity threshold is met
+    """
+
+    class Config(L0_projection_sparsifier.Config):
+        block_size: int = 16
+        columnwise_blocking: bool = False
+        accumulate_mask: bool = False
+        layerwise_pruning: bool = True
+
+    def __init__(
+        self,
+        sparsity,
+        starting_epoch,
+        frequency,
+        block_size,
+        columnwise_blocking,
+        accumulate_mask,
+        layerwise_pruning,
+    ):
+        super().__init__(sparsity, starting_epoch, frequency, layerwise_pruning)
+        self.block_size = block_size
+        self.columnwise_blocking = columnwise_blocking
+        self.accumulate_mask = accumulate_mask
+        self._pre_masks = None
+        assert self.layerwise_pruning, "layerwise pruning is forced"
+
+    @classmethod
+    def from_config(cls, config: Config):
+        return cls(
+            config.sparsity,
+            config.starting_epoch,
+            config.frequency,
+            config.block_size,
+            config.columnwise_blocking,
+            config.accumulate_mask,
+            config.layerwise_pruning,
+        )
+
+    def _padding_into_full_blocks(self, param):
+        nrows, ncols = param.shape
+        ncols_pad = math.ceil(ncols / self.block_size) * self.block_size
+        padded_param = param.new_zeros((nrows, ncols_pad))
+        padded_param[:nrows, :ncols] = param
+        return padded_param
+
+    def _num_blocks_kept(self, param):
+        max_num_nonzeros = math.ceil(param.numel() * (1 - self.sparsity))
+        return math.ceil(max_num_nonzeros / self.block_size)
+
+    def _compute_param_mask(
+        self,
+        param: torch.Tensor,
+        pre_mask: torch.Tensor = None,
+        columnwise_blocking: bool = False,
+    ):
+        if columnwise_blocking:
+            return self._compute_param_mask(
+                param.transpose(1, 0),
+                pre_mask=(pre_mask.transpose(1, 0) if pre_mask else None),
+            ).transpose(1, 0)
+        padded_param = self._padding_into_full_blocks(param)
+        block_l1norms = padded_param.reshape(-1, 1, self.block_size).sum(dim=2)
+        max_num_blocks = self._num_blocks_kept(param)
+
+        topk_threshold = (
+            torch.topk(block_l1norms.flatten(), max_num_blocks).values.min().item()
+        )
+        mask = (
+            block_l1norms.repeat(1, 1, self.block_size).reshape(padded_param.shape)
+            >= topk_threshold
+        ).to(param.dtype)
+        if pre_mask is None:
+            return mask[: param.size(0), : param.size(1)]
+        else:
+            return mask[: param.size(0), : param.size(1)] * pre_mask
+
+    def get_masks(
+        self, model: nn.Module, pre_masks: List[torch.Tensor] = None
+    ) -> List[torch.Tensor]:
+
+        learnableparams = [p for p in model.parameters() if p.requires_grad]
+        if pre_masks:
+            self._pre_masks = pre_masks
+
+        if self._pre_masks:
+            assert len(learnableparams) == len(
+                self._pre_masks
+            ), "parameter dimension and mask dimension does not match"
+            for m, w in zip(self._pre_masks, learnableparams):
+                # check only for non-empty mask
+                if len(m.size()):
+                    assert (
+                        m.size() == w.size()
+                    ), "parameter dimension and mask dimension does not match"
+
+        if self._pre_masks is not None:
+            # sparsifying 2D tensor only, skip mask for unlearnable
+            # and unsparsifierable param
+            masks = [
+                self._compute_param_mask(p, m, self.columnwise_blocking)
+                if len(p.shape) == 2 and p.requires_grad
+                else p.new_empty(())
+                for p, m in zip(learnableparams, self._pre_masks)
+            ]
+        else:
+            # sparsifying 2D tensor only, skip mask for unlearnable
+            # and unsparsifierable param
+            masks = [
+                self._compute_param_mask(
+                    p, columnwise_blocking=self.columnwise_blocking
+                )
+                if len(p.shape) == 2 and p.requires_grad
+                else p.new_empty(())
+                for p in learnableparams
+            ]
+        if self.accumulate_mask:
+            self._pre_masks = masks
+        return masks

--- a/pytext/optimizer/sparsifiers/sparsifier.py
+++ b/pytext/optimizer/sparsifiers/sparsifier.py
@@ -76,7 +76,6 @@ class L0_projection_sparsifier(Sparsifier):
         """
         obtain a mask and apply the mask to sparsify
         """
-        print("running L0 projection-based (unstructured) sparsification. \n ")
         model = state.model
         masks = self.get_masks(model)
         self.apply_masks(model, masks)
@@ -88,8 +87,9 @@ class L0_projection_sparsifier(Sparsifier):
         learnableparams = [p for p in model.parameters() if p.requires_grad]
         assert len(learnableparams) == len(masks)
         for m, w in zip(masks, learnableparams):
-            assert m.size() == w.size()
-            w.data *= m.clone()
+            if len(m.size()):
+                assert m.size() == w.size()
+                w.data *= m.clone()
 
     def get_masks(
         self, model: Model, pre_masks: List[torch.Tensor] = None

--- a/pytext/optimizer/sparsifiers/tests/sparsifier_test.py
+++ b/pytext/optimizer/sparsifiers/tests/sparsifier_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import math
+import unittest
+
+import torch
+from pytext.optimizer.sparsifiers.blockwise_sparsifier import (
+    BlockwiseMagnitudeSparsifier,
+)
+
+
+class TestSparsifier(unittest.TestCase):
+    def _get_blockwise_sparsifier(
+        self, block_size, sparsity, columnwise_blocking=False
+    ):
+        config = BlockwiseMagnitudeSparsifier.Config(
+            block_size=block_size,
+            sparsity=sparsity,
+            columnwise_blocking=columnwise_blocking,
+        )
+        return BlockwiseMagnitudeSparsifier.from_config(config)
+
+    def test_param_padding(self):
+        blockwise_sparsifier = self._get_blockwise_sparsifier(2, 0.6)
+        param = torch.tensor([i for i in range(25)], dtype=float).view(5, 5)
+        true_padded_param = param.new_zeros(param.size(0), 6)
+        true_padded_param[:, : param.size(1)] = param
+        padded_param = blockwise_sparsifier._padding_into_full_blocks(param)
+        self.assertTrue(
+            torch.allclose(
+                torch.sum(true_padded_param - padded_param),
+                torch.tensor([0.0], dtype=float),
+            )
+        )
+
+    def test_param_mask(self):
+        sparsity = 0.6
+        block_sz = 3
+        blockwise_sparsifier = self._get_blockwise_sparsifier(block_sz, sparsity)
+        param = torch.tensor([i for i in range(100)], dtype=float).view(10, 10)
+        block_l1_norms = param.new_zeros(param.shape)
+        # loop-based implementation to compute blockwise l1norm
+        abs_vals = []
+        for i in range(10):
+            for j in range(0, 10, block_sz):
+                block_l1_norms[i, j : j + block_sz] = torch.sum(
+                    param[i, j : j + block_sz]
+                )
+                abs_vals.append(torch.sum(param[i, j : j + block_sz]))
+
+        nnz = math.ceil(100 * (1 - sparsity))
+        nnz_blocks = math.ceil(nnz / block_sz)
+        abs_vals.sort(reverse=True)
+        threshold = abs_vals[nnz_blocks - 1]
+        true_mask = (block_l1_norms >= threshold).to(param.dtype)
+        mask = blockwise_sparsifier._compute_param_mask(param)
+        diff = torch.sum(torch.abs(mask - true_mask)).item()
+        self.assertTrue(diff <= 0.00000001)
+
+    def test_param_mask_columnwise(self):
+        sparsity = 0.6
+        block_sz = 3
+        blockwise_sparsifier = self._get_blockwise_sparsifier(
+            block_sz, sparsity, columnwise_blocking=True
+        )
+        param = torch.tensor([i for i in range(100)], dtype=float).view(10, 10)
+        block_l1_norms = param.new_zeros(param.shape)
+        # loop-based implementation to compute blockwise l1norm
+        abs_vals = []
+        for i in range(10):
+            for j in range(0, 10, block_sz):
+                block_l1_norms[j : j + block_sz, i] = torch.sum(
+                    param[j : j + block_sz, i]
+                )
+                abs_vals.append(torch.sum(param[j : j + block_sz, i]))
+
+        nnz = math.ceil(100 * (1 - sparsity))
+        nnz_blocks = math.ceil(nnz / block_sz)
+        abs_vals.sort(reverse=True)
+        threshold = abs_vals[nnz_blocks - 1]
+        true_mask = (block_l1_norms >= threshold).to(param.dtype)
+        mask = blockwise_sparsifier._compute_param_mask(param, columnwise_blocking=True)
+        diff = torch.sum(torch.abs(mask - true_mask)).item()
+        self.assertTrue(diff <= 0.00000001)
+
+    def test_param_mask_with_pre_mask(self):
+        sparsity = 0.6
+        block_sz = 3
+        blockwise_sparsifier = self._get_blockwise_sparsifier(block_sz, sparsity)
+        param = torch.tensor([i for i in range(100)], dtype=float).view(10, 10)
+        pre_mask = torch.tensor([i % 2 for i in range(100)], dtype=float).view(10, 10)
+        block_l1_norms = param.new_zeros(param.shape)
+        # loop-based implementation to compute blockwise l1norm
+        abs_vals = []
+        for i in range(10):
+            for j in range(0, 10, block_sz):
+                block_l1_norms[i, j : j + block_sz] = torch.sum(
+                    param[i, j : j + block_sz]
+                )
+                abs_vals.append(torch.sum(param[i, j : j + block_sz]))
+
+        nnz = math.ceil(100 * (1 - sparsity))
+        nnz_blocks = math.ceil(nnz / block_sz)
+        abs_vals.sort(reverse=True)
+        threshold = abs_vals[nnz_blocks - 1]
+        true_mask = (block_l1_norms >= threshold).to(param.dtype) * pre_mask
+        mask = blockwise_sparsifier._compute_param_mask(param, pre_mask)
+        diff = torch.sum(torch.abs(mask - true_mask)).item()
+        self.assertTrue(diff <= 0.00000001)

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -24,7 +24,7 @@ from pytext.models.model import Model
 from pytext.optimizer import Adam, Optimizer, learning_rates
 from pytext.optimizer.fp16_optimizer import FP16Optimizer, FP16OptimizerFairseq
 from pytext.optimizer.scheduler import Scheduler
-from pytext.optimizer.sparsifier import Sparsifier
+from pytext.optimizer.sparsifiers.sparsifier import Sparsifier
 from pytext.task.serialize import save
 from pytext.trainers.training_state import TrainingState
 from pytext.utils import cuda, precision, timing

--- a/pytext/trainers/training_state.py
+++ b/pytext/trainers/training_state.py
@@ -9,7 +9,7 @@ from pytext.data.tensorizers import Tensorizer
 from pytext.models.model import Model
 from pytext.optimizer import Optimizer
 from pytext.optimizer.scheduler import Scheduler
-from pytext.optimizer.sparsifier import Sparsifier
+from pytext.optimizer.sparsifiers.sparsifier import Sparsifier
 
 
 class TrainingState:


### PR DESCRIPTION
Summary:
Support row or column blockwise sparsification. Group parameters into blocks and either an entire block is removed or retained.

1. refactor sparsifier.py under optimizer/sparsifers and create "sparsifiers_lib". Reason: some sparsifiers depend on "models_lib" to extract particualr layers to perform sparsification. Yet "models_lib depends on "optimizers_lib". Refactoring prevents circular dependency.

2. add blockwise_sparsifier.py and unit-tests.

Differential Revision: D17910541

