### PR TITLE
Skip loading extra data for export

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -242,7 +242,9 @@ class _NewTask(TaskBase):
         optimizer = self.trainer.optimizer
         optimizer.pre_export(model)
 
-        unused_raw_batch, batch = next(iter(self.data.batches(Stage.TRAIN)))
+        unused_raw_batch, batch = next(
+            iter(self.data.batches(Stage.TRAIN, load_early=True))
+        )
         if metric_channels:
             print("Exporting metrics")
             for mc in metric_channels:
@@ -264,7 +266,9 @@ class _NewTask(TaskBase):
         model.eval()
         model.prepare_for_onnx_export_()
 
-        unused_raw_batch, batch = next(iter(self.data.batches(Stage.TRAIN)))
+        unused_raw_batch, batch = next(
+            iter(self.data.batches(Stage.TRAIN, load_early=True))
+        )
         inputs = model.arrange_model_inputs(batch)
         # call model forward to set correct device types
         model(*inputs)


### PR DESCRIPTION
Summary: When performing a standalone model export, we just need one batch of data to pass through. But we currently get the data via `data.batches(...)` which could use PoolingBatcher, which loads many many examples, or could have `in_memory=True`, which loads all examples. This can take hours for a large dataset (especially since we also tokenize the data). Add a flag for `batches()` that forcibly skips loading all data into memory and using pooling.

Differential Revision: D17920179

