### PR TITLE
Support exporting pytext LSTM to torchscript with quantization

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -108,6 +108,10 @@ class DocModel(Model):
         )
         return exporter.export_to_caffe2(self, path, export_onnx_path=export_onnx_path)
 
+    def quantize(self):
+        jit.quantized.quantize_linear_modules(self)
+        jit.quantized.quantize_rnn_modules(self)
+
     def torchscriptify(self, tensorizers, traced_model):
         output_layer = self.output_layer.torchscript_predictions()
 

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -122,6 +122,13 @@ class BaseModel(nn.Module, Component):
 
         self.apply(apply_prepare_for_onnx_export_)
 
+    def prepare_for_torchscript_export_(self, **kwargs):
+        def apply_prepare_for_torchscript_export_(module):
+            if module != self and hasattr(module, "prepare_for_torchscript_export_"):
+                module.prepare_for_torchscript_export_(**kwargs)
+
+        self.apply(apply_prepare_for_torchscript_export_)
+
     def quantize(self):
         """Quantize the model during export."""
         # by default only quantize the linear modules, override this method if your

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -265,6 +265,7 @@ class _NewTask(TaskBase):
         # Trace needs eval mode, to disable dropout etc
         model.eval()
         model.prepare_for_onnx_export_()
+        model.prepare_for_torchscript_export_(quantize=quantize)
 
         unused_raw_batch, batch = next(
             iter(self.data.batches(Stage.TRAIN, load_early=True))


### PR DESCRIPTION
Summary: The LSTM quantization code in `jit/quantized.py` only supports LSTMs with batch_first = False and pytext's LSTMs use batch_first = True. To enable exporting pytext's LSTMs with quantization, during the export first prepare the module by modifying that setting.

Differential Revision: D17911526

