### PR TITLE
Implement Cyclic CopyUnk Functionality

### DIFF
--- a/pytext/utils/tests/torch_test.py
+++ b/pytext/utils/tests/torch_test.py
@@ -69,6 +69,14 @@ class VocabTest(unittest.TestCase):
         vocab = Vocabulary(vocab_list, unk_idx=1)
         self.assertEqual([0, 1, 3, 4], vocab.lookup_indices_1d(["a", "e", "c", "d"]))
 
+    def test_lookup_words_1d_cycle_heuristic(self):
+        self.assertEqual(
+            self.vocab.lookup_words_1d_cycle_heuristic(
+                torch.tensor([1, 0, 0]), [], ["y", "z"]
+            ),
+            ["a", "y", "z"],
+        )
+
 
 BPE_VOCAB_FILE = io.StringIO(
     """


### PR DESCRIPTION
Summary: This implementation implements cyclic copying of unk tokens for when number of unk in utterances and target is the same, as well as copy unk when there's only one unk. For all the other cases we implement cyclic copying. This implementation is backward compatible with expected behavior and latency is not changed.

Differential Revision: D18032736

