### PR TITLE
Upgrade the torch.jit.quantized to torch.quantization.quantize_dynamic API in PyText

### DIFF
--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -125,8 +125,12 @@ class BaseModel(nn.Module, Component):
     def quantize(self):
         """Quantize the model during export."""
         # by default only quantize the linear modules, override this method if your
-        # model wants other modules quantized
-        quantized.quantize_linear_modules(self)
+        # model wants other modules quantized.
+        # By default we dynamic quantize Linear for PyText models.
+        # Todo: we can also add quantized torch.nn.LSTM/GRU support in the future.
+        torch.quantization.quantize_dynamic(
+            self, {torch.nn.Linear}, dtype=torch.qint8, inplace=True
+        )
 
     def get_param_groups_for_optimizer(self) -> List[Dict[str, List[nn.Parameter]]]:
         """


### PR DESCRIPTION
Summary: `torch.jit.quantized` is going to be deprecated. We would like to use the new PyTorch dynamic quantization API introduced in PT 1.3 release: https://pytorch.org/docs/stable/quantization.html#torch.quantization.quantize_dynamic

Differential Revision: D18073977

