### PR TITLE
Output encoded layers in Bert classification model

### DIFF
--- a/pytext/models/bert_classification_models.py
+++ b/pytext/models/bert_classification_models.py
@@ -69,7 +69,7 @@ class NewBertModel(BaseModel):
     def forward(
         self, encoder_inputs: Tuple[torch.Tensor, ...], *args
     ) -> List[torch.Tensor]:
-        representation = self.encoder(encoder_inputs)[0]
+        _, representation = self.encoder(encoder_inputs)
         return self.decoder(representation, *args)
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
@@ -80,7 +80,10 @@ class NewBertModel(BaseModel):
         labels = tensorizers["labels"].vocab
         vocab = tensorizers["tokens"].vocab
         encoder = create_module(
-            config.encoder, padding_idx=vocab.get_pad_index(), vocab_size=len(vocab)
+            config.encoder,
+            output_encoded_layers=True,
+            padding_idx=vocab.get_pad_index(),
+            vocab_size=len(vocab),
         )
         dense_dim = tensorizers["dense"].dim if "dense" in tensorizers else 0
         decoder = create_module(

--- a/pytext/models/bert_regression_model.py
+++ b/pytext/models/bert_regression_model.py
@@ -29,6 +29,7 @@ class NewBertRegressionModel(NewBertModel):
         vocab = tensorizers["tokens"].vocab
         encoder = create_module(
             config.encoder,
+            output_encoded_layers=True,
             padding_idx=vocab.get_pad_index(),
             vocab_size=vocab.__len__(),
         )


### PR DESCRIPTION
Summary:
Bert classification benefits from getting the full layer representations, because

1. We can do multi-tasking of classification and MLM. (The masked LM needs output_encoded_layers = True, and since the tasks share the encoder module the classification model would need it too.

2. Next diff in the stack needs encoded layers to add losses to the intermediate layers.

These layer representations are computed by the underlying transformer module anyways, so there is no increase in training time.

Differential Revision: D18096829

