### PR TITLE
Add stacked transformers

### DIFF
--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -131,11 +131,8 @@ class FileChannel(Channel):
         return ("prediction", "target", "score") + context_keys
 
     def gen_content(self, metrics, loss, preds, targets, scores, context):
-        context_values = context.values()
-        for i in range(len(preds)):
-            res = [preds[i], targets[i], scores[i]]
-            res.extend([v_list[i] for v_list in context_values])
-            yield res
+        # Use zip to truncate to the shortest of these sequences
+        return zip(preds, targets, scores, *context.values())
 
 
 class TensorBoardChannel(Channel):

--- a/pytext/models/bert_classification_models.py
+++ b/pytext/models/bert_classification_models.py
@@ -69,7 +69,7 @@ class NewBertModel(BaseModel):
     def forward(
         self, encoder_inputs: Tuple[torch.Tensor, ...], *args
     ) -> List[torch.Tensor]:
-        representation = self.encoder(encoder_inputs)[0]
+        representation = self.encoder(encoder_inputs)[-1]
         return self.decoder(representation, *args)
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
@@ -80,7 +80,10 @@ class NewBertModel(BaseModel):
         labels = tensorizers["labels"].vocab
         vocab = tensorizers["tokens"].vocab
         encoder = create_module(
-            config.encoder, padding_idx=vocab.get_pad_index(), vocab_size=len(vocab)
+            config.encoder,
+            padding_idx=vocab.get_pad_index(),
+            vocab_size=len(vocab),
+            output_encoded_layers=True,
         )
         dense_dim = tensorizers["dense"].dim if "dense" in tensorizers else 0
         decoder = create_module(

--- a/pytext/models/bert_regression_model.py
+++ b/pytext/models/bert_regression_model.py
@@ -31,6 +31,7 @@ class NewBertRegressionModel(NewBertModel):
             config.encoder,
             padding_idx=vocab.get_pad_index(),
             vocab_size=vocab.__len__(),
+            output_encoded_layers=True,
         )
         decoder = create_module(
             config.decoder, in_dim=encoder.representation_dim, out_dim=1

--- a/pytext/models/masked_lm.py
+++ b/pytext/models/masked_lm.py
@@ -32,6 +32,8 @@ class MaskedLanguageModel(BaseModel):
 
     SUPPORT_FP16_OPTIMIZER = True
 
+    __EXPANSIBLE__ = True
+
     class Config(BaseModel.Config):
         class InputConfig(ConfigBase):
             tokens: BERTTensorizer.Config = BERTTensorizer.Config(max_seq_len=128)


### PR DESCRIPTION
Summary: Add stacked models for pre-training (MLM) and fine-tuning (classification). These models are Bert models where the losses can be applied to multiple layers, so that after fine-tuning we can keep several or all layers and have good final models (for faster inference). https://fb.quip.com/m2HOASKMgJc4

Differential Revision: D18096913

