### PR TITLE
Enable passing `model_test_params` to model during pytext testing

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from collections import OrderedDict
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 class ConfigBaseMeta(type):
@@ -147,6 +147,8 @@ class TestConfig(ConfigBase):
     use_tensorboard: bool = True
     # Output path where metric reporter writes to.
     test_out_path: str = ""
+    # Dictionary of test params to be passed to the model when preparing for testing.
+    model_test_params: Optional[Dict[str, str]] = None
 
 
 LATEST_VERSION = 18

--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -130,11 +130,8 @@ class FileChannel(Channel):
         return ("prediction", "target", "score") + context_keys
 
     def gen_content(self, metrics, loss, preds, targets, scores, context):
-        context_values = context.values()
-        for i in range(len(preds)):
-            res = [preds[i], targets[i], scores[i]]
-            res.extend([v_list[i] for v_list in context_values])
-            yield res
+        # Use zip to truncate to the shortest of these sequences
+        return zip(preds, targets, scores, *context.values())
 
 
 class TensorBoardChannel(Channel):

--- a/pytext/models/bert_classification_models.py
+++ b/pytext/models/bert_classification_models.py
@@ -69,7 +69,7 @@ class NewBertModel(BaseModel):
     def forward(
         self, encoder_inputs: Tuple[torch.Tensor, ...], *args
     ) -> List[torch.Tensor]:
-        representation = self.encoder(encoder_inputs)[0]
+        _, representation = self.encoder(encoder_inputs)
         return self.decoder(representation, *args)
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
@@ -80,7 +80,10 @@ class NewBertModel(BaseModel):
         labels = tensorizers["labels"].vocab
         vocab = tensorizers["tokens"].vocab
         encoder = create_module(
-            config.encoder, padding_idx=vocab.get_pad_index(), vocab_size=len(vocab)
+            config.encoder,
+            output_encoded_layers=True,
+            padding_idx=vocab.get_pad_index(),
+            vocab_size=len(vocab),
         )
         dense_dim = tensorizers["dense"].dim if "dense" in tensorizers else 0
         decoder = create_module(

--- a/pytext/models/bert_regression_model.py
+++ b/pytext/models/bert_regression_model.py
@@ -29,6 +29,7 @@ class NewBertRegressionModel(NewBertModel):
         vocab = tensorizers["tokens"].vocab
         encoder = create_module(
             config.encoder,
+            output_encoded_layers=True,
             padding_idx=vocab.get_pad_index(),
             vocab_size=vocab.__len__(),
         )

--- a/pytext/models/masked_lm.py
+++ b/pytext/models/masked_lm.py
@@ -32,6 +32,8 @@ class MaskedLanguageModel(BaseModel):
 
     SUPPORT_FP16_OPTIMIZER = True
 
+    __EXPANSIBLE__ = True
+
     class Config(BaseModel.Config):
         class InputConfig(ConfigBase):
             tokens: BERTTensorizer.Config = BERTTensorizer.Config(max_seq_len=128)

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -207,6 +207,9 @@ class BaseModel(nn.Module, Component):
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
         pass
 
+    def prepare_for_test(self, test_params):
+        self.eval()
+
 
 class Model(BaseModel):
     """

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -206,11 +206,12 @@ class _NewTask(TaskBase):
         )
 
     @torch.no_grad()
-    def test(self, data_source):
+    def test(self, data_source, model_test_params=None):
         return self.trainer.test(
             self.data.batches(Stage.TEST, data_source=data_source),
             self.model,
             self.metric_reporter,
+            model_test_params,
         )
 
     def predict(self, examples):

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -148,11 +148,13 @@ class Trainer(TrainerBase):
         return cls(config, model)
 
     @timing.time("Trainer.test")
-    def test(self, test_iter, model, metric_reporter: MetricReporter):
+    def test(
+        self, test_iter, model, metric_reporter: MetricReporter, model_test_params=None
+    ):
         state = TrainingState(stage=Stage.TEST, model=model, epoch=1)
         if cuda.CUDA_ENABLED:
             state.model.cuda()
-        state.model.eval()
+        state.model.prepare_for_test(model_test_params)
         with torch.no_grad():
             return self.run_epoch(state, test_iter, metric_reporter)
 

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -216,6 +216,7 @@ def test_model(
         metric_channels,
         test_out_path,
         test_config.field_names,
+        test_config.model_test_params,
     )
 
 
@@ -226,6 +227,7 @@ def test_model_from_snapshot_path(
     metric_channels: Optional[List[Channel]] = None,
     test_out_path: str = "",
     field_names: Optional[List[str]] = None,
+    model_test_params: Optional[Dict[str, str]] = None,
 ):
     _set_cuda(use_cuda_if_available)
     task, train_config, _training_state = load(snapshot_path)
@@ -248,7 +250,7 @@ def test_model_from_snapshot_path(
         data_source = _get_data_source(
             test_path, train_config.task.data, field_names, task
         )
-        test_results = task.test(data_source)
+        test_results = task.test(data_source, model_test_params)
     else:
         if not test_path:
             test_path = train_config.task.data_handler.test_path


### PR DESCRIPTION
Summary:
Enable configuring test params during pytext testing and configuring a list of test params to the TrainAndMultiTestWorkflow and RunMultilingualKDWorkflow. These params are passed to the model to prepare for testing.

In particular, for stacked transformers we train a single model, but want to test each K-layer model individually. So we need to configure which layer to test for each test run.

Differential Revision: D18097006

