### PR TITLE
Consolidate Bert, XLM and RoBERTa Tensorizers

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -2,15 +2,58 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import itertools
-from typing import List
+from typing import Dict, List
 
+from fairseq.data.dictionary import Dictionary
 from fairseq.data.legacy.masked_lm_dictionary import BertDictionary
 from pytext.config.component import ComponentType, create_component
-from pytext.data.tensorizers import Tensorizer, TokenTensorizer, lookup_tokens
-from pytext.data.tokenizers import Gpt2Tokenizer, Tokenizer, WordPieceTokenizer
-from pytext.data.utils import BOS, EOS, MASK, PAD, UNK, Vocabulary, pad_and_tensorize
-from pytext.torchscript.tensorizer import ScriptRoBERTaTensorizer
-from pytext.utils.torch import Vocabulary as ScriptVocabulary
+from pytext.data.tensorizers import TokenTensorizer, lookup_tokens
+from pytext.data.tokenizers import Tokenizer, WordPieceTokenizer
+from pytext.data.utils import (
+    BOS,
+    EOS,
+    MASK,
+    PAD,
+    UNK,
+    SpecialToken,
+    Vocabulary,
+    pad_and_tensorize,
+)
+
+
+def build_wordpiece_vocab(
+    wordpiece_vocab: Dict, special_token_replacements: Dict[str, SpecialToken] = None
+) -> Vocabulary:
+    """
+    Build the wordpiece vocab. This requires a special function since the vocab is
+    extracted from the tokenizer.
+    """
+    return Vocabulary(
+        [token for token, _ in wordpiece_vocab.items()],
+        replacements=special_token_replacements,
+    )
+
+
+def build_fairseq_vocab(
+    dictionary_class: Dictionary,
+    vocab_file: str,
+    special_token_replacements: Dict[str, SpecialToken] = None,
+    max_vocab: int = -1,
+    min_count: int = -1,
+) -> Vocabulary:
+    """
+    Function builds a PyText vocabulary for models pre-trained using Fairseq
+    modules. The dictionary class can take any Dictionary (or its child) class
+    and is used to load the vocab file.
+    """
+    dictionary = dictionary_class.load(vocab_file)
+    # finalize will sort the dict based on frequency so only do this if
+    # a min_count or max_vocab size is specified
+    if min_count > 0 or max_vocab > 0:
+        dictionary.finalize(threshold=min_count, nwords=max_vocab, padding_factor=1)
+    return Vocabulary(
+        dictionary.symbols, dictionary.count, replacements=special_token_replacements
+    )
 
 
 class BERTTensorizer(TokenTensorizer):
@@ -24,8 +67,13 @@ class BERTTensorizer(TokenTensorizer):
         #: The tokenizer to use to split input text into tokens.
         columns: List[str] = ["text"]
         tokenizer: Tokenizer.Config = WordPieceTokenizer.Config()
-        add_bos_token: bool = True
+        add_bos_token: bool = False
         add_eos_token: bool = True
+        # If set to true, this will call the wrap function
+        # which has logic for doing model specific wrapping of numberized
+        # sentences. This flag also allows us to use the add_bos_token and
+        # add_eos_token flags for what they were originally meant to do
+        wrap_special_tokens: bool = True
         bos_token: str = "[CLS]"
         eos_token: str = "[SEP]"
         pad_token: str = "[PAD]"
@@ -34,40 +82,60 @@ class BERTTensorizer(TokenTensorizer):
         vocab_file: str = WordPieceTokenizer.Config().wordpiece_vocab_path
 
     @classmethod
-    def from_config(cls, config: Config, **kwargs):
+    def from_config(cls, config: Config):
         tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
-        replacements = {
+        special_token_replacements = {
             config.unk_token: UNK,
             config.pad_token: PAD,
             config.bos_token: BOS,
             config.eos_token: EOS,
             config.mask_token: MASK,
         }
+        # Build the Vocabulary. Here we need a special case for
+        # WordPiece since the vocabulary for WordPiece is created inside the
+        # tokenizer
         if isinstance(tokenizer, WordPieceTokenizer):
-            vocab = Vocabulary(
-                [token for token, _ in tokenizer.vocab.items()],
-                replacements=replacements,
-            )
+            vocab = build_wordpiece_vocab(tokenizer.vocab, special_token_replacements)
         else:
-            dictionary = BertDictionary.load(config.vocab_file)
-            vocab = Vocabulary(
-                dictionary.symbols, dictionary.count, replacements=replacements
+            vocab = build_fairseq_vocab(
+                dictionary_class=BertDictionary,
+                vocab_file=config.vocab_file,
+                special_token_replacements=special_token_replacements,
             )
+
         return cls(
             columns=config.columns,
             tokenizer=tokenizer,
+            vocab=vocab,
             add_bos_token=config.add_bos_token,
             add_eos_token=config.add_eos_token,
             use_eos_token_for_bos=config.use_eos_token_for_bos,
+            wrap_special_tokens=config.wrap_special_tokens,
             max_seq_len=config.max_seq_len,
-            vocab=vocab,
-            **kwargs,
         )
 
-    def __init__(self, columns, **kwargs):
-        super().__init__(text_column=None, **kwargs)
+    def __init__(
+        self,
+        columns: List[str],
+        vocab: Vocabulary,
+        tokenizer: Tokenizer,
+        add_bos_token: bool = Config.add_bos_token,
+        add_eos_token: bool = Config.add_eos_token,
+        use_eos_token_for_bos: bool = Config.use_eos_token_for_bos,
+        wrap_special_tokens: bool = Config.wrap_special_tokens,
+        max_seq_len: int = Config.max_seq_len,
+    ) -> None:
+        super().__init__(
+            text_column=None,
+            vocab=vocab,
+            tokenizer=tokenizer,
+            add_bos_token=add_bos_token,
+            add_eos_token=add_eos_token,
+            use_eos_token_for_bos=use_eos_token_for_bos,
+            max_seq_len=max_seq_len,
+        )
         self.columns = columns
-        # Manually initialize column_schema since we are sending None to TokenTensorizer
+        self.wrap_special_tokens = wrap_special_tokens
 
     def initialize(self, vocab_builder=None, from_scratch=True):
         # vocab for BERT is already set
@@ -80,94 +148,57 @@ class BERTTensorizer(TokenTensorizer):
         return [(column, str) for column in self.columns]
 
     def _lookup_tokens(self, text):
+        """
+        lookup_tokens does both the numberization as well as the wrapping
+        of text with special tokens (eg: EOS and BOS). In some cases (eg: BERT),
+        we use the add_bos_token flag to add a single BOS token at the start of
+        the text instead of at the start of every sentence. As a result the call
+        to lookup_tokens can be model specific and each child of BERTTensorizer
+        has the option of customizing this call.
+        """
         return lookup_tokens(
             text,
             tokenizer=self.tokenizer,
             vocab=self.vocab,
-            bos_token=None,
-            eos_token=self.vocab.eos_token,
+            bos_token=self.vocab.bos_token if self.add_bos_token else None,
+            eos_token=self.vocab.eos_token if self.add_eos_token else None,
             max_seq_len=self.max_seq_len,
         )
 
+    def wrap(self, sentences: List[List[str]]):
+        """
+        Function which handles wrapping of numberized text with special tokens.
+        """
+        bos_token = (
+            self.vocab.eos_token if self.use_eos_token_for_bos else self.vocab.bos_token
+        )
+        sentences[0] = [self.vocab.idx[bos_token]] + sentences[0]
+        return sentences
+
     def numberize(self, row):
-        """Tokenize, look up in vocabulary."""
+        """
+        Tokenize and look up in vocabulary. This also adds a BOS token once at
+        the beginning of the final numberized output.
+        """
         sentences = [self._lookup_tokens(row[column])[0] for column in self.columns]
-        if self.add_bos_token:
-            bos_token = (
-                self.vocab.eos_token
-                if self.use_eos_token_for_bos
-                else self.vocab.bos_token
-            )
-            sentences[0] = [self.vocab.idx[bos_token]] + sentences[0]
+        if self.wrap_special_tokens:
+            sentences = self.wrap(sentences)
         seq_lens = (len(sentence) for sentence in sentences)
         segment_labels = ([i] * seq_len for i, seq_len in enumerate(seq_lens))
         tokens = list(itertools.chain(*sentences))
         segment_labels = list(itertools.chain(*segment_labels))
         seq_len = len(tokens)
+        positions = [index for index in range(seq_len)]
         # tokens, segment_label, seq_len
-        return tokens, segment_labels, seq_len
+        return tokens, segment_labels, seq_len, positions
 
     def sort_key(self, row):
         return row[2]
 
     def tensorize(self, batch):
-        tokens, segment_labels, seq_lens = zip(*batch)
+        tokens, segment_labels, seq_lens, positions = zip(*batch)
         tokens = pad_and_tensorize(tokens, self.vocab.get_pad_index())
         pad_mask = (tokens != self.vocab.get_pad_index()).long()
         segment_labels = pad_and_tensorize(segment_labels, self.vocab.get_pad_index())
-        return tokens, pad_mask, segment_labels
-
-
-class RoBERTaTensorizer(BERTTensorizer):
-    class Config(Tensorizer.Config):
-        columns: List[str] = ["text"]
-        tokenizer: Gpt2Tokenizer.Config = Gpt2Tokenizer.Config()
-        max_seq_len: int = 256
-
-    @classmethod
-    def from_config(cls, config: Config, **kwargs):
-        tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
-        vocab = tokenizer.vocab
-        return cls(
-            columns=config.columns,
-            tokenizer=tokenizer,
-            max_seq_len=config.max_seq_len,
-            vocab=vocab,
-        )
-
-    def __init__(self, columns, tokenizer=None, vocab=None, max_seq_len=256):
-        super().__init__(
-            columns=columns,
-            tokenizer=tokenizer,
-            add_bos_token=False,
-            add_eos_token=True,
-            max_seq_len=max_seq_len,
-            vocab=vocab,
-        )
-        self.bpe = self.tokenizer.bpe
-        self.bos = self.tokenizer.bos
-        self.eos = self.tokenizer.eos
-
-    def _lookup_tokens(self, text):
-        return lookup_tokens(
-            text,
-            tokenizer=self.tokenizer,
-            vocab=self.vocab,
-            bos_token=self.bos,
-            eos_token=self.eos,
-            max_seq_len=self.max_seq_len,
-        )
-
-    def torchscriptify(self):
-        return ScriptRoBERTaTensorizer(
-            tokenizer=self.tokenizer.torchscriptify(),
-            vocab=ScriptVocabulary(
-                list(self.vocab),
-                pad_idx=self.vocab.get_pad_index(),
-                bos_idx=self.vocab.get_bos_index(),
-                eos_idx=self.vocab.get_eos_index(),
-            ),
-            max_seq_len=self.max_seq_len,
-            add_bos_token=True,
-            use_eos_token_for_bos=False,
-        )
+        positions = pad_and_tensorize(positions)
+        return tokens, pad_mask, segment_labels, positions

--- a/pytext/data/packed_lm_data.py
+++ b/pytext/data/packed_lm_data.py
@@ -80,10 +80,8 @@ class PackedLMData(Data):
         numberize. We will simply create this in `_format_output_row`.
         """
         numberized_row = self.tensorizer.numberize(row)
-        if isinstance(self.tensorizer, XLMTensorizer):
-            tokens, seq_len, segment_labels, _ = numberized_row
-        elif isinstance(self.tensorizer, BERTTensorizer):
-            tokens, segment_labels, seq_len = numberized_row
+        if isinstance(self.tensorizer, BERTTensorizer):
+            tokens, segment_labels, seq_len, _ = numberized_row
         elif isinstance(self.tensorizer, TokenTensorizer):
             tokens, seq_len, _ = numberized_row
             segment_labels = []
@@ -102,11 +100,9 @@ class PackedLMData(Data):
         In case of the XLMTensorizer, we also need to create a new positions list
         which goes from 0 to seq_len.
         """
-        if isinstance(self.tensorizer, XLMTensorizer):
+        if isinstance(self.tensorizer, BERTTensorizer):
             positions = [index for index in range(seq_len)]
-            return {self.tensorizer_name: (tokens, seq_len, segment_labels, positions)}
-        elif isinstance(self.tensorizer, BERTTensorizer):
-            return {self.tensorizer_name: (tokens, segment_labels, seq_len)}
+            return {self.tensorizer_name: (tokens, segment_labels, seq_len, positions)}
         elif isinstance(self.tensorizer, TokenTensorizer):
             # dummy token_ranges
             return {self.tensorizer_name: (tokens, seq_len, [(-1, -1)] * seq_len)}

--- a/pytext/data/roberta_tensorizer.py
+++ b/pytext/data/roberta_tensorizer.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import List
+
+from fairseq.data.dictionary import Dictionary
+from pytext.config.component import ComponentType, create_component
+from pytext.data.bert_tensorizer import BERTTensorizer, build_fairseq_vocab
+from pytext.data.tensorizers import Tensorizer, lookup_tokens
+from pytext.data.tokenizers import Gpt2Tokenizer, Tokenizer
+from pytext.data.utils import BOS, EOS, PAD, UNK, Vocabulary
+from pytext.torchscript.tensorizer import ScriptRoBERTaTensorizer
+from pytext.utils.torch import Vocabulary as ScriptVocabulary
+
+
+def build_roberta_vocab(
+    pad_token: str, bos_token: str, eos_token: str, unk_token: str, vocab_file: str
+) -> Vocabulary:
+    special_token_replacements = {
+        pad_token: PAD,
+        bos_token: BOS,
+        eos_token: EOS,
+        unk_token: UNK,
+    }
+    vocab = build_fairseq_vocab(
+        dictionary_class=Dictionary,
+        vocab_file=vocab_file,
+        special_token_replacements=special_token_replacements,
+    )
+    return vocab
+
+
+class RoBERTaTensorizer(BERTTensorizer):
+    class Config(Tensorizer.Config):
+        columns: List[str] = ["text"]
+        vocab_file: str = (
+            "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/dict.txt"
+        )
+        tokenizer: Tokenizer.Config = Gpt2Tokenizer.Config()
+        bos_token: str = "<s>"
+        eos_token: str = "</s>"
+        pad_token: str = "<pad>"
+        unk_token: str = "<unk>"
+        max_seq_len: int = 256
+
+    @classmethod
+    def from_config(cls, config: Config, **kwargs):
+        tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
+        vocab = build_roberta_vocab(
+            config.pad_token,
+            config.bos_token,
+            config.eos_token,
+            config.unk_token,
+            config.vocab_file,
+        )
+        return cls(
+            columns=config.columns,
+            tokenizer=tokenizer,
+            max_seq_len=config.max_seq_len,
+            vocab=vocab,
+        )
+
+    def __init__(self, columns, tokenizer=None, vocab=None, max_seq_len=256):
+        super().__init__(
+            columns=columns,
+            tokenizer=tokenizer,
+            add_bos_token=False,
+            add_eos_token=True,
+            max_seq_len=max_seq_len,
+            vocab=vocab,
+        )
+
+    def _lookup_tokens(self, text):
+        return lookup_tokens(
+            text,
+            tokenizer=self.tokenizer,
+            vocab=self.vocab,
+            bos_token=self.vocab.bos_token,
+            eos_token=self.vocab.eos_token,
+            max_seq_len=self.max_seq_len,
+        )
+
+    def torchscriptify(self):
+        return ScriptRoBERTaTensorizer(
+            tokenizer=self.tokenizer.torchscriptify(),
+            vocab=ScriptVocabulary(
+                list(self.vocab),
+                pad_idx=self.vocab.get_pad_index(),
+                bos_idx=self.vocab.get_bos_index(),
+                eos_idx=self.vocab.get_eos_index(),
+            ),
+            max_seq_len=self.max_seq_len,
+            add_bos_token=True,
+            use_eos_token_for_bos=False,
+        )

--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -180,9 +180,6 @@ class Gpt2Tokenizer(Tokenizer):
     """Tokenizer for gpt-2 and RoBERTa."""
 
     class Config(ConfigBase):
-        token_dictionary_path: str = (
-            "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/dict.txt"
-        )
         bpe_encoder_path: str = (
             "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/encoder.json"
         )
@@ -192,24 +189,15 @@ class Gpt2Tokenizer(Tokenizer):
 
     @classmethod
     def from_config(cls, config: Config):
-        dictionary = Dictionary.load(config.token_dictionary_path)
         bpe = create_gpt2_bpe(config.bpe_encoder_path, config.bpe_vocab_path)
         # This hacks the bpe instance to be picklable
         bpe = copy.copy(bpe)
         bpe.__class__ = PickleableGPT2BPEEncoder
 
-        return cls(bpe, dictionary)
+        return cls(bpe)
 
-    def __init__(self, bpe, dictionary: Dictionary):
+    def __init__(self, bpe):
         self.bpe = bpe
-        self.vocab = Vocabulary(
-            dictionary.symbols,
-            pad_token=str(dictionary[dictionary.pad()]),
-            bos_token=str(dictionary[dictionary.bos()]),
-            eos_token=str(dictionary[dictionary.eos()]),
-        )
-        self.bos = self.vocab.bos_token
-        self.eos = self.vocab.eos_token
 
     def tokenize(self, input_str: str) -> List[Token]:
         bpe_ids = self.bpe.encode(input_str)

--- a/pytext/data/xlm_tensorizer.py
+++ b/pytext/data/xlm_tensorizer.py
@@ -4,156 +4,136 @@
 import itertools
 from typing import Any, Dict, List, Optional, Tuple
 
-import torch
 from fairseq.data.legacy.masked_lm_dictionary import MaskedLMDictionary
 from pytext.config.component import ComponentType, create_component
-from pytext.data.bert_tensorizer import BERTTensorizer
+from pytext.data.bert_tensorizer import BERTTensorizer, build_fairseq_vocab
 from pytext.data.tensorizers import lookup_tokens
 from pytext.data.tokenizers import Tokenizer
-from pytext.data.utils import BOS, EOS, MASK, PAD, UNK, Vocabulary, pad_and_tensorize
+from pytext.data.utils import EOS, MASK, PAD, UNK, Vocabulary
 from pytext.data.xlm_constants import LANG2ID_15
-from pytext.data.xlm_dictionary import Dictionary as XLMDictionary
-
-
-def read_vocab(
-    vocab_file: str, max_vocab: int, min_count: int
-) -> Tuple[List, List, Dict]:
-    dictionary = XLMDictionary.read_vocab(vocab_file)
-    if max_vocab >= 1:
-        dictionary.max_vocab(max_vocab)
-    if min_count >= 0:
-        dictionary.min_count(min_count)
-    vocab_list = [dictionary.id2word[w] for w in sorted(dictionary.id2word)]
-    counts = [dictionary.counts[w] for w in vocab_list]
-    replacements = {"<unk>": UNK, "<pad>": PAD, "<s>": BOS, "</s>": EOS}
-    return vocab_list, counts, replacements
-
-
-def read_fairseq_vocab(
-    vocab_file: str, max_vocab: int = -1, min_count: int = -1
-) -> Tuple[List, List, Dict]:
-    dictionary = MaskedLMDictionary.load(vocab_file)
-    dictionary.finalize(threshold=min_count, nwords=max_vocab, padding_factor=1)
-    vocab_list = dictionary.symbols
-    counts = dictionary.count
-    replacements = {"<pad>": PAD, "</s>": EOS, "<unk>": UNK, "<mask>": MASK}
-    return vocab_list, counts, replacements
 
 
 class XLMTensorizer(BERTTensorizer):
     """
     Tensorizer for Cross-lingual LM tasks. Works for single sentence as well
-    as sentence pair.
+    as sentence pair (as long as the pair have the same language).
     """
 
     class Config(BERTTensorizer.Config):
+        columns: List[str] = ["text"]
+        # Parameters related to the vocab
         vocab_file: str = "/mnt/vol/nlp_technologies/xlm/vocab_xnli_15"
-        tokenizer: Tokenizer.Config = Tokenizer.Config()
-        is_fairseq: bool = False
-        pretraining: bool = False
-        max_seq_len: Optional[int] = 256
         max_vocab: int = 95000
         min_count: int = 0
-        language_columns: List[str] = ["language"]
-        lang2id: Dict[str, int] = LANG2ID_15
-        reset_positions: bool = False
-        has_language_in_data: bool = False
+        # Special tokens need to be specified in order to update PyText defaults
+        eos_token: str = "</s>"
+        pad_token: str = "<pad>"
+        unk_token: str = "<unk>"
+        mask_token: str = "<mask>"
+
+        # Parameters related to the tokenizer and numberization
+        tokenizer: Tokenizer.Config = Tokenizer.Config()
+        add_bos_token: bool = True
+        add_eos_token: bool = True
+        use_eos_token_for_bos: bool = True
+        # See parent class for more details about this flag
+        wrap_special_tokens: bool = False
+
+        max_seq_len: Optional[int] = 256
+        # controls whether we train with language embeddings or not
         use_language_embeddings: bool = True
+        # language identifiers for extracting the language from a row of data
+        # during numberize
+        language_columns: List[str] = ["language"]
+        # language-to-id mapping used to obtain language embeddings
+        lang2id: Dict[str, int] = LANG2ID_15
+        # Controls whether language is being read from the data file (which
+        # is what happens for finetuning) or being added during processing
+        # (which is what happens during pretraining)
+        has_language_in_data: bool = False
+
+        # Deprecated parameters
+        # TODO: Remove these after adding the necessary config adapters
+        is_fairseq: bool = False
+        pretraining: bool = False
+        reset_positions: bool = False
 
     @classmethod
     def from_config(cls, config: Config):
         tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
-        return cls(
-            columns=config.columns,
-            tokenizer=tokenizer,
+        special_token_replacements = {
+            config.unk_token: UNK,
+            config.pad_token: PAD,
+            config.eos_token: EOS,
+            config.mask_token: MASK,
+        }
+        vocab = build_fairseq_vocab(
+            dictionary_class=MaskedLMDictionary,
             vocab_file=config.vocab_file,
-            is_fairseq=config.is_fairseq,
-            pretraining=config.pretraining,
-            max_seq_len=config.max_seq_len,
+            special_token_replacements=special_token_replacements,
             max_vocab=config.max_vocab,
             min_count=config.min_count,
+        )
+        return cls(
+            columns=config.columns,
+            vocab=vocab,
+            tokenizer=tokenizer,
+            add_bos_token=config.add_bos_token,
+            add_eos_token=config.add_eos_token,
+            use_eos_token_for_bos=config.use_eos_token_for_bos,
+            wrap_special_tokens=config.wrap_special_tokens,
+            max_seq_len=config.max_seq_len,
             language_columns=config.language_columns,
             lang2id=config.lang2id,
-            reset_positions=config.reset_positions,
-            has_language_in_data=config.has_language_in_data,
             use_language_embeddings=config.use_language_embeddings,
+            has_language_in_data=config.has_language_in_data,
         )
 
     def __init__(
         self,
-        columns=Config.columns,
-        tokenizer=None,
-        vocab_file=Config.vocab_file,
-        is_fairseq=Config.is_fairseq,
-        pretraining=Config.pretraining,
-        max_seq_len=Config.max_seq_len,
-        max_vocab=Config.max_vocab,
-        min_count=Config.min_count,
+        columns: List[str],
+        vocab: Vocabulary,
+        tokenizer: Tokenizer,
+        add_bos_token: bool = Config.add_bos_token,
+        add_eos_token: bool = Config.add_eos_token,
+        use_eos_token_for_bos: bool = Config.use_eos_token_for_bos,
+        wrap_special_tokens: bool = Config.wrap_special_tokens,
+        max_seq_len: int = Config.max_seq_len,
         language_columns=Config.language_columns,
         lang2id=Config.lang2id,
-        reset_positions=Config.reset_positions,
-        has_language_in_data=Config.has_language_in_data,
         use_language_embeddings=Config.use_language_embeddings,
+        has_language_in_data=Config.has_language_in_data,
     ) -> None:
-        assert (
-            len(columns) <= 2 and len(language_columns) <= 2
-        ), "Number of text fields and language columns cannot be greater than 2."
+        assert len(columns) <= 2, "More than 2 text fields are not supported."
 
-        assert (
-            len(language_columns) == len(columns) or len(language_columns) == 1
-        ), "language columns must be same length as columns, or of length one"
-
-        # Used to distinguish the model pre-trained in PyText and the OSS FAIR model
-        self.is_fairseq = is_fairseq
-
-        # controls the settings we need explictly for pretraining
-        self.pretraining = pretraining
-
-        # language identifiers for extracting the language from a row of data
-        # during numberize
-        self.language_columns = language_columns
-
-        # language-to-id mapping used to obtain language embeddings
-        self.lang2id = lang2id
-
-        vocab = self._build_vocab(vocab_file, max_vocab, min_count)
-        self.special_token = vocab.idx[EOS]
-
-        # Controls whether we reset the position or not in case we have
-        # multiplt text fields
-        self.reset_positions = reset_positions
-
-        # controls whether we train with language embeddings or not
-        self.use_language_embeddings = use_language_embeddings
+        assert len(language_columns) == 1, "More than 1 language is not supported."
 
         super().__init__(
             columns=columns,
-            tokenizer=tokenizer,
-            add_bos_token=False,
-            add_eos_token=False,
-            use_eos_token_for_bos=True,
             vocab=vocab,
+            tokenizer=tokenizer,
+            add_bos_token=add_bos_token,
+            add_eos_token=add_eos_token,
+            use_eos_token_for_bos=use_eos_token_for_bos,
+            wrap_special_tokens=wrap_special_tokens,
             max_seq_len=max_seq_len,
         )
-        # if the dataset has a language column then adjust the schema appropriately
+
+        self.num_special_tokens = (1 if add_bos_token else 0) + (
+            1 if add_eos_token else 0
+        )
+        self.language_columns = language_columns
+        self.lang2id = lang2id
+        self.use_language_embeddings = use_language_embeddings
         self.has_language_in_data = has_language_in_data
 
     @property
     def column_schema(self):
         schema = super().column_schema
+        # input data always has a language for each instance
         if self.has_language_in_data:
             schema += [(column, str) for column in self.language_columns]
         return schema
-
-    def _numberize_and_wrap(self, text: str, seq_len: int) -> List[List[int]]:
-        sentence = (
-            [self.special_token]
-            + lookup_tokens(
-                text, tokenizer=self.tokenizer, vocab=self.vocab, max_seq_len=seq_len
-            )[0]
-            + [self.special_token]
-        )
-        return [sentence]
 
     def get_lang_id(self, row: Dict, col: str) -> int:
         # generate lang embeddings. if training without lang embeddings, use
@@ -167,94 +147,62 @@ class XLMTensorizer(BERTTensorizer):
             # use En as default
             return self.lang2id.get("en", 0)
 
+    def _lookup_tokens(self, text: str, seq_len: int) -> List[str]:
+        """
+        XLM wraps every sentence with the EOS token both at the beginning and
+        at the end. So the call to lookup_tokens can just use the flags as is.
+        """
+        return lookup_tokens(
+            text,
+            tokenizer=self.tokenizer,
+            vocab=self.vocab,
+            bos_token=self.vocab.bos_token if self.add_bos_token else None,
+            eos_token=self.vocab.eos_token if self.add_eos_token else None,
+            use_eos_token_for_bos=self.use_eos_token_for_bos,
+            max_seq_len=seq_len,
+        )
+
+    def wrap(self, numberized_sentences: List[List[str]]):
+        raise NotImplementedError("XLM does not support special token wrapping.")
+
     def numberize(self, row: Dict) -> Tuple[Any, ...]:
         """
         Extract text and language information from the current row of data being
         processed. Process the text by tokenizing and vocabulary lookup. Convert
-        language to corresponding list of ids. This function can handle both
-        monolingual and parallel data as well as single sentence and sentence
-        pairs.
+        language to corresponding list of ids.
         """
         sentences = []
         language_columns = self.language_columns
         columns = self.columns
 
-        # When we have sentence pairs, we need to truncate each text field to
-        # max_seq_len // 2. However, the one case where this is not true
-        # is the case when we're pre-training MLM + TLM and the given row
-        # corresponds to monolingual data. Here the target text
-        # (text field related to columns[1]) is None and we don't need to adjust
-        # sequence length. Instead, we update columns and language_columns for
-        # this row. The following if statement handels this case.
-        if self.pretraining and len(columns) == 2:
-            if row[columns[1]] is None:
-                columns = columns[:1]
-                language_columns = ["language"]
-
         # sequence_length is adjusted based on the number of text fields and needs
         # to account for the special tokens which we will be wrapping
         for column in columns:
             sentences.extend(
-                self._numberize_and_wrap(
-                    text=row[column], seq_len=(self.max_seq_len // len(columns) - 2)
-                )
+                [
+                    self._lookup_tokens(
+                        text=row[column],
+                        seq_len=(
+                            self.max_seq_len // len(columns) - self.num_special_tokens
+                        ),
+                    )[0]
+                ]
             )
-
+        if self.wrap_special_tokens:
+            sentences = self.wrap(sentences)
         tokens = list(itertools.chain(*sentences))
         seq_lens = [len(sentence) for sentence in sentences]
-
-        # create the language tensor. if only one language column is specified,
-        # use it for all texts
-        lang_ids = [self.get_lang_id(row, column) for column in language_columns]
+        lang_ids = [self.get_lang_id(row, language_columns[0])]
         if len(lang_ids) == 1:
             lang_ids = lang_ids * len(self.columns)
 
         # expand the language ids to each token
         lang_ids = ([lang_id] * seq_len for lang_id, seq_len in zip(lang_ids, seq_lens))
-        lang_ids = list(itertools.chain(*lang_ids))
-
-        length = len(tokens)
-
-        if not self.reset_positions:
-            positions = [index for index in range(length)]
-        else:
-            positions = (range(seq_len) for seq_len in seq_lens)
-            positions = list(itertools.chain(*positions))
-        return tokens, length, lang_ids, positions
+        segment_labels = list(itertools.chain(*lang_ids))
+        seq_len = len(tokens)
+        positions = [index for index in range(seq_len)]
+        # return tokens, seq_len, segment_labels, positions
+        return tokens, segment_labels, seq_len, positions
 
     def sort_key(self, row):
         return row[1]
-
-    def tensorize(self, batch) -> Tuple[torch.Tensor, ...]:
-        tokens, seq_lens, lang_ids, positions = zip(*batch)
-        padded_tokens = pad_and_tensorize(tokens, self.vocab.get_pad_index())
-        padded_lang_ids = pad_and_tensorize(lang_ids)
-        if self.is_fairseq:
-            positions = pad_and_tensorize(positions)
-        else:
-            positions = None
-        pad_mask = (padded_tokens != self.vocab.get_pad_index()).long()
-        return (
-            padded_tokens,
-            pad_mask,
-            pad_and_tensorize(seq_lens),
-            padded_lang_ids,
-            positions,
-        )
-
-    def _build_vocab(
-        self, vocab_file: str, max_vocab: int, min_count: int
-    ) -> Vocabulary:
-        """
-        Build Vocab for XLM by calling the vocab reader associated with the model
-        source.
-        """
-        if self.is_fairseq:
-            vocab_list, counts, replacements = read_fairseq_vocab(
-                vocab_file, max_vocab, min_count
-            )
-        else:
-            vocab_list, counts, replacements = read_vocab(
-                vocab_file, max_vocab, min_count
-            )
-        return Vocabulary(vocab_list, counts, replacements=replacements)

--- a/pytext/models/qna/bert_squad_qa.py
+++ b/pytext/models/qna/bert_squad_qa.py
@@ -76,16 +76,18 @@ class BertSquadQAModel(NewBertModel):
             tokens,
             pad_mask,
             segment_labels,
+            positions,
             answer_start_indices,
             answer_end_indices,
         ) = tensor_dict["squad_input"]
-        return tokens, pad_mask, segment_labels
+        return tokens, pad_mask, segment_labels, positions
 
     def arrange_targets(self, tensor_dict):
         (
             tokens,
             pad_mask,
             segment_labels,
+            positions,
             answer_start_indices,
             answer_end_indices,
         ) = tensor_dict["squad_input"]

--- a/pytext/models/representations/huggingface_bert_sentence_encoder.py
+++ b/pytext/models/representations/huggingface_bert_sentence_encoder.py
@@ -81,7 +81,7 @@ class HuggingFaceBertSentenceEncoder(TransformerSentenceEncoderBase):
         self.bert = model
 
     def _encoder(self, input_tuple: Tuple[torch.Tensor, ...]):
-        tokens, pad_mask, segment_labels = input_tuple
+        tokens, pad_mask, segment_labels, _ = input_tuple
         return self.bert(tokens, segment_labels, pad_mask)
 
     def _embedding(self):

--- a/pytext/models/representations/transformer_sentence_encoder.py
+++ b/pytext/models/representations/transformer_sentence_encoder.py
@@ -120,17 +120,8 @@ class TransformerSentenceEncoder(TransformerSentenceEncoderBase):
     def _encoder(
         self, input_tuple: Tuple[torch.Tensor, ...]
     ) -> Tuple[torch.Tensor, ...]:
-        # If multilingual is True then the input_tuple has additional information
-        # related to the lengths of the inputs as well as a position tensor
-        if self.multilingual:
-            tokens, _, lengths, segment_labels, positions = input_tuple
-
-            # we need this for backwards compatibility with models that are
-            # pre-trained with the offset
-            if self.offset_positions_by_padding:
-                positions = None
-        else:
-            tokens, _, segment_labels = input_tuple
+        tokens, _, segment_labels, positions = input_tuple
+        if self.offset_positions_by_padding or (not self.multilingual):
             positions = None
 
         encoded_layers, pooled_output = self.sentence_encoder(

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 import torch
 from pytext.config import ConfigBase
-from pytext.data.bert_tensorizer import RoBERTaTensorizer
+from pytext.data.roberta_tensorizer import RoBERTaTensorizer
 from pytext.data.tensorizers import LabelTensorizer
 from pytext.models.bert_classification_models import NewBertModel
 from pytext.models.module import Module, create_module
@@ -30,7 +30,7 @@ class RoBERTaEncoderBase(TransformerSentenceEncoderBase):
 
     def _encoder(self, inputs):
         # NewBertModel expects the output as a tuple and grabs the first element
-        tokens, _, _ = inputs
+        tokens, _, _, _ = inputs
         full_representation = self.encoder(tokens)
         sentence_rep = full_representation[:, 0, :]
         return [full_representation], sentence_rep


### PR DESCRIPTION
Summary:
Our current Tensorizer situation is quite unmanageable and it largely stems from the fact that tensorizers doing similar things have different signatures. In this diff I take a fast stab at consolidating some of this by refactoring XLM, BERT and RoBERTa Tensorizers. I kill a bunch of dead code and simiplify a lot.
- I kill TLM - long live TLM.
- I (temporaarily) kill support for OSS XLM which probably should have its own tensorizer anyways since it has nothing to do with transformer_sentence_encoder.
- I move around a ton of the Gpt2Tokenizer stuff to make it conform to other tokenizers
- I've also tried to make the add_bos_token and add_eos_token flags more useful by actually using them.

There's a lot that might be broken and my plan is to systematically fix it. **Please dont simply review by saying "broken test please fix". I'd like more systematic feedback for the larger change.** There are tons of TODOs as well and I plan to address them in future diffs.

Differential Revision: D18195009

