### PR TITLE
Allow zero length sequence in BiLSTM

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -41,6 +41,8 @@ class WordFeatConfig(ModuleConfig):
     mlp_layer_dims: Optional[List[int]] = []
     padding_idx: Optional[int] = None
     cpu_only: bool = False
+    delimiter: str = " "
+    skip_header: bool = True
 
 
 class DictFeatConfig(ModuleConfig):

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -8,11 +8,10 @@ import torch
 from pytext.config.field_config import WordFeatConfig
 from pytext.data.tensorizers import Tensorizer
 from pytext.fields import FieldMeta
+from pytext.models.embeddings.embedding_base import EmbeddingBase
 from pytext.utils.embeddings import PretrainedEmbedding
 from torch import nn
 from torch.utils.tensorboard import SummaryWriter
-
-from .embedding_base import EmbeddingBase
 
 
 class WordEmbedding(EmbeddingBase):
@@ -71,6 +70,8 @@ class WordEmbedding(EmbeddingBase):
                 pretrained_embedding = PretrainedEmbedding(
                     config.pretrained_embeddings_path,  # doesn't support fbpkg
                     lowercase_tokens=config.lowercase_tokens,
+                    delimiter=config.delimiter,
+                    skip_header=config.skip_header,
                 )
                 embeddings_weight = pretrained_embedding.initialize_embeddings_weights(
                     tensorizer.vocab.idx,

--- a/pytext/utils/embeddings.py
+++ b/pytext/utils/embeddings.py
@@ -17,7 +17,11 @@ class PretrainedEmbedding(object):
     """
 
     def __init__(
-        self, embeddings_path: str = None, lowercase_tokens: bool = True
+        self,
+        embeddings_path: str = None,
+        lowercase_tokens: bool = True,
+        delimiter: str = " ",
+        skip_header: bool = True,
     ) -> None:
         if embeddings_path:
             if PathManager.isdir(embeddings_path):
@@ -41,11 +45,17 @@ class PretrainedEmbedding(object):
                 except Exception:
                     print("Failed to load cached embeddings, loading the raw file.")
                     self.load_pretrained_embeddings(
-                        raw_embeddings_path, lowercase_tokens=lowercase_tokens
+                        raw_embeddings_path,
+                        lowercase_tokens=lowercase_tokens,
+                        delimiter=delimiter,
+                        skip_header=skip_header,
                     )
             else:
                 self.load_pretrained_embeddings(
-                    raw_embeddings_path, lowercase_tokens=lowercase_tokens
+                    raw_embeddings_path,
+                    lowercase_tokens=lowercase_tokens,
+                    delimiter=delimiter,
+                    skip_header=skip_header,
                 )
         else:
             self.embed_vocab = []  # type: List[str]
@@ -58,6 +68,8 @@ class PretrainedEmbedding(object):
         append: bool = False,
         dialect: str = None,
         lowercase_tokens: bool = True,
+        delimiter: str = " ",
+        skip_header: bool = True,
     ) -> None:
         """
         Loading raw embeddings vectors from file in the format:
@@ -100,7 +112,10 @@ class PretrainedEmbedding(object):
                             yield dtype(item)
 
         t = time.time()
-        embed_array = np.fromiter(iter_parser(skip_header=1), dtype=np.float32)
+        skip_header = 1 if skip_header else 0
+        embed_array = np.fromiter(
+            iter_parser(skip_header=skip_header, delimiter=delimiter), dtype=np.float32
+        )
         embed_matrix = embed_array.reshape((len(chunk_vocab), -1))
         print("Rows loaded: ", embed_matrix.shape[0], "; Time: ", time.time() - t, "s.")
 


### PR DESCRIPTION
Summary: In order to use character level BiLSTM, we sometimes need to feed in zero length sequence, this change strips the zero length sequence before feeding into lstm and pad them back after.

Differential Revision: D18180278

