### PR TITLE
RoBERTa-QA JIT

### DIFF
--- a/pytext/models/output_layers/squad_output_layer.py
+++ b/pytext/models/output_layers/squad_output_layer.py
@@ -109,7 +109,7 @@ class SquadOutputLayer(OutputLayerBase):
         start_pos_preds, end_pos_preds = self.get_position_preds(
             start_pos_logits, end_pos_logits, self.max_answer_len
         )
-        has_answer_preds = has_answer_logits.argmax(-1)
+        has_answer_preds = has_answer_logits.float().argmax(-1)
         has_answer_scores = torch.zeros(has_answer_logits.size())
         if not self.ignore_impossible:
             has_answer_scores = F.softmax(has_answer_logits, 1)

--- a/pytext/torchscript/tensorizer/__init__.py
+++ b/pytext/torchscript/tensorizer/__init__.py
@@ -3,7 +3,12 @@
 
 from .bert import ScriptBERTTensorizer
 from .normalizer import VectorNormalizer
-from .roberta import ScriptRoBERTaTensorizer
+from .roberta import ScriptRoBERTaTensorizer, ScriptRoBERTaTensorizerWithIndices
 
 
-__all__ = ["ScriptBERTTensorizer", "ScriptRoBERTaTensorizer", "VectorNormalizer"]
+__all__ = [
+    "ScriptBERTTensorizer",
+    "ScriptRoBERTaTensorizer",
+    "ScriptRoBERTaTensorizerWithIndices",
+    "VectorNormalizer",
+]

--- a/pytext/torchscript/tensorizer/roberta.py
+++ b/pytext/torchscript/tensorizer/roberta.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
+from pytext.torchscript.utils import pad_2d, pad_2d_mask
 
 from .bert import ScriptBERTTensorizerBase
 
@@ -18,3 +19,83 @@ class ScriptRoBERTaTensorizer(ScriptBERTTensorizerBase):
             use_eos_token_for_bos=False,
             max_seq_len=self.max_seq_len,
         )[0]
+
+
+class ScriptRoBERTaTensorizerWithIndices(ScriptBERTTensorizerBase):
+    @torch.jit.script_method
+    def _lookup_tokens(
+        self, tokens: List[Tuple[str, int, int]]
+    ) -> Tuple[List[int], List[int], List[int]]:
+        return self.vocab_lookup(
+            tokens,
+            bos_idx=self.vocab.bos_idx,
+            eos_idx=self.vocab.eos_idx,
+            use_eos_token_for_bos=False,
+            max_seq_len=self.max_seq_len,
+        )
+
+    @torch.jit.script_method
+    def numberize(
+        self, text_row: Optional[List[str]], token_row: Optional[List[List[str]]]
+    ) -> Tuple[List[int], int, List[int], List[int], List[int]]:
+        token_ids: List[int] = []
+        seq_len: int = 0
+        start_indices: List[int] = []
+        end_indices: List[int] = []
+        positions: List[int] = []
+        per_sentence_tokens: List[List[Tuple[str, int, int]]] = self.tokenize(
+            text_row, token_row
+        )
+
+        for idx, per_sentence_token in enumerate(per_sentence_tokens):
+            lookup_ids, start_ids, end_ids = self._lookup_tokens(per_sentence_token)
+            lookup_ids = self._wrap_numberized_tokens(lookup_ids, idx)
+            token_ids.extend(lookup_ids)
+            start_indices.extend(start_ids)
+            end_indices.extend(end_ids)
+
+        seq_len = len(token_ids)
+        positions = [i for i in range(seq_len)]
+
+        return token_ids, seq_len, start_indices, end_indices, positions
+
+    @torch.jit.script_method
+    def tensorize(
+        self,
+        texts: Optional[List[List[str]]] = None,
+        tokens: Optional[List[List[List[str]]]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        tokens_2d: List[List[int]] = []
+        seq_len_2d: List[int] = []
+        start_indices_2d: List[List[int]] = []
+        end_indices_2d: List[List[int]] = []
+        positions_2d: List[List[int]] = []
+
+        for idx in range(self.batch_size(texts, tokens)):
+            numberized: Tuple[
+                List[int], int, List[int], List[int], List[int]
+            ] = self.numberize(
+                self.get_texts_by_index(texts, idx),
+                self.get_tokens_by_index(tokens, idx),
+            )
+            tokens_2d.append(numberized[0])
+            seq_len_2d.append(numberized[1])
+            start_indices_2d.append(numberized[2])
+            end_indices_2d.append(numberized[3])
+            positions_2d.append(numberized[4])
+
+        tokens, pad_mask = pad_2d_mask(tokens_2d, pad_value=self.vocab.pad_idx)
+        start_indices = torch.tensor(
+            pad_2d(start_indices_2d, seq_lens=seq_len_2d, pad_idx=self.vocab.pad_idx),
+            dtype=torch.long,
+        )
+        end_indices = torch.tensor(
+            pad_2d(end_indices_2d, seq_lens=seq_len_2d, pad_idx=self.vocab.pad_idx),
+            dtype=torch.long,
+        )
+        positions = torch.tensor(
+            pad_2d(positions_2d, seq_lens=seq_len_2d, pad_idx=self.vocab.pad_idx),
+            dtype=torch.long,
+        )
+
+        return tokens, pad_mask, start_indices, end_indices, positions


### PR DESCRIPTION
Summary:
This diff torchscriptifies RoBERTa-QA to make it exportable in the same manner as BERT-QA.
It also converts the has_answer_logits tensor to float before doing an argmax in squad_output_layer in order to use the FP16FairseqOptimizer. This otherwise breaks as argmax_cuda isn't supported for "Half" datatype.

Differential Revision: D18218091

