### PR TITLE
Id for all modules and torchscript compatibility workaround

### DIFF
--- a/pytext/models/module.py
+++ b/pytext/models/module.py
@@ -9,6 +9,7 @@ import torch.jit
 import torch.nn as nn
 from pytext.config.component import Component, ComponentType, create_component
 from pytext.config.module_config import ModuleConfig
+from pytext.config.pytext_config import ConfigBase
 
 
 SHARED_MODULE_REGISTRY: Dict[str, torch.nn.Module] = {}
@@ -85,3 +86,51 @@ class Module(nn.Module, Component):
     def freeze(self) -> None:
         for param in self.parameters():
             param.requires_grad = False
+
+    def __dir__(self):
+        """Jit doesnt allow scripting of attributes whose classname includes "."
+
+        Example Repro:
+
+        class OldModule(Module):
+            class Config(ConfigBase):
+                a: int = 5
+
+            @classmethod
+            def from_config(cls, config: Config):
+                return cls(config.a)
+
+            def __init__(self, a):
+                super().__init__()
+                self.a = a
+
+            def forward(self, b: int) -> int:
+                return b + self.a
+
+        m = OldModule.from_config(OldModule.Config())
+        jit.script(m)
+
+            > RuntimeError: Could not get qualified name for class 'OldModule.Config':
+        'OldModule.Config' is not a valid identifier
+
+        print(m.Config.__name__)
+            > OldModule.Config
+
+        At the sametime, we dont need to script the config classes because they
+        are not needed during inference time. Hence in this workaround we skip
+        the config classes.
+
+        Ideal solution is that when building models they should be inheriting
+        from nn.Module only and not Component. This requires significant changes
+        to the way models are created in PyText.
+
+        """
+        result = super().__dir__()
+        return [
+            r
+            for r in result
+            if not (
+                isinstance(getattr(self, r, None), type)
+                and issubclass(getattr(self, r, None), ConfigBase)
+            )
+        ]


### PR DESCRIPTION
Summary: We need a id for each module that was created for incremental decoding. Also this diff includes a workaround to make sure our models work with the new scripting api.

Differential Revision: D17636128

