### PR TITLE
Update CrossLingualLMData to use hive data sources and multiple base configs

### DIFF
--- a/pytext/models/masked_lm.py
+++ b/pytext/models/masked_lm.py
@@ -108,7 +108,9 @@ class MaskedLanguageModel(BaseModel):
         # initialize the frequency based sampling weights if these will be used
         self.token_sampling_weights = None
         if self.masking_strategy == MaskingStrategy.FREQUENCY:
-            self.token_sampling_weights = [x ** -0.5 for x in self.vocab.counts]
+            self.token_sampling_weights = [
+                self.vocab.counts[t] ** -0.5 for t in self.vocab._vocab
+            ]
 
             # Set probability of masking special tokens to be very low, since it doesn't
             # make sense to use them for MLM (unless there are no other tokens in the


### PR DESCRIPTION
Summary:
We want to pre-train XLM on multiple hive tables, which requires:

- correct updating of data paths from base config when it uses a hive data source

- supporting multiple base configs (e.g. one per hive table)

Also fixes a data type discrepancy in masked_lm.py

Differential Revision: D18258165

