### PR TITLE
Redo of D18096829: Output encoded layers in Bert model

### DIFF
--- a/pytext/models/bert_classification_models.py
+++ b/pytext/models/bert_classification_models.py
@@ -70,7 +70,7 @@ class NewBertModel(BaseModel):
     def forward(
         self, encoder_inputs: Tuple[torch.Tensor, ...], *args
     ) -> List[torch.Tensor]:
-        representation = self.encoder(encoder_inputs)[0]
+        representation = self.encoder(encoder_inputs)[-1]
         return self.decoder(representation, *args)
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
@@ -81,7 +81,10 @@ class NewBertModel(BaseModel):
         labels = tensorizers["labels"].vocab
         vocab = tensorizers["tokens"].vocab
         encoder = create_module(
-            config.encoder, padding_idx=vocab.get_pad_index(), vocab_size=len(vocab)
+            config.encoder,
+            padding_idx=vocab.get_pad_index(),
+            vocab_size=len(vocab),
+            output_encoded_layers=True,
         )
         dense_dim = tensorizers["dense"].dim if "dense" in tensorizers else 0
         decoder = create_module(

--- a/pytext/models/bert_regression_model.py
+++ b/pytext/models/bert_regression_model.py
@@ -31,6 +31,7 @@ class NewBertRegressionModel(NewBertModel):
             config.encoder,
             padding_idx=vocab.get_pad_index(),
             vocab_size=vocab.__len__(),
+            output_encoded_layers=True,
         )
         decoder = create_module(
             config.decoder, in_dim=encoder.representation_dim, out_dim=1


### PR DESCRIPTION
Summary:
Bert classification benefits from getting the full layer representations, because

- We can do multi-tasking of classification and MLM. (The masked LM needs output_encoded_layers = True, and since the tasks share the encoder module the classification model would need it too.

- Next diff in the stack needs encoded layers to add losses to the intermediate layers.

These layer representations are computed by the underlying transformer module anyways, so there is no increase in training time.

Differential Revision: D18263698

