### PR TITLE
skip tensorizer init in batch_predict_caffe2_model

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -10,3 +10,4 @@ pytorch-pretrained-bert
 requests
 torchtext
 tensorboard==1.14
+pandas

--- a/pytext/__init__.py
+++ b/pytext/__init__.py
@@ -57,6 +57,7 @@ def create_predictor(
     config: PyTextConfig,
     model_file: Optional[str] = None,
     db_type: str = CAFFE2_DB_TYPE,
+    task: Optional[NewTask] = None,
 ) -> Predictor:
     """
     Create a simple prediction API from a training config and an exported caffe2
@@ -69,7 +70,7 @@ def create_predictor(
         filename=model_file or config.export_caffe2_path, db_type=db_type
     )
 
-    new_task = NewTask.from_config(config.task)
+    new_task = task or NewTask.from_config(config.task)
     input_tensorizers = {
         name: tensorizer
         for name, tensorizer in new_task.data.tensorizers.items()
@@ -95,7 +96,7 @@ def batch_predict_caffe2_model(
 
     data_source = data_source or task.data.data_source
     logging.info("Loading Caffe2 model")
-    predictor = create_predictor(train_config, caffe2_model_file, db_type)
+    predictor = create_predictor(train_config, caffe2_model_file, db_type, task)
     logging.info(f"Model loaded, start testing")
     predictions = [predictor(example) for example in data_source.test]
     return predictions

--- a/pytext/data/sources/__init__.py
+++ b/pytext/data/sources/__init__.py
@@ -2,8 +2,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .data_source import DataSource, RawExample
+from .pandas import PandasDataSource
 from .squad import SquadDataSource
 from .tsv import TSVDataSource
 
 
-__all__ = ["DataSource", "RawExample", "SquadDataSource", "TSVDataSource"]
+__all__ = [
+    "DataSource",
+    "RawExample",
+    "SquadDataSource",
+    "TSVDataSource",
+    "PandasDataSource",
+]

--- a/pytext/data/sources/pandas.py
+++ b/pytext/data/sources/pandas.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Optional
+
+from pandas import DataFrame
+from pytext.data.sources.data_source import RootDataSource
+
+
+class PandasDataSource(RootDataSource):
+    """
+    DataSource which loads data from a pandas DataFrame.
+
+    Inputs:
+        train_df: DataFrame for training
+
+        eval_df: DataFrame for evalu
+
+        test_df: DataFrame for test
+
+        schema: same as base DataSource, define the list of output values with their types
+
+        column_mapping: maps the column names in DataFrame to the name defined in schema
+
+    """
+
+    def __init__(
+        self,
+        train_df: Optional[DataFrame] = None,
+        eval_df: Optional[DataFrame] = None,
+        test_df: Optional[DataFrame] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.train_df = train_df
+        self.eval_df = eval_df
+        self.test_df = test_df
+
+    @staticmethod
+    def raw_generator(df: Optional[DataFrame]):
+        if df is None:
+            yield from ()
+        else:
+            for _, row in df.iterrows():
+                yield row
+
+    def raw_train_data_generator(self):
+        return self.raw_generator(self.train_df)
+
+    def raw_eval_data_generator(self):
+        return self.raw_generator(self.eval_df)
+
+    def raw_test_data_generator(self):
+        return self.raw_generator(self.test_df)

--- a/pytext/data/test/pandas_data_source_test.py
+++ b/pytext/data/test/pandas_data_source_test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+import pandas as pd
+from pytext.data.sources import PandasDataSource
+
+
+class PandasDataSourceTest(unittest.TestCase):
+    def test_create_data_source(self):
+        ds = PandasDataSource(
+            train_df=pd.DataFrame({"c1": [10, 20, 30], "c2": [40, 50, 60]}),
+            eval_df=pd.DataFrame({"c1": [11, 21, 31], "c2": [41, 51, 61]}),
+            test_df=pd.DataFrame({"c1": [12, 22, 32], "c2": [42, 52, 62]}),
+            schema={"feature1": float, "feature2": float},
+            column_mapping={"c1": "feature1", "c2": "feature2"},
+        )
+        self.assertEqual({"feature1": 10, "feature2": 40}, next(iter(ds.train)))
+        self.assertEqual({"feature1": 11, "feature2": 41}, next(iter(ds.eval)))
+        self.assertEqual({"feature1": 12, "feature2": 42}, next(iter(ds.test)))
+        self.assertEqual(3, len(list(ds.train)))
+
+    def test_empty_data(self):
+        ds = PandasDataSource(schema={"feature1": float, "feature2": float})
+        self.assertEqual(0, len(list(ds.train)))


### PR DESCRIPTION
Summary: currently when in create_predictor function the task is created from scratch which costs lots of time to initialize tensorizers, provide a way to support passing into a task from a saved file instead.

Reviewed By: chenyangyu1988

Differential Revision: D18279759

