### PR TITLE
Add delimiter option to VocabBuilder and PretrainedEmbedding

### DIFF
--- a/pytext/config/field_config.py
+++ b/pytext/config/field_config.py
@@ -42,6 +42,7 @@ class WordFeatConfig(ModuleConfig):
     padding_idx: Optional[int] = None
     cpu_only: bool = False
     skip_header: bool = True
+    delimiter: str = " "
 
 
 class DictFeatConfig(ModuleConfig):

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -203,6 +203,7 @@ class TokenTensorizer(Tensorizer):
         use_eos_token_for_bos: bool = False
         max_seq_len: Optional[int] = None
         vocab: VocabConfig = VocabConfig()
+        vocab_file_delimiter: str = " "
 
     @classmethod
     def from_config(cls, config: Config):
@@ -215,6 +216,7 @@ class TokenTensorizer(Tensorizer):
             use_eos_token_for_bos=config.use_eos_token_for_bos,
             max_seq_len=config.max_seq_len,
             vocab_config=config.vocab,
+            vocab_file_delimiter=config.vocab_file_delimiter,
         )
 
     def __init__(
@@ -227,6 +229,7 @@ class TokenTensorizer(Tensorizer):
         max_seq_len=Config.max_seq_len,
         vocab_config=None,
         vocab=None,
+        vocab_file_delimiter=" ",
     ):
         self.text_column = text_column
         self.tokenizer = tokenizer or Tokenizer()
@@ -237,6 +240,7 @@ class TokenTensorizer(Tensorizer):
         self.max_seq_len = max_seq_len or 2 ** 30  # large number
         self.vocab_builder = None
         self.vocab_config = vocab_config or VocabConfig()
+        self.vocab_file_delimiter = vocab_file_delimiter
 
     @property
     def column_schema(self):
@@ -288,7 +292,9 @@ class TokenTensorizer(Tensorizer):
         if not self.vocab_builder:
             # else means not initialize from scratch, self.vocab_builder
             # would be set already
-            self.vocab_builder = vocab_builder or VocabBuilder()
+            self.vocab_builder = vocab_builder or VocabBuilder(
+                delimiter=self.vocab_file_delimiter
+            )
             self.vocab_builder.use_bos = self.add_bos_token
             self.vocab_builder.use_eos = self.add_eos_token
         if not self.vocab_config.build_from_data:

--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -207,7 +207,7 @@ class Vocabulary:
 class VocabBuilder:
     """Helper class for aggregating and building `Vocabulary` objects."""
 
-    def __init__(self):
+    def __init__(self, delimiter=" "):
         self._counter = Counter()
         self.use_unk = True
         self.unk_index = 0
@@ -228,6 +228,8 @@ class VocabBuilder:
         self.pad_token = PAD
         self.bos_token = BOS
         self.eos_token = EOS
+
+        self.delimiter = delimiter
 
     def add_all(self, values) -> None:
         """Count a value or nested container of values in the vocabulary."""
@@ -252,7 +254,7 @@ class VocabBuilder:
                     f"Skipping rest of the file."
                 )
                 break
-            token = line.split()[0].strip()
+            token = line.split(self.delimiter)[0].strip()
             if lowercase_tokens:
                 token = token.lower()
             vocab_from_file.add(token)

--- a/pytext/models/embeddings/word_embedding.py
+++ b/pytext/models/embeddings/word_embedding.py
@@ -71,6 +71,7 @@ class WordEmbedding(EmbeddingBase):
                     config.pretrained_embeddings_path,  # doesn't support fbpkg
                     lowercase_tokens=config.lowercase_tokens,
                     skip_header=config.skip_header,
+                    delimiter=config.delimiter,
                 )
                 embeddings_weight = pretrained_embedding.initialize_embeddings_weights(
                     tensorizer.vocab.idx,

--- a/pytext/utils/embeddings.py
+++ b/pytext/utils/embeddings.py
@@ -21,6 +21,7 @@ class PretrainedEmbedding(object):
         embeddings_path: str = None,
         lowercase_tokens: bool = True,
         skip_header: bool = True,
+        delimiter: str = " ",
     ) -> None:
         if embeddings_path:
             if PathManager.isdir(embeddings_path):
@@ -47,12 +48,14 @@ class PretrainedEmbedding(object):
                         raw_embeddings_path,
                         lowercase_tokens=lowercase_tokens,
                         skip_header=skip_header,
+                        delimiter=delimiter,
                     )
             else:
                 self.load_pretrained_embeddings(
                     raw_embeddings_path,
                     lowercase_tokens=lowercase_tokens,
                     skip_header=skip_header,
+                    delimiter=delimiter,
                 )
         else:
             self.embed_vocab = []  # type: List[str]
@@ -66,6 +69,7 @@ class PretrainedEmbedding(object):
         dialect: str = None,
         lowercase_tokens: bool = True,
         skip_header: bool = True,
+        delimiter: str = " ",
     ) -> None:
         """
         Loading raw embeddings vectors from file in the format:
@@ -78,7 +82,9 @@ class PretrainedEmbedding(object):
         """
         chunk_vocab = []
 
-        def iter_parser(skip_header: int = 0, dtype: type = np.float32):
+        def iter_parser(
+            skip_header: int = 0, delimiter: str = " ", dtype: type = np.float32
+        ):
             """ Iterator to load numpy 1-d array from multi-row text file,
             where format is assumed to be:
                 word_i v0, v1, v2, ...., v_dim
@@ -94,7 +100,7 @@ class PretrainedEmbedding(object):
                 for _ in range(skip_header):
                     next(txtfile)
                 for line in txtfile:
-                    split_line = line.rstrip("\r\n ").split()
+                    split_line = line.rstrip("\r\n ").split(delimiter)
                     token = split_line[0]
                     if lowercase_tokens:
                         # lowercase here so that returned matrix doesn't contain
@@ -108,7 +114,7 @@ class PretrainedEmbedding(object):
         t = time.time()
         skip_header = 1 if skip_header else 0
         embed_array = np.fromiter(
-            iter_parser(skip_header=skip_header), dtype=np.float32
+            iter_parser(skip_header=skip_header, delimiter=delimiter), dtype=np.float32
         )
         embed_matrix = embed_array.reshape((len(chunk_vocab), -1))
         print("Rows loaded: ", embed_matrix.shape[0], "; Time: ", time.time() - t, "s.")


### PR DESCRIPTION
Summary:
we want to handle different delimiters e.g. " " and "\t" and using .split() is troublesome as it handles too much different whitespace characters. we add these options to VocabBuilder and PretrainedEmbedding. Default option is " ". It's up to the users to make sure vocab and pretrained embeddings are handled consistently.

more details: https://fb.workplace.com/groups/1941258842562334/permalink/2715522195135991/

this diff should have fixed this D18034127

Differential Revision: D18302890

