### PR TITLE
add label smoothing to the doc/word loss and add entropy-based option

### DIFF
--- a/pytext/models/output_layers/doc_classification_output_layer.py
+++ b/pytext/models/output_layers/doc_classification_output_layer.py
@@ -14,6 +14,7 @@ from pytext.loss import (
     CrossEntropyLoss,
     KLDivergenceBCELoss,
     KLDivergenceCELoss,
+    LabelSmoothedCrossEntropyLoss,
     MultiLabelSoftMarginLoss,
 )
 from pytext.utils.label import get_label_weights
@@ -45,6 +46,7 @@ class ClassificationOutputLayer(OutputLayerBase):
             AUCPRHingeLoss.Config,
             KLDivergenceBCELoss.Config,
             KLDivergenceCELoss.Config,
+            LabelSmoothedCrossEntropyLoss.Config,
         ] = CrossEntropyLoss.Config()
         label_weights: Optional[Dict[str, float]] = None
 

--- a/pytext/models/output_layers/word_tagging_output_layer.py
+++ b/pytext/models/output_layers/word_tagging_output_layer.py
@@ -17,6 +17,7 @@ from pytext.loss import (
     CrossEntropyLoss,
     KLDivergenceBCELoss,
     KLDivergenceCELoss,
+    LabelSmoothedCrossEntropyLoss,
 )
 from pytext.models.crf import CRF
 from pytext.utils.label import get_label_weights
@@ -44,6 +45,7 @@ class WordTaggingOutputLayer(OutputLayerBase):
             AUCPRHingeLoss.Config,
             KLDivergenceBCELoss.Config,
             KLDivergenceCELoss.Config,
+            LabelSmoothedCrossEntropyLoss.Config,
         ] = CrossEntropyLoss.Config()
         label_weights: Dict[str, float] = {}
         ignore_pad_in_loss: Optional[bool] = True


### PR DESCRIPTION
Summary: In the entropy option, instead of the KL divergence with a uniform distribution, entropy of the distribution is the added loss.

Reviewed By: arbabu123

Differential Revision: D18345100

