### PR TITLE
Standardize RoBERTa Tensorizer Vocab Creation

### DIFF
--- a/pytext/data/squad_for_bert_tensorizer.py
+++ b/pytext/data/squad_for_bert_tensorizer.py
@@ -5,8 +5,12 @@ import itertools
 from typing import List
 
 from pytext.config.component import ComponentType, create_component
-from pytext.data.bert_tensorizer import BERTTensorizer, RoBERTaTensorizer
-from pytext.data.utils import pad_and_tensorize
+from pytext.data.bert_tensorizer import (
+    BERTTensorizer,
+    RoBERTaTensorizer,
+    build_fairseq_vocab,
+)
+from pytext.data.utils import BOS, EOS, PAD, UNK, pad_and_tensorize
 
 
 class SquadForBERTTensorizer(BERTTensorizer):
@@ -101,7 +105,15 @@ class SquadForRoBERTaTensorizer(SquadForBERTTensorizer, RoBERTaTensorizer):
     @classmethod
     def from_config(cls, config: Config):
         tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
-        vocab = tokenizer.vocab
+        vocab = build_fairseq_vocab(
+            vocab_file=config.vocab_file,
+            special_token_replacements={
+                config.pad_token: PAD,
+                config.bos_token: BOS,
+                config.eos_token: EOS,
+                config.unk_token: UNK,
+            },
+        )
         return cls(
             columns=config.columns,
             tokenizer=tokenizer,

--- a/pytext/data/test/tokenizers_test.py
+++ b/pytext/data/test/tokenizers_test.py
@@ -56,7 +56,6 @@ class GPT2BPETest(unittest.TestCase):
         expected = [Token("19703", 0, 4), Token("8690", 4, 9)]
         tokenizer = GPT2BPETokenizer.from_config(
             GPT2BPETokenizer.Config(
-                token_dictionary_path="pytext/data/test/data/gpt2_dict.txt",
                 bpe_vocab_path="pytext/data/test/data/gpt2_vocab.bpe",
                 bpe_encoder_path="pytext/data/test/data/gpt2_encoder.json",
             )

--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -183,9 +183,6 @@ class GPT2BPETokenizer(Tokenizer):
     """Tokenizer for gpt-2 and RoBERTa."""
 
     class Config(ConfigBase):
-        token_dictionary_path: str = (
-            "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/dict.txt"
-        )
         bpe_encoder_path: str = (
             "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/encoder.json"
         )
@@ -195,24 +192,15 @@ class GPT2BPETokenizer(Tokenizer):
 
     @classmethod
     def from_config(cls, config: Config):
-        dictionary = Dictionary.load(config.token_dictionary_path)
         bpe = create_gpt2_bpe(config.bpe_encoder_path, config.bpe_vocab_path)
         # This hacks the bpe instance to be picklable
         bpe = copy.copy(bpe)
         bpe.__class__ = PickleableGPT2BPEEncoder
 
-        return cls(bpe, dictionary)
+        return cls(bpe)
 
-    def __init__(self, bpe, dictionary: Dictionary):
+    def __init__(self, bpe: GPT2BPEEncoder):
         self.bpe = bpe
-        self.vocab = Vocabulary(
-            dictionary.symbols,
-            pad_token=str(dictionary[dictionary.pad()]),
-            bos_token=str(dictionary[dictionary.bos()]),
-            eos_token=str(dictionary[dictionary.eos()]),
-        )
-        self.bos = self.vocab.bos_token
-        self.eos = self.vocab.eos_token
 
     def tokenize(self, input_str: str) -> List[Token]:
         bpe_ids = self.bpe.encode(input_str)

--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -97,7 +97,7 @@ class Vocabulary:
     def __init__(
         self,
         vocab_list: List[str],
-        counts: Optional[typing.Counter[str]] = None,
+        counts: List = None,
         replacements: Optional[Dict[str, str]] = None,
         unk_token: str = UNK,
         pad_token: str = PAD,
@@ -126,9 +126,6 @@ class Vocabulary:
             idx = self.idx.pop(token)
             self._vocab[idx] = replacement
             self.idx[replacement] = idx
-            if self.counts and self.counts[token]:
-                count = self.counts.pop(token)
-                self.counts[replacement] += count
 
     def lookup_all(self, nested_values):
         res, unk_counter, total = self.lookup_all_internal(nested_values)


### PR DESCRIPTION
Summary: As part of the Tensorizer refactor, I standarize vocab creation for the RoBERTa tesorizer i.e. remove vocab creation from the tokenizer and bring it into the tensorizer. I also make the special tokens for RoBERTa confiurable so that we don't need a separate tensorizer if we decide to train RoBERTa with different special tokens. I also revert some of the changes made in D17974656 which break loading of fairseq vocab for all tensorizers.

Reviewed By: chenyangyu1988

Differential Revision: D18289234

