### PR TITLE
Move RoBERTaTensorizer to its own file

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -7,8 +7,8 @@ from typing import Dict, List
 from fairseq.data.dictionary import Dictionary
 from fairseq.data.legacy.masked_lm_dictionary import BertDictionary
 from pytext.config.component import ComponentType, create_component
-from pytext.data.tensorizers import Tensorizer, TokenTensorizer, lookup_tokens
-from pytext.data.tokenizers import GPT2BPETokenizer, Tokenizer, WordPieceTokenizer
+from pytext.data.tensorizers import TokenTensorizer, lookup_tokens
+from pytext.data.tokenizers import Tokenizer, WordPieceTokenizer
 from pytext.data.utils import (
     BOS,
     EOS,
@@ -19,11 +19,6 @@ from pytext.data.utils import (
     Vocabulary,
     pad_and_tensorize,
 )
-from pytext.torchscript.tensorizer import (
-    ScriptRoBERTaTensorizer,
-    ScriptRoBERTaTokenTensorizer,
-)
-from pytext.torchscript.vocab import ScriptVocabulary
 
 
 def build_fairseq_vocab(
@@ -152,80 +147,3 @@ class BERTTensorizer(TokenTensorizer):
         pad_mask = (tokens != self.vocab.get_pad_index()).long()
         segment_labels = pad_and_tensorize(segment_labels, self.vocab.get_pad_index())
         return tokens, pad_mask, segment_labels
-
-
-class RoBERTaTensorizer(BERTTensorizer):
-    class Config(Tensorizer.Config):
-        columns: List[str] = ["text"]
-        vocab_file: str = (
-            "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/dict.txt"
-        )
-        tokenizer: GPT2BPETokenizer.Config = GPT2BPETokenizer.Config()
-        # Make special tokens configurable so we don't need a new
-        # tensorizer if the model is trained with different special token
-        bos_token: str = "<s>"
-        eos_token: str = "</s>"
-        pad_token: str = "<pad>"
-        unk_token: str = "<unk>"
-        max_seq_len: int = 256
-
-    @classmethod
-    def from_config(cls, config: Config, **kwargs):
-        tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
-        vocab = build_fairseq_vocab(
-            vocab_file=config.vocab_file,
-            special_token_replacements={
-                config.pad_token: PAD,
-                config.bos_token: BOS,
-                config.eos_token: EOS,
-                config.unk_token: UNK,
-            },
-        )
-        return cls(
-            columns=config.columns,
-            tokenizer=tokenizer,
-            max_seq_len=config.max_seq_len,
-            vocab=vocab,
-        )
-
-    def __init__(self, columns, tokenizer=None, vocab=None, max_seq_len=256):
-        super().__init__(
-            columns=columns,
-            tokenizer=tokenizer,
-            add_bos_token=False,
-            add_eos_token=True,
-            max_seq_len=max_seq_len,
-            vocab=vocab,
-        )
-
-    def _lookup_tokens(self, text):
-        return lookup_tokens(
-            text,
-            tokenizer=self.tokenizer,
-            vocab=self.vocab,
-            bos_token=self.vocab.bos_token,
-            eos_token=self.vocab.eos_token,
-            max_seq_len=self.max_seq_len,
-        )
-
-    def torchscriptify(self):
-        input_type = self.tokenizer.torchscriptify_input_type()
-        if input_type.is_text():
-            script_tensorizer_class = ScriptRoBERTaTensorizer
-        elif input_type.is_token():
-            script_tensorizer_class = ScriptRoBERTaTokenTensorizer
-        else:
-            raise RuntimeError(f"Unsupported {input_type}...")
-
-        return script_tensorizer_class(
-            tokenizer=self.tokenizer.torchscriptify(),
-            vocab=ScriptVocabulary(
-                list(self.vocab),
-                pad_idx=self.vocab.get_pad_index(),
-                bos_idx=self.vocab.get_bos_index(),
-                eos_idx=self.vocab.get_eos_index(),
-            ),
-            max_seq_len=self.max_seq_len,
-            add_bos_token=True,
-            use_eos_token_for_bos=False,
-        )

--- a/pytext/data/roberta_tensorizer.py
+++ b/pytext/data/roberta_tensorizer.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import List
+
+from pytext.config.component import ComponentType, create_component
+from pytext.data.bert_tensorizer import BERTTensorizer, build_fairseq_vocab
+from pytext.data.tensorizers import Tensorizer, lookup_tokens
+from pytext.data.tokenizers import GPT2BPETokenizer, Tokenizer
+from pytext.data.utils import BOS, EOS, PAD, UNK, Vocabulary
+from pytext.torchscript.tensorizer import (
+    ScriptRoBERTaTensorizer,
+    ScriptRoBERTaTokenTensorizer,
+)
+from pytext.torchscript.vocab import ScriptVocabulary
+
+
+class RoBERTaTensorizer(BERTTensorizer):
+    class Config(Tensorizer.Config):
+        columns: List[str] = ["text"]
+        vocab_file: str = (
+            "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/dict.txt"
+        )
+        tokenizer: GPT2BPETokenizer.Config = GPT2BPETokenizer.Config()
+        # Make special tokens configurable so we don't need a new
+        # tensorizer if the model is trained with different special token
+        bos_token: str = "<s>"
+        eos_token: str = "</s>"
+        pad_token: str = "<pad>"
+        unk_token: str = "<unk>"
+        max_seq_len: int = 256
+
+    @classmethod
+    def from_config(cls, config: Config, **kwargs):
+        tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
+        vocab = build_fairseq_vocab(
+            vocab_file=config.vocab_file,
+            special_token_replacements={
+                config.pad_token: PAD,
+                config.bos_token: BOS,
+                config.eos_token: EOS,
+                config.unk_token: UNK,
+            },
+        )
+        return cls(
+            columns=config.columns,
+            tokenizer=tokenizer,
+            max_seq_len=config.max_seq_len,
+            vocab=vocab,
+        )
+
+    def __init__(
+        self,
+        columns: List[str],
+        tokenizer: Tokenizer = None,
+        vocab: Vocabulary = None,
+        max_seq_len=256,
+    ) -> None:
+        super().__init__(
+            columns=columns,
+            tokenizer=tokenizer,
+            add_bos_token=False,
+            add_eos_token=True,
+            max_seq_len=max_seq_len,
+            vocab=vocab,
+        )
+
+    def _lookup_tokens(self, text: str):
+        return lookup_tokens(
+            text,
+            tokenizer=self.tokenizer,
+            vocab=self.vocab,
+            bos_token=self.vocab.bos_token,
+            eos_token=self.vocab.eos_token,
+            max_seq_len=self.max_seq_len,
+        )
+
+    def torchscriptify(self):
+        input_type = self.tokenizer.torchscriptify_input_type()
+        if input_type.is_text():
+            script_tensorizer_class = ScriptRoBERTaTensorizer
+        elif input_type.is_token():
+            script_tensorizer_class = ScriptRoBERTaTokenTensorizer
+        else:
+            raise RuntimeError(f"Unsupported {input_type}...")
+
+        return script_tensorizer_class(
+            tokenizer=self.tokenizer.torchscriptify(),
+            vocab=ScriptVocabulary(
+                list(self.vocab),
+                pad_idx=self.vocab.get_pad_index(),
+                bos_idx=self.vocab.get_bos_index(),
+                eos_idx=self.vocab.get_eos_index(),
+            ),
+            max_seq_len=self.max_seq_len,
+            add_bos_token=True,
+            use_eos_token_for_bos=False,
+        )

--- a/pytext/data/squad_for_bert_tensorizer.py
+++ b/pytext/data/squad_for_bert_tensorizer.py
@@ -5,8 +5,12 @@ import itertools
 from typing import List
 
 from pytext.config.component import ComponentType, create_component
-from pytext.data.bert_tensorizer import BERTTensorizer, RoBERTaTensorizer
-from pytext.data.utils import pad_and_tensorize
+from pytext.data.bert_tensorizer import (
+    BERTTensorizer,
+    RoBERTaTensorizer,
+    build_fairseq_vocab,
+)
+from pytext.data.utils import BOS, EOS, PAD, UNK, pad_and_tensorize
 
 
 class SquadForBERTTensorizer(BERTTensorizer):
@@ -101,7 +105,15 @@ class SquadForRoBERTaTensorizer(SquadForBERTTensorizer, RoBERTaTensorizer):
     @classmethod
     def from_config(cls, config: Config):
         tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
-        vocab = tokenizer.vocab
+        vocab = build_fairseq_vocab(
+            vocab_file=config.vocab_file,
+            special_token_replacements={
+                config.pad_token: PAD,
+                config.bos_token: BOS,
+                config.eos_token: EOS,
+                config.unk_token: UNK,
+            },
+        )
         return cls(
             columns=config.columns,
             tokenizer=tokenizer,

--- a/pytext/data/squad_for_bert_tensorizer.py
+++ b/pytext/data/squad_for_bert_tensorizer.py
@@ -5,11 +5,8 @@ import itertools
 from typing import List
 
 from pytext.config.component import ComponentType, create_component
-from pytext.data.bert_tensorizer import (
-    BERTTensorizer,
-    RoBERTaTensorizer,
-    build_fairseq_vocab,
-)
+from pytext.data.bert_tensorizer import BERTTensorizer, build_fairseq_vocab
+from pytext.data.roberta_tensorizer import RoBERTaTensorizer
 from pytext.data.utils import BOS, EOS, PAD, UNK, pad_and_tensorize
 
 

--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -183,9 +183,6 @@ class GPT2BPETokenizer(Tokenizer):
     """Tokenizer for gpt-2 and RoBERTa."""
 
     class Config(ConfigBase):
-        token_dictionary_path: str = (
-            "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/dict.txt"
-        )
         bpe_encoder_path: str = (
             "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/encoder.json"
         )
@@ -195,24 +192,15 @@ class GPT2BPETokenizer(Tokenizer):
 
     @classmethod
     def from_config(cls, config: Config):
-        dictionary = Dictionary.load(config.token_dictionary_path)
         bpe = create_gpt2_bpe(config.bpe_encoder_path, config.bpe_vocab_path)
         # This hacks the bpe instance to be picklable
         bpe = copy.copy(bpe)
         bpe.__class__ = PickleableGPT2BPEEncoder
 
-        return cls(bpe, dictionary)
+        return cls(bpe)
 
-    def __init__(self, bpe, dictionary: Dictionary):
+    def __init__(self, bpe: GPT2BPEEncoder):
         self.bpe = bpe
-        self.vocab = Vocabulary(
-            dictionary.symbols,
-            pad_token=str(dictionary[dictionary.pad()]),
-            bos_token=str(dictionary[dictionary.bos()]),
-            eos_token=str(dictionary[dictionary.eos()]),
-        )
-        self.bos = self.vocab.bos_token
-        self.eos = self.vocab.eos_token
 
     def tokenize(self, input_str: str) -> List[Token]:
         bpe_ids = self.bpe.encode(input_str)

--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -97,7 +97,7 @@ class Vocabulary:
     def __init__(
         self,
         vocab_list: List[str],
-        counts: Optional[typing.Counter[str]] = None,
+        counts: List = None,
         replacements: Optional[Dict[str, str]] = None,
         unk_token: str = UNK,
         pad_token: str = PAD,
@@ -126,9 +126,6 @@ class Vocabulary:
             idx = self.idx.pop(token)
             self._vocab[idx] = replacement
             self.idx[replacement] = idx
-            if self.counts and self.counts[token]:
-                count = self.counts.pop(token)
-                self.counts[replacement] += count
 
     def lookup_all(self, nested_values):
         res, unk_counter, total = self.lookup_all_internal(nested_values)

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 import torch
 from pytext.config import ConfigBase
-from pytext.data.bert_tensorizer import RoBERTaTensorizer
+from pytext.data.roberta_tensorizer import RoBERTaTensorizer
 from pytext.data.tensorizers import LabelTensorizer
 from pytext.models.bert_classification_models import NewBertModel
 from pytext.models.module import Module, create_module
@@ -59,7 +59,9 @@ class RoBERTaEncoder(RoBERTaEncoderBase):
     class Config(RoBERTaEncoderBase.Config):
         num_encoder_layers: int = 12
         num_attention_heads: int = 12
-        model_path: str = "manifold://pytext_training/tree/static/models/roberta_base_torch.pt"
+        model_path: str = (
+            "manifold://pytext_training/tree/static/models/roberta_base_torch.pt"
+        )
 
     def __init__(self, config: Config, output_encoded_layers: bool, **kwarg) -> None:
         super().__init__(config, output_encoded_layers=output_encoded_layers)


### PR DESCRIPTION
Summary: Remove RoBERTaTensorizer from bert_tensorizer and add type annotations to the different functions.

Reviewed By: rutyrinott

Differential Revision: D18289271

