### PR TITLE
refactor ScriptTensorizer with general tensorize API

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -20,6 +20,8 @@ from pytext.data.utils import (
     Vocabulary,
     pad_and_tensorize,
 )
+from pytext.torchscript.tensorizer import ScriptBERTTensorizer
+from pytext.torchscript.vocab import ScriptVocabulary
 
 
 def build_fairseq_vocab(
@@ -231,3 +233,15 @@ class BERTTensorizer(BERTTensorizerBase):
     ) -> List[List[str]]:
         numberized_sentences[0] = [self.vocab.get_bos_index()] + numberized_sentences[0]
         return numberized_sentences
+
+    def torchscriptify(self):
+        return ScriptBERTTensorizer(
+            tokenizer=self.tokenizer.torchscriptify(),
+            vocab=ScriptVocabulary(
+                list(self.vocab),
+                pad_idx=self.vocab.get_pad_index(),
+                bos_idx=self.vocab.get_bos_index(),
+                eos_idx=self.vocab.get_eos_index(),
+            ),
+            max_seq_len=self.max_seq_len,
+        )

--- a/pytext/data/roberta_tensorizer.py
+++ b/pytext/data/roberta_tensorizer.py
@@ -7,10 +7,7 @@ from pytext.config.component import ComponentType, create_component
 from pytext.data.bert_tensorizer import BERTTensorizerBase, build_fairseq_vocab
 from pytext.data.tokenizers import GPT2BPETokenizer, Tokenizer
 from pytext.data.utils import BOS, EOS, PAD, UNK, Vocabulary
-from pytext.torchscript.tensorizer import (
-    ScriptRoBERTaTensorizer,
-    ScriptRoBERTaTokenTensorizer,
-)
+from pytext.torchscript.tensorizer import ScriptRoBERTaTensorizer
 from pytext.torchscript.vocab import ScriptVocabulary
 
 
@@ -53,15 +50,7 @@ class RoBERTaTensorizer(BERTTensorizerBase):
         )
 
     def torchscriptify(self):
-        input_type = self.tokenizer.torchscriptify_input_type()
-        if input_type.is_text():
-            script_tensorizer_class = ScriptRoBERTaTensorizer
-        elif input_type.is_token():
-            script_tensorizer_class = ScriptRoBERTaTokenTensorizer
-        else:
-            raise RuntimeError(f"Unsupported {input_type}...")
-
-        return script_tensorizer_class(
+        return ScriptRoBERTaTensorizer(
             tokenizer=self.tokenizer.torchscriptify(),
             vocab=ScriptVocabulary(
                 list(self.vocab),
@@ -70,6 +59,4 @@ class RoBERTaTensorizer(BERTTensorizerBase):
                 eos_idx=self.vocab.get_eos_index(),
             ),
             max_seq_len=self.max_seq_len,
-            add_bos_token=True,
-            use_eos_token_for_bos=False,
         )

--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -4,12 +4,11 @@ import copy
 import re
 from typing import List, NamedTuple
 
-from fairseq.data.dictionary import Dictionary
 from fairseq.data.encoders.gpt2_bpe import get_encoder as create_gpt2_bpe
 from fairseq.data.encoders.gpt2_bpe_utils import Encoder as GPT2BPEEncoder
 from pytext.config import ConfigBase
 from pytext.config.component import Component, ComponentType, create_component
-from pytext.data.utils import ScriptTokenizerInputType, Vocabulary
+from pytext.data.utils import Vocabulary
 from pytorch_pretrained_bert.tokenization import (
     BasicTokenizer,
     WordpieceTokenizer,
@@ -59,9 +58,6 @@ class Tokenizer(Component):
         return [token for token in tokens if token.value]
 
     def torchscriptify(self):
-        raise NotImplementedError
-
-    def torchscriptify_input_type(self) -> ScriptTokenizerInputType:
         raise NotImplementedError
 
 
@@ -213,6 +209,3 @@ class GPT2BPETokenizer(Tokenizer):
             end = start + length
             tokens.append(Token(str(id), start, end))
         return [token for token in tokens if token.value]
-
-    def torchscriptify_input_type(self) -> ScriptTokenizerInputType:
-        return ScriptTokenizerInputType.text

--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -2,9 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import itertools
-import typing
 from collections import Counter
-from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
 import torch
@@ -328,14 +326,3 @@ def align_target_label(
         aligned_targets[label_vocab[label]] = target
     assert all(t is not None for t in aligned_targets)
     return aligned_targets
-
-
-class ScriptTokenizerInputType(Enum):
-    text = 1
-    token = 2
-
-    def is_text(self):
-        return self is ScriptTokenizerInputType.text
-
-    def is_token(self):
-        return self is ScriptTokenizerInputType.token

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -118,10 +118,9 @@ class ScriptRoBERTa(torch.jit.ScriptModule):
 
     @torch.jit.script_method
     def forward(self, texts: List[str]):
-        rows: List[List[str]] = [[text] for text in texts]
         input_tensors: Tuple[
-            torch.Tensor, torch.Tensor, torch.Tensor
-        ] = self.tensorizer.tensorize(rows)
+            torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+        ] = self.tensorizer.tensorize_1d(texts=texts)
         logits = self.model(input_tensors)
         return self.output_layer(logits)
 

--- a/pytext/torchscript/tensorizer/__init__.py
+++ b/pytext/torchscript/tensorizer/__init__.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from .bert import ScriptBERTTensorizer, ScriptBERTTokenTensorizer
+from .bert import ScriptBERTTensorizer
 from .normalizer import VectorNormalizer
-from .roberta import ScriptRoBERTaTensorizer, ScriptRoBERTaTokenTensorizer
+from .roberta import ScriptRoBERTaTensorizer
 
 
-__all__ = [
-    "ScriptBERTTensorizer",
-    "ScriptBERTTokenTensorizer",
-    "ScriptRoBERTaTensorizer",
-    "ScriptRoBERTaTokenTensorizer",
-    "VectorNormalizer",
-]
+__all__ = ["ScriptBERTTensorizer", "ScriptRoBERTaTensorizer", "VectorNormalizer"]

--- a/pytext/torchscript/tensorizer/bert.py
+++ b/pytext/torchscript/tensorizer/bert.py
@@ -4,7 +4,7 @@
 from typing import List, Optional, Tuple
 
 import torch
-from pytext.torchscript.utils import pad_2d_mask
+from pytext.torchscript.utils import pad_2d, pad_2d_mask
 from pytext.torchscript.vocab import ScriptVocabulary
 
 from .tensorizer import ScriptTensorizer, VocabLookup
@@ -16,119 +16,109 @@ class ScriptBERTTensorizerBase(ScriptTensorizer):
         tokenizer: torch.jit.ScriptModule,
         vocab: ScriptVocabulary,
         max_seq_len: int,
-        add_bos_token: bool,
-        use_eos_token_for_bos: bool,
     ):
         super().__init__()
         self.tokenizer = tokenizer
         self.vocab = vocab
         self.vocab_lookup = VocabLookup(vocab)
         self.max_seq_len = torch.jit.Attribute(max_seq_len, int)
-        self.add_bos_token = torch.jit.Attribute(add_bos_token, bool)
-        self.use_eos_token_for_bos = torch.jit.Attribute(use_eos_token_for_bos, bool)
 
     @torch.jit.script_method
-    def numberize(self, row: List[str]) -> Tuple[List[int], List[int], int]:
-        """Convert raw inputs into token ids by doing vocab look-up. It will also
-        append bos & eos index into token ids if needed.
+    def tokenize(
+        self, text_row: Optional[List[str]], token_row: Optional[List[List[str]]]
+    ) -> List[List[Tuple[str, int, int]]]:
+        per_sentence_tokens: List[List[Tuple[str, int, int]]] = []
 
-        Args:
-            row: 1) a list of raw inputs, in most case it is a
-                single text or a pair of texts.
-                 2) a list of preprocced tokens, we could still
-                apply other operations (for example: bpe) on it.
+        if text_row is not None:
+            for text in text_row:
+                per_sentence_tokens.append(self.tokenizer.tokenize(text))
+        elif token_row is not None:
+            for sentence_raw_tokens in token_row:
+                sentence_tokens: List[Tuple[str, int, int]] = []
+                for raw_token in sentence_raw_tokens:
+                    sentence_tokens.extend(self.tokenizer.tokenize(raw_token))
+                per_sentence_tokens.append(sentence_tokens)
 
-        Returns:
-            a list of token ids after doing vocab lookup and segment labels.
-        """
+        return per_sentence_tokens
+
+    @torch.jit.script_method
+    def _lookup_tokens(self, tokens: List[Tuple[str, int, int]]) -> List[int]:
+        raise NotImplementedError
+
+    @torch.jit.script_method
+    def _wrap_numberized_tokens(self, token_ids: List[int], idx: int) -> List[int]:
+        return token_ids
+
+    @torch.jit.script_method
+    def numberize(
+        self, text_row: Optional[List[str]], token_row: Optional[List[List[str]]]
+    ) -> Tuple[List[int], List[int], int, List[int]]:
         token_ids: List[int] = []
         segment_labels: List[int] = []
         seq_len: int = 0
-        per_sentence_tokens: List[List[Tuple[str, int, int]]] = self.tokenize(row)
+        positions: List[int] = []
+        per_sentence_tokens: List[List[Tuple[str, int, int]]] = self.tokenize(
+            text_row, token_row
+        )
 
-        for idx, tokens in enumerate(per_sentence_tokens):
-            if idx == 0 and self.add_bos_token:
-                bos_idx: Optional[int] = self.vocab.bos_idx
-            else:
-                bos_idx: Optional[int] = None
+        for idx, per_sentence_token in enumerate(per_sentence_tokens):
+            lookup_ids: List[int] = self._lookup_tokens(per_sentence_token)
+            lookup_ids = self._wrap_numberized_tokens(lookup_ids, idx)
 
-            lookup_ids: List[int] = self.vocab_lookup(
-                tokens,
-                bos_idx=bos_idx,
-                eos_idx=self.vocab.eos_idx,
-                use_eos_token_for_bos=self.use_eos_token_for_bos,
-                max_seq_len=self.max_seq_len,
-            )[0]
             token_ids.extend(lookup_ids)
             segment_labels.extend([idx] * len(lookup_ids))
         seq_len = len(token_ids)
+        positions = [i for i in range(seq_len)]
 
-        return token_ids, segment_labels, seq_len
+        return token_ids, segment_labels, seq_len, positions
 
     @torch.jit.script_method
     def tensorize(
-        self, rows: List[List[str]]
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Convert multiple rows of raw inputs into model input tensors.
-
-        Args:
-            row: 1) each row is a list of raw inputs, in most case it is a
-                single text or a pair of texts.
-                 2) each row is a list of preprocced tokens, we could still
-                apply other operations (for example: bpe) on it.
-
-        Returns:
-            model input tensors.
-        """
-
+        self,
+        texts: Optional[List[List[str]]] = None,
+        tokens: Optional[List[List[List[str]]]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         tokens_2d: List[List[int]] = []
         segment_labels_2d: List[List[int]] = []
         seq_len_2d: List[int] = []
+        positions_2d: List[List[int]] = []
 
-        for row in rows:
-            numberized: Tuple[List[int], List[int], int] = self.numberize(row)
+        for idx in range(self.batch_size(texts, tokens)):
+            numberized: Tuple[List[int], List[int], int, List[int]] = self.numberize(
+                self.get_texts_by_index(texts, idx),
+                self.get_tokens_by_index(tokens, idx),
+            )
             tokens_2d.append(numberized[0])
             segment_labels_2d.append(numberized[1])
             seq_len_2d.append(numberized[2])
+            positions_2d.append(numberized[3])
 
         tokens, pad_mask = pad_2d_mask(tokens_2d, pad_value=self.vocab.pad_idx)
-        segment_labels, _ = pad_2d_mask(segment_labels_2d, pad_value=self.vocab.pad_idx)
-        return tokens, pad_mask, segment_labels
+        segment_labels = torch.tensor(
+            pad_2d(segment_labels_2d, seq_lens=seq_len_2d, pad_idx=self.vocab.pad_idx),
+            dtype=torch.long,
+        )
+        positions = torch.tensor(
+            pad_2d(positions_2d, seq_lens=seq_len_2d, pad_idx=self.vocab.pad_idx),
+            dtype=torch.long,
+        )
+
+        return tokens, pad_mask, segment_labels, positions
 
 
 class ScriptBERTTensorizer(ScriptBERTTensorizerBase):
     @torch.jit.script_method
-    def tokenize(self, row: List[str]) -> List[List[Tuple[str, int, int]]]:
-        """Convert raw inputs into tokens.
+    def _lookup_tokens(self, tokens: List[Tuple[str, int, int]]) -> List[int]:
+        return self.vocab_lookup(
+            tokens,
+            bos_idx=None,
+            eos_idx=self.vocab.eos_idx,
+            use_eos_token_for_bos=False,
+            max_seq_len=self.max_seq_len,
+        )[0]
 
-        Args:
-            row: a list of raw inputs, in most case it is a
-                single text or a pair of texts.
-
-        Returns:
-            a per sentence list of tokens which include token index.
-        """
-
-        per_sentence_tokens: List[List[Tuple[str, int, int]]] = []
-        for text in row:
-            per_sentence_tokens.append(self.tokenizer.tokenize(text))
-        return per_sentence_tokens
-
-
-class ScriptBERTTokenTensorizer(ScriptBERTTensorizerBase):
     @torch.jit.script_method
-    def tokenize(self, row: List[str]) -> List[List[Tuple[str, int, int]]]:
-        """Convert raw inputs into tokens.
-
-        Args:
-            row: a list of preprocced tokens, we could still
-                apply other operations (for example: bpe) on it.
-
-        Returns:
-            a per sentence list of tokens which include token index.
-        """
-
-        per_sentence_tokens: List[Tuple[str, int, int]] = []
-        for raw_token in row:
-            per_sentence_tokens.extend(self.tokenizer.tokenize(raw_token))
-        return [per_sentence_tokens]
+    def _wrap_numberized_tokens(self, token_ids: List[int], idx: int) -> List[int]:
+        if idx == 0:
+            token_ids = [self.vocab.bos_idx] + token_ids
+        return token_ids

--- a/pytext/torchscript/tensorizer/roberta.py
+++ b/pytext/torchscript/tensorizer/roberta.py
@@ -8,73 +8,13 @@ import torch
 from .bert import ScriptBERTTensorizerBase
 
 
-class ScriptRoBERTaTensorizerBase(ScriptBERTTensorizerBase):
+class ScriptRoBERTaTensorizer(ScriptBERTTensorizerBase):
     @torch.jit.script_method
-    def numberize(self, row: List[str]) -> Tuple[List[int], List[int], int]:
-        """Convert raw inputs into token ids by doing vocab look-up. It will also
-        append bos & eos index into token ids if needed.
-
-        Args:
-            row: 1) a list of raw inputs, in most case it is a
-                single text or a pair of texts.
-                 2) a list of preprocced tokens, we could still
-                apply other operations (for example: bpe) on it.
-
-        Returns:
-            a list of token ids after doing vocab lookup and segment labels.
-        """
-        token_ids: List[int] = []
-        segment_labels: List[int] = []
-        seq_len: int = 0
-        per_sentence_tokens: List[List[Tuple[str, int, int]]] = self.tokenize(row)
-
-        for idx, tokens in enumerate(per_sentence_tokens):
-            lookup_ids: List[int] = self.vocab_lookup(
-                tokens,
-                bos_idx=self.vocab.bos_idx,
-                eos_idx=self.vocab.eos_idx,
-                max_seq_len=self.max_seq_len,
-            )[0]
-            token_ids.extend(lookup_ids)
-            segment_labels.extend([idx] * len(lookup_ids))
-        seq_len = len(token_ids)
-
-        return token_ids, segment_labels, seq_len
-
-
-class ScriptRoBERTaTensorizer(ScriptRoBERTaTensorizerBase):
-    @torch.jit.script_method
-    def tokenize(self, row: List[str]) -> List[List[Tuple[str, int, int]]]:
-        """Convert raw inputs into tokens.
-
-        Args:
-            row: a list of raw inputs, in most case it is a
-                single text or a pair of texts.
-
-        Returns:
-            a per sentence list of tokens which include token index.
-        """
-
-        per_sentence_tokens: List[List[Tuple[str, int, int]]] = []
-        for text in row:
-            per_sentence_tokens.append(self.tokenizer.tokenize(text))
-        return per_sentence_tokens
-
-
-class ScriptRoBERTaTokenTensorizer(ScriptRoBERTaTensorizerBase):
-    @torch.jit.script_method
-    def tokenize(self, row: List[str]) -> List[List[Tuple[str, int, int]]]:
-        """Convert raw inputs into tokens.
-
-        Args:
-            row: a list of raw inputs, in most case it is a
-                single text or a pair of texts.
-
-        Returns:
-            a per sentence list of tokens which include token index.
-        """
-
-        per_sentence_tokens: List[Tuple[str, int, int]] = []
-        for raw_token in row:
-            per_sentence_tokens.extend(self.tokenizer.tokenize(raw_token))
-        return [per_sentence_tokens]
+    def _lookup_tokens(self, tokens: List[Tuple[str, int, int]]) -> List[int]:
+        return self.vocab_lookup(
+            tokens,
+            bos_idx=self.vocab.bos_idx,
+            eos_idx=self.vocab.eos_idx,
+            use_eos_token_for_bos=False,
+            max_seq_len=self.max_seq_len,
+        )[0]

--- a/pytext/torchscript/tensorizer/tensorizer.py
+++ b/pytext/torchscript/tensorizer/tensorizer.py
@@ -4,36 +4,98 @@
 from typing import List, Optional, Tuple
 
 import torch
+from pytext.torchscript.utils import squeeze_1d, squeeze_2d
 from pytext.torchscript.vocab import ScriptVocabulary
 
 
 class ScriptTensorizer(torch.jit.ScriptModule):
     @torch.jit.script_method
-    def tokenize(self, row):
+    def tokenize(
+        self, text_row: Optional[List[str]], token_row: Optional[List[List[str]]]
+    ):
         """
-        Tokenize raw inputs into tokens, for example gpt-2 bpe,
-        sentence piece and yoda tokenizer.
-        """
-        raise NotImplementedError
-
-    @torch.jit.script_method
-    def numberize(self, row):
-        """
-        Convert raw inputs into numberized result, which usually include the
-        process of tokenization and vocab lookup.
+        Process a single line of raw inputs into tokens, it supports
+        two input formats:
+            1) a single line of texts (single sentence or a pair)
+            2) a single line of pre-processed tokens (single sentence or a pair)
         """
         raise NotImplementedError
 
     @torch.jit.script_method
-    def tensorize(self, rows):
+    def numberize(
+        self, text_row: Optional[List[str]], token_row: Optional[List[List[str]]]
+    ):
         """
-        Convert raw inputs into model input tensors, for example: raw inputs
-        could be text or list of tokens.
+        Process a single line of raw inputs into numberized result, it supports
+        two input formats:
+            1) a single line of texts (single sentence or a pair)
+            2) a single line of pre-processed tokens (single sentence or a pair)
 
-        This function should handle the calling to numberize() and padding
-        the numberized result.
+        This function should handle the logic of calling tokenize(), add special
+        tokens and vocab lookup.
         """
         raise NotImplementedError
+
+    @torch.jit.script_method
+    def tensorize(
+        self,
+        texts: Optional[List[List[str]]] = None,
+        tokens: Optional[List[List[List[str]]]] = None,
+    ):
+        """
+        Process raw inputs into model input tensors, it supports two input
+        formats:
+            1) multiple rows of texts (single sentence or a pair)
+            2) multiple rows of pre-processed tokens (single sentence or a pair)
+
+        This function should handle the logic of calling numberize() and also
+        padding the numberized result.
+        """
+        raise NotImplementedError
+
+    @torch.jit.script_method
+    def tensorize_1d(
+        self,
+        texts: Optional[List[str]] = None,
+        tokens: Optional[List[List[str]]] = None,
+    ):
+        """
+        Process raw inputs(single sentence) into model input tensors, it
+        supports two input formats:
+            1) multiple rows of single sentence
+            2) multiple rows of single sentence pre-processed tokens
+
+        This function should handle the logic of calling numberize() and also
+        padding the numberized result.
+        """
+        return self.tensorize(squeeze_1d(texts), squeeze_2d(tokens))
+
+    @torch.jit.script_method
+    def batch_size(
+        self, texts: Optional[List[List[str]]], tokens: Optional[List[List[List[str]]]]
+    ) -> int:
+        if texts is not None:
+            return len(texts)
+        elif tokens is not None:
+            return len(tokens)
+        else:
+            raise RuntimeError("Empty input for both texts and tokens.")
+
+    @torch.jit.script_method
+    def get_texts_by_index(
+        self, texts: Optional[List[List[str]]], index: int
+    ) -> Optional[List[str]]:
+        if texts is None:
+            return None
+        return texts[index]
+
+    @torch.jit.script_method
+    def get_tokens_by_index(
+        self, tokens: Optional[List[List[List[str]]]], index: int
+    ) -> Optional[List[List[str]]]:
+        if tokens is None:
+            return None
+        return tokens[index]
 
 
 class VocabLookup(torch.jit.ScriptModule):

--- a/pytext/torchscript/tests/test_tensorizer.py
+++ b/pytext/torchscript/tests/test_tensorizer.py
@@ -55,30 +55,19 @@ class TensorizerTest(unittest.TestCase):
         tokenizer, rand_tokens = self._mock_tokenizer()
         vocab = self._mock_vocab()
 
-        bert = ScriptBERTTensorizer(
-            tokenizer,
-            vocab,
-            max_seq_len=100,
-            add_bos_token=False,
-            use_eos_token_for_bos=False,
-        )
-        token_ids, _, _ = bert.numberize("mock test")
+        bert = ScriptBERTTensorizer(tokenizer, vocab, max_seq_len=100)
+        token_ids, _, _, _ = bert.numberize(["mock test"], None)
+        self.assertEqual(token_ids[0], 201)
         self.assertEqual(token_ids[-1], 202)
-        for token_id, token in zip(token_ids[0:-1], rand_tokens):
+        for token_id, token in zip(token_ids[1:-1], rand_tokens):
             self.assertEqual(token_id, int(token[0]) - 100)
 
     def test_roberta_tensorizer(self):
         tokenizer, rand_tokens = self._mock_tokenizer()
         vocab = self._mock_vocab()
 
-        bert = ScriptRoBERTaTensorizer(
-            tokenizer,
-            vocab,
-            max_seq_len=100,
-            add_bos_token=False,
-            use_eos_token_for_bos=True,
-        )
-        token_ids, _, _ = bert.numberize("mock test")
+        roberta = ScriptRoBERTaTensorizer(tokenizer, vocab, max_seq_len=100)
+        token_ids, _, _, _ = roberta.numberize(["mock test"], None)
         self.assertEqual(token_ids[0], 201)
         self.assertEqual(token_ids[-1], 202)
         for token_id, token in zip(token_ids[1:-1], rand_tokens):

--- a/pytext/torchscript/utils.py
+++ b/pytext/torchscript/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 
@@ -193,3 +193,23 @@ def make_byte_inputs(
                 bytes[batch_index][token_index][byte_index] = v + offset_for_non_padding
 
     return bytes, torch.tensor(seq_lens)
+
+
+@torch.jit.script
+def squeeze_1d(inputs: Optional[List[str]]) -> Optional[List[List[str]]]:
+    result: Optional[List[List[str]]] = None
+    if inputs is not None:
+        result = torch.jit.annotate(List[List[str]], [])
+        for line in inputs:
+            result.append([line])
+    return result
+
+
+@torch.jit.script
+def squeeze_2d(inputs: Optional[List[List[str]]]) -> Optional[List[List[List[str]]]]:
+    result: Optional[List[List[List[str]]]] = None
+    if inputs is not None:
+        result = torch.jit.annotate(List[List[List[str]]], [])
+        for line in inputs:
+            result.append([line])
+    return result


### PR DESCRIPTION
Summary:
This diff introduced a general API for handling different inputs.

In most general case, we would expect inputs to be either
1) multiple rows, each row contains a list of text (in most case it is single sentence or a pair) ===> List[List[str]]
2) multiple rows, each row contains a list of pre-processes tokens (in most case it is single sentence or a pair) ===> List[List[List[str]]]

For single sentence classification task, we would expect inputs to be either
1) multiple rows, each row contains a single text ===> List[str]
2) multiple rows, each row contains a single pre-processed tokens ===> List[List[str]]

This refactoring provides two general API
1) def tensorize(
        self,
        texts_list: Optional[List[List[str]]] = None,
        tokens_list: Optional[List[List[List[str]]]] = None,
    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

2) def tensorize_single(
        self,
        texts_list: Optional[List[str]] = None,
        tokens_list: Optional[List[List[str]]] = None,
    ):

And internally it will automate handle the passed inputs is texts or tokens

Differential Revision: D18386345

