### PR TITLE
Consolidate BERT, XLM and RobERTa Tensorizers

### DIFF
--- a/pytext/data/packed_lm_data.py
+++ b/pytext/data/packed_lm_data.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Type
 
 from pytext.common.constants import Stage
 from pytext.data import Batcher, Data
-from pytext.data.bert_tensorizer import BERTTensorizer
+from pytext.data.bert_tensorizer import BERTTensorizerBase
 from pytext.data.data import RowData
 from pytext.data.sources import DataSource
 from pytext.data.tensorizers import Tensorizer, TokenTensorizer
@@ -80,10 +80,8 @@ class PackedLMData(Data):
         numberize. We will simply create this in `_format_output_row`.
         """
         numberized_row = self.tensorizer.numberize(row)
-        if isinstance(self.tensorizer, XLMTensorizer):
-            tokens, seq_len, segment_labels, _ = numberized_row
-        elif isinstance(self.tensorizer, BERTTensorizer):
-            tokens, segment_labels, seq_len = numberized_row
+        if isinstance(self.tensorizer, BERTTensorizerBase):
+            tokens, segment_labels, seq_len, _ = numberized_row
         elif isinstance(self.tensorizer, TokenTensorizer):
             tokens, seq_len, _ = numberized_row
             segment_labels = []
@@ -102,11 +100,9 @@ class PackedLMData(Data):
         In case of the XLMTensorizer, we also need to create a new positions list
         which goes from 0 to seq_len.
         """
-        if isinstance(self.tensorizer, XLMTensorizer):
+        if isinstance(self.tensorizer, BERTTensorizerBase):
             positions = [index for index in range(seq_len)]
-            return {self.tensorizer_name: (tokens, seq_len, segment_labels, positions)}
-        elif isinstance(self.tensorizer, BERTTensorizer):
-            return {self.tensorizer_name: (tokens, segment_labels, seq_len)}
+            return {self.tensorizer_name: (tokens, segment_labels, seq_len, positions)}
         elif isinstance(self.tensorizer, TokenTensorizer):
             # dummy token_ranges
             return {self.tensorizer_name: (tokens, seq_len, [(-1, -1)] * seq_len)}

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -720,13 +720,13 @@ class BERTTensorizerTest(unittest.TestCase):
                 )
             )
         )
-        tokens, segment_label, seq_len = tensorizer.numberize(row)
+        tokens, segment_label, seq_len, positions = tensorizer.numberize(row)
         self.assertEqual(tokens, expected)
         self.assertEqual(seq_len, len(expected))
         self.assertEqual(segment_label, [0] * len(expected))
 
-        tokens, pad_mask, segment_labels = tensorizer.tensorize(
-            [(tokens, segment_label, seq_len)]
+        tokens, pad_mask, segment_labels, _ = tensorizer.tensorize(
+            [(tokens, segment_label, seq_len, positions)]
         )
         self.assertEqual(pad_mask[0].tolist(), [1] * len(expected))
 
@@ -743,7 +743,7 @@ class BERTTensorizerTest(unittest.TestCase):
                 ),
             )
         )
-        tokens, segment_labels, seq_len = tensorizer.numberize(row)
+        tokens, segment_labels, seq_len, _ = tensorizer.numberize(row)
         self.assertEqual(tokens, expected_tokens)
         self.assertEqual(segment_labels, expected_segment_labels)
         self.assertEqual(seq_len, len(expected_tokens))
@@ -765,7 +765,7 @@ class SquadForBERTTensorizerTest(unittest.TestCase):
                 max_seq_len=250,
             )
         )
-        tokens, segments, seq_len, start, end = tensorizer.numberize(row)
+        tokens, segments, seq_len, positions, start, end = tensorizer.numberize(row)
         # check against manually verified answer positions in tokenized output
         # there are 4 identical answers
         self.assertEqual(start, [83, 83, 83, 83])
@@ -775,7 +775,7 @@ class SquadForBERTTensorizerTest(unittest.TestCase):
 
         tensorizer.max_seq_len = 50
         # answer should be truncated out
-        _, _, _, start, end = tensorizer.numberize(row)
+        _, _, _, _, start, end = tensorizer.numberize(row)
         self.assertEqual(start, [-100, -100, -100, -100])
         self.assertEqual(end, [-100, -100, -100, -100])
         self.assertEqual(len(tokens), seq_len)

--- a/pytext/data/xlm_tensorizer.py
+++ b/pytext/data/xlm_tensorizer.py
@@ -2,159 +2,96 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import itertools
-from collections import Counter
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
-import torch
 from fairseq.data.legacy.masked_lm_dictionary import MaskedLMDictionary
 from pytext.config.component import ComponentType, create_component
-from pytext.data.bert_tensorizer import BERTTensorizer
+from pytext.data.bert_tensorizer import BERTTensorizerBase, build_fairseq_vocab
 from pytext.data.tensorizers import lookup_tokens
 from pytext.data.tokenizers import Tokenizer
-from pytext.data.utils import BOS, EOS, MASK, PAD, UNK, Vocabulary, pad_and_tensorize
+from pytext.data.utils import EOS, MASK, PAD, UNK, Vocabulary
 from pytext.data.xlm_constants import LANG2ID_15
-from pytext.data.xlm_dictionary import Dictionary as XLMDictionary
 
 
-def read_vocab(
-    vocab_file: str, max_vocab: int, min_count: int
-) -> Tuple[List, List, Dict]:
-    dictionary = XLMDictionary.read_vocab(vocab_file)
-    if max_vocab >= 1:
-        dictionary.max_vocab(max_vocab)
-    if min_count >= 0:
-        dictionary.min_count(min_count)
-    vocab_list = [dictionary.id2word[w] for w in sorted(dictionary.id2word)]
-    counts = Counter(dictionary.counts)
-    replacements = {"<unk>": UNK, "<pad>": PAD, "<s>": BOS, "</s>": EOS}
-    return vocab_list, counts, replacements
-
-
-def read_fairseq_vocab(
-    vocab_file: str, max_vocab: int = -1, min_count: int = -1
-) -> Tuple[List, List, Dict]:
-    dictionary = MaskedLMDictionary.load(vocab_file)
-    dictionary.finalize(threshold=min_count, nwords=max_vocab, padding_factor=1)
-    vocab_list = dictionary.symbols
-    counts = Counter(dict(zip(vocab_list, dictionary.count)))
-    replacements = {"<pad>": PAD, "</s>": EOS, "<unk>": UNK, "<mask>": MASK}
-    return vocab_list, counts, replacements
-
-
-class XLMTensorizer(BERTTensorizer):
+class XLMTensorizer(BERTTensorizerBase):
     """
     Tensorizer for Cross-lingual LM tasks. Works for single sentence as well
     as sentence pair.
     """
 
-    class Config(BERTTensorizer.Config):
+    class Config(BERTTensorizerBase.Config):
         vocab_file: str = "/mnt/vol/nlp_technologies/xlm/vocab_xnli_15"
         tokenizer: Tokenizer.Config = Tokenizer.Config()
-        is_fairseq: bool = False
-        pretraining: bool = False
-        max_seq_len: Optional[int] = 256
         max_vocab: int = 95000
         min_count: int = 0
-        language_columns: List[str] = ["language"]
+        # language identifiers for extracting the language from a row of data
+        # during numberize
+        language_column: str = "language"
+        # language-to-id mapping used to obtain language embeddings
         lang2id: Dict[str, int] = LANG2ID_15
-        reset_positions: bool = False
+        # Controls whether language is being read from the data file (which
+        # is what happens for finetuning) or being added during processing
+        # (which is what happens during pretraining)
         has_language_in_data: bool = False
+        # controls whether we train with language embeddings or not
         use_language_embeddings: bool = True
 
     @classmethod
     def from_config(cls, config: Config):
         tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
-        return cls(
-            columns=config.columns,
-            tokenizer=tokenizer,
+        vocab = build_fairseq_vocab(
+            dictionary_class=MaskedLMDictionary,
             vocab_file=config.vocab_file,
-            is_fairseq=config.is_fairseq,
-            pretraining=config.pretraining,
-            max_seq_len=config.max_seq_len,
             max_vocab=config.max_vocab,
             min_count=config.min_count,
-            language_columns=config.language_columns,
+            special_token_replacements={
+                "<unk>": UNK,
+                "<pad>": PAD,
+                "</s>": EOS,
+                "<mask>": MASK,
+            },
+        )
+        return cls(
+            columns=config.columns,
+            vocab=vocab,
+            tokenizer=tokenizer,
+            max_seq_len=config.max_seq_len,
+            language_column=config.language_column,
             lang2id=config.lang2id,
-            reset_positions=config.reset_positions,
-            has_language_in_data=config.has_language_in_data,
             use_language_embeddings=config.use_language_embeddings,
+            has_language_in_data=config.has_language_in_data,
         )
 
     def __init__(
         self,
-        columns=Config.columns,
-        tokenizer=None,
-        vocab_file=Config.vocab_file,
-        is_fairseq=Config.is_fairseq,
-        pretraining=Config.pretraining,
-        max_seq_len=Config.max_seq_len,
-        max_vocab=Config.max_vocab,
-        min_count=Config.min_count,
-        language_columns=Config.language_columns,
-        lang2id=Config.lang2id,
-        reset_positions=Config.reset_positions,
-        has_language_in_data=Config.has_language_in_data,
-        use_language_embeddings=Config.use_language_embeddings,
+        columns: List[str] = Config.columns,
+        vocab: Vocabulary = None,
+        tokenizer: Tokenizer = None,
+        max_seq_len: int = Config.max_seq_len,
+        language_column: str = Config.language_column,
+        lang2id: Dict[str, int] = Config.lang2id,
+        use_language_embeddings: bool = Config.use_language_embeddings,
+        has_language_in_data: bool = Config.has_language_in_data,
     ) -> None:
-        assert (
-            len(columns) <= 2 and len(language_columns) <= 2
-        ), "Number of text fields and language columns cannot be greater than 2."
-
-        assert (
-            len(language_columns) == len(columns) or len(language_columns) == 1
-        ), "language columns must be same length as columns, or of length one"
-
-        # Used to distinguish the model pre-trained in PyText and the OSS FAIR model
-        self.is_fairseq = is_fairseq
-
-        # controls the settings we need explicitly for pretraining
-        self.pretraining = pretraining
-
-        # language identifiers for extracting the language from a row of data
-        # during numberize
-        self.language_columns = language_columns
-
-        # language-to-id mapping used to obtain language embeddings
-        self.lang2id = lang2id
-
-        vocab = self._build_vocab(vocab_file, max_vocab, min_count)
-        self.special_token = vocab.idx[EOS]
-
-        # Controls whether we reset the position or not in case we have
-        # multiplt text fields
-        self.reset_positions = reset_positions
-
-        # controls whether we train with language embeddings or not
-        self.use_language_embeddings = use_language_embeddings
+        assert len(columns) <= 2, "More than 2 text fields are not supported."
 
         super().__init__(
-            columns=columns,
-            tokenizer=tokenizer,
-            add_bos_token=False,
-            add_eos_token=False,
-            use_eos_token_for_bos=True,
-            vocab=vocab,
-            max_seq_len=max_seq_len,
+            columns=columns, vocab=vocab, tokenizer=tokenizer, max_seq_len=max_seq_len
         )
-        # if the dataset has a language column then adjust the schema appropriately
+        self.language_column = language_column
+        self.lang2id = lang2id
+        self.use_language_embeddings = use_language_embeddings
         self.has_language_in_data = has_language_in_data
+        # unlike BERT, XLM uses the EOS token for both beginning and end of
+        # sentence
+        self.bos_token = self.vocab.eos_token
 
     @property
     def column_schema(self):
         schema = super().column_schema
         if self.has_language_in_data:
-            schema += [(column, str) for column in self.language_columns]
+            schema += [(self.language_column, str)]
         return schema
-
-    def _numberize_and_wrap(self, text: str, seq_len: int) -> List[List[int]]:
-        sentence = (
-            [self.special_token]
-            + lookup_tokens(
-                text, tokenizer=self.tokenizer, vocab=self.vocab, max_seq_len=seq_len
-            )[0]
-            + [self.special_token]
-        )
-        return [sentence]
 
     def get_lang_id(self, row: Dict, col: str) -> int:
         # generate lang embeddings. if training without lang embeddings, use
@@ -168,94 +105,35 @@ class XLMTensorizer(BERTTensorizer):
             # use En as default
             return self.lang2id.get("en", 0)
 
-    def numberize(self, row: Dict) -> Tuple[Any, ...]:
-        """
-        Extract text and language information from the current row of data being
-        processed. Process the text by tokenizing and vocabulary lookup. Convert
-        language to corresponding list of ids. This function can handle both
-        monolingual and parallel data as well as single sentence and sentence
-        pairs.
-        """
-        sentences = []
-        language_columns = self.language_columns
-        columns = self.columns
+    def _lookup_tokens(self, text: str, seq_len: int) -> List[str]:
+        return lookup_tokens(
+            text,
+            tokenizer=self.tokenizer,
+            vocab=self.vocab,
+            bos_token=self.vocab.eos_token,
+            eos_token=self.vocab.eos_token,
+            use_eos_token_for_bos=True,
+            max_seq_len=seq_len,
+        )
 
-        # When we have sentence pairs, we need to truncate each text field to
-        # max_seq_len // 2. However, the one case where this is not true
-        # is the case when we're pre-training MLM + TLM and the given row
-        # corresponds to monolingual data. Here the target text
-        # (text field related to columns[1]) is None and we don't need to adjust
-        # sequence length. Instead, we update columns and language_columns for
-        # this row. The following if statement handels this case.
-        if self.pretraining and len(columns) == 2:
-            if row[columns[1]] is None:
-                columns = columns[:1]
-                language_columns = ["language"]
+    def numberize(self, row: Dict) -> Tuple[Any, ...]:
+        sentences = []
+        language_column = self.language_column
+        columns = self.columns
 
         # sequence_length is adjusted based on the number of text fields and needs
         # to account for the special tokens which we will be wrapping
-        for column in columns:
-            sentences.extend(
-                self._numberize_and_wrap(
-                    text=row[column], seq_len=(self.max_seq_len // len(columns) - 2)
-                )
-            )
-
-        tokens = list(itertools.chain(*sentences))
+        seq_len = self.max_seq_len // len(columns)
+        sentences = [
+            self._lookup_tokens(row[column], seq_len)[0] for column in self.columns
+        ]
         seq_lens = [len(sentence) for sentence in sentences]
-
-        # create the language tensor. if only one language column is specified,
-        # use it for all texts
-        lang_ids = [self.get_lang_id(row, column) for column in language_columns]
-        if len(lang_ids) == 1:
-            lang_ids = lang_ids * len(self.columns)
-
+        lang_ids = [self.get_lang_id(row, language_column)] * len(self.columns)
         # expand the language ids to each token
         lang_ids = ([lang_id] * seq_len for lang_id, seq_len in zip(lang_ids, seq_lens))
-        lang_ids = list(itertools.chain(*lang_ids))
 
-        length = len(tokens)
-
-        if not self.reset_positions:
-            positions = [index for index in range(length)]
-        else:
-            positions = (range(seq_len) for seq_len in seq_lens)
-            positions = list(itertools.chain(*positions))
-        return tokens, length, lang_ids, positions
-
-    def sort_key(self, row):
-        return row[1]
-
-    def tensorize(self, batch) -> Tuple[torch.Tensor, ...]:
-        tokens, seq_lens, lang_ids, positions = zip(*batch)
-        padded_tokens = pad_and_tensorize(tokens, self.vocab.get_pad_index())
-        padded_lang_ids = pad_and_tensorize(lang_ids)
-        if self.is_fairseq:
-            positions = pad_and_tensorize(positions)
-        else:
-            positions = None
-        pad_mask = (padded_tokens != self.vocab.get_pad_index()).long()
-        return (
-            padded_tokens,
-            pad_mask,
-            pad_and_tensorize(seq_lens),
-            padded_lang_ids,
-            positions,
-        )
-
-    def _build_vocab(
-        self, vocab_file: str, max_vocab: int, min_count: int
-    ) -> Vocabulary:
-        """
-        Build Vocab for XLM by calling the vocab reader associated with the model
-        source.
-        """
-        if self.is_fairseq:
-            vocab_list, counts, replacements = read_fairseq_vocab(
-                vocab_file, max_vocab, min_count
-            )
-        else:
-            vocab_list, counts, replacements = read_vocab(
-                vocab_file, max_vocab, min_count
-            )
-        return Vocabulary(vocab_list, counts, replacements=replacements)
+        tokens = list(itertools.chain(*sentences))
+        segment_labels = list(itertools.chain(*lang_ids))
+        seq_len = len(tokens)
+        positions = [index for index in range(seq_len)]
+        return tokens, segment_labels, seq_len, positions

--- a/pytext/models/qna/bert_squad_qa.py
+++ b/pytext/models/qna/bert_squad_qa.py
@@ -76,16 +76,18 @@ class BertSquadQAModel(NewBertModel):
             tokens,
             pad_mask,
             segment_labels,
+            positions,
             answer_start_indices,
             answer_end_indices,
         ) = tensor_dict["squad_input"]
-        return tokens, pad_mask, segment_labels
+        return tokens, pad_mask, segment_labels, positions
 
     def arrange_targets(self, tensor_dict):
         (
             tokens,
             pad_mask,
             segment_labels,
+            positions,
             answer_start_indices,
             answer_end_indices,
         ) = tensor_dict["squad_input"]

--- a/pytext/models/representations/huggingface_bert_sentence_encoder.py
+++ b/pytext/models/representations/huggingface_bert_sentence_encoder.py
@@ -81,7 +81,7 @@ class HuggingFaceBertSentenceEncoder(TransformerSentenceEncoderBase):
         self.bert = model
 
     def _encoder(self, input_tuple: Tuple[torch.Tensor, ...]):
-        tokens, pad_mask, segment_labels = input_tuple
+        tokens, pad_mask, segment_labels, _ = input_tuple
         return self.bert(tokens, segment_labels, pad_mask)
 
     def _embedding(self):

--- a/pytext/models/representations/transformer_sentence_encoder.py
+++ b/pytext/models/representations/transformer_sentence_encoder.py
@@ -120,17 +120,8 @@ class TransformerSentenceEncoder(TransformerSentenceEncoderBase):
     def _encoder(
         self, input_tuple: Tuple[torch.Tensor, ...]
     ) -> Tuple[torch.Tensor, ...]:
-        # If multilingual is True then the input_tuple has additional information
-        # related to the lengths of the inputs as well as a position tensor
-        if self.multilingual:
-            tokens, _, lengths, segment_labels, positions = input_tuple
-
-            # we need this for backwards compatibility with models that are
-            # pre-trained with the offset
-            if self.offset_positions_by_padding:
-                positions = None
-        else:
-            tokens, _, segment_labels = input_tuple
+        tokens, _, segment_labels, positions = input_tuple
+        if self.offset_positions_by_padding or (not self.multilingual):
             positions = None
 
         encoded_layers, pooled_output = self.sentence_encoder(

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -30,7 +30,7 @@ class RoBERTaEncoderBase(TransformerSentenceEncoderBase):
 
     def _encoder(self, inputs):
         # NewBertModel expects the output as a tuple and grabs the first element
-        tokens, _, _ = inputs
+        tokens, _, _, _ = inputs
         full_representation = self.encoder(tokens)
         sentence_rep = full_representation[:, 0, :]
         return [full_representation], sentence_rep

--- a/pytext/models/test/transformer_sentence_encoder_test.py
+++ b/pytext/models/test/transformer_sentence_encoder_test.py
@@ -28,7 +28,7 @@ class TransformerSentenceEncoderTest(unittest.TestCase):
 
     def test_monolingual_transformer_sentence_encoder(self):
 
-        input_tuple = (self.tokens, self.pad_mask, self.segment_labels)
+        input_tuple = (self.tokens, self.pad_mask, self.segment_labels, self.positions)
 
         sentence_encoder = TransformerSentenceEncoder.from_config(
             TransformerSentenceEncoder.Config(
@@ -55,13 +55,7 @@ class TransformerSentenceEncoderTest(unittest.TestCase):
 
     def test_multilingual_transformer_sentence_encoder(self):
 
-        input_tuple = (
-            self.tokens,
-            self.pad_mask,
-            self.lengths,
-            self.segment_labels,
-            self.positions,
-        )
+        input_tuple = (self.tokens, self.pad_mask, self.segment_labels, self.positions)
 
         sentence_encoder = TransformerSentenceEncoder.from_config(
             TransformerSentenceEncoder.Config(


### PR DESCRIPTION
Summary:
In this diff I take a fast stab at consolidating the XLM, BERT and RoBERTa Tensorizers. I kill a bunch of dead code and simiplify a lot.
- I create a BERTTensorizerBase class which derives from Tensorizer and not TokenTensorizer since this makes the logic a lot easier especially since we no longer have to deal with all the bos, eos flags. Given that tokenize and lookup_tokens are not part of TokenTensorizer, I think this formulation makes a lot of sense.
- As per suggestions, I derive the config classes from Tensorizer as well and kill all of the special flags.
- I try to put as much of the functionality in the base class as possible in order to minimize copy paste code. There is still some but I dont want perfect to be the enemy of better.
- I kill TLM - long live TLM.
- I (temporaarily) kill support for OSS XLM which probably should have its own tensorizer anyways since it has nothing to do with transformer_sentence_encoder.

Reviewed By: rutyrinott

Differential Revision: D18290264

