### PR TITLE
Print model into the output log

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -401,6 +401,7 @@ class Trainer(TrainerBase):
         trainable_params = sum(
             p.numel() for p in state.model.parameters() if p.requires_grad
         )
+        print(f"Model :{model}")
         print(f"Num trainable parameters: {trainable_params}")
 
         while self.continue_training(state):


### PR DESCRIPTION
Summary: This diff prints the built model to the stdout log. This is useful because sometimes the config remains the same and implementation of the model changes. In those cases printing the model can help us spot differences in actual model.

Differential Revision: D18455407

