### PR TITLE
Complete training loop gracefully even if no timing is reported

### DIFF
--- a/pytext/utils/timing.py
+++ b/pytext/utils/timing.py
@@ -113,6 +113,13 @@ class Snapshot:
                     }
                     print("PyTorchObserver " + json_dumps(info))
 
+        if len(self.times) == 0:
+            print(
+                "Note: Nothing was reported. "
+                'Please use timing.time("foo") to measure time.'
+            )
+            return
+
         results = [
             {
                 "name": path(key),


### PR DESCRIPTION
Summary: PyText always requires/assums that at least one "timing" exists at the end of the training and tries to print it as an ascii table. However, if one simply does not have any `timing.time("foo")` call during the training, the entire training loop crashes in the end, which is I don't think desirable behavior and not all people might not be that interested in timing info at the early phase iteration/research.

Differential Revision: D18461987

