### PR TITLE
Explicitly set trivial start and end losses for MRC models to float type

### DIFF
--- a/pytext/models/output_layers/squad_output_layer.py
+++ b/pytext/models/output_layers/squad_output_layer.py
@@ -157,8 +157,12 @@ class SquadOutputLayer(OutputLayerBase):
 
         num_answers = start_pos_target.size()[-1]
         if num_answers == 0:
-            start_loss = torch.tensor(0, requires_grad=True).type_as(end_pos_logit)
-            end_loss = torch.tensor(0, requires_grad=True).type_as(end_pos_logit)
+            start_loss = torch.tensor(
+                0.0, dtype=torch.float, requires_grad=True
+            ).type_as(end_pos_logit)
+            end_loss = torch.tensor(0.0, dtype=torch.float, requires_grad=True).type_as(
+                end_pos_logit
+            )
         else:
             start_loss = self.loss_fn(
                 start_pos_logit.repeat((num_answers, 1)),


### PR DESCRIPTION
Summary:
For MRC models, when true answer is not present, start and end position losses are set to 0. PyTorch complains that the value of tensors that require grads must be floating point dtype. Default behavior of `torch.tensor()` constructor is infer data type from data if dtype is not mentioned.

Note: I couldn't find anything that says the default behavior has changed though. Not sure why we didn't encounter this before.

Differential Revision: D18450671

