### PR TITLE
minor refactoring, move sparsification_condition inside sparsifier

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -220,14 +220,9 @@ class Trainer(TrainerBase):
         if not self.config.sparsifier:
             return
 
-        if state.stage != Stage.TRAIN:
-            return
-
-        if state.sparsifier.sparsification_condition(state):
-            state.sparsifier.sparsify(state)
-
+        self.sparsifier.sparsify(state)
         if state.rank == 0:
-            current_sparsity = state.sparsifier.get_current_sparsity(state.model)
+            current_sparsity = self.sparsifier.get_current_sparsity(state.model)
             print(f"sparsity in the model: {current_sparsity}")
 
     def continue_training(self, state: TrainingState) -> bool:


### PR DESCRIPTION
Summary:
refactoring and move sparsification_condition logics from trainer to sparsifier.

Reasons: it gives more flexibilty for writing sparisfication algorithms.

 1: some sparsifier has different behavior of sparisfication_condition during train and eval.
 2: allows the existent mask (when config.accumulate_mask is true) to be applied on the params even when sparisfication_condition is False (not updating the mask)

Differential Revision: D18466384

