### PR TITLE
support torchscriptify XLM-R

### DIFF
--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -8,6 +8,7 @@ from fairseq.data.encoders.gpt2_bpe import get_encoder as create_gpt2_bpe
 from fairseq.data.encoders.gpt2_bpe_utils import Encoder as GPT2BPEEncoder
 from pytext.config import ConfigBase
 from pytext.config.component import Component, ComponentType, create_component
+from pytext.torchscript.tokenizer import ScriptDoNothingTokenizer
 from pytorch_pretrained_bert.tokenization import (
     BasicTokenizer,
     WordpieceTokenizer,
@@ -80,6 +81,9 @@ class DoNothingTokenizer(Tokenizer):
     def tokenize(self, input: List[str]) -> List[Token]:
         tokens = [Token(token_text, -1, -1) for token_text in input if token_text]
         return tokens
+
+    def torchscriptify(self):
+        return ScriptDoNothingTokenizer()
 
 
 class BERTInitialTokenizer(Tokenizer):
@@ -248,3 +252,6 @@ class SentencePieceTokenizer(Tokenizer, CppProcessorMixin):
     def _load_processor(self):
         self.processor = SentencePieceProcessor()
         self.processor.Load(self.sp_model_path)
+
+    def torchscriptify(self):
+        return ScriptDoNothingTokenizer()

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -18,7 +18,7 @@ from pytext.models.representations.transformer import (
 from pytext.models.representations.transformer_sentence_encoder_base import (
     TransformerSentenceEncoderBase,
 )
-from pytext.torchscript.module import ScriptTextModule
+from pytext.torchscript.module import get_script_module_cls
 from torch.serialization import default_restore_location
 
 
@@ -118,8 +118,13 @@ class RoBERTa(NewBertModel):
         includes generating tensors from simple data types, and returns classified
         values according to the output layer (eg. as a dict mapping class name to score)
         """
-        return ScriptTextModule(
+        script_tensorizer = tensorizers["tokens"].torchscriptify()
+        script_module_cls = get_script_module_cls(
+            script_tensorizer.tokenizer.input_type()
+        )
+
+        return script_module_cls(
             model=traced_model,
             output_layer=self.output_layer.torchscript_predictions(),
-            tensorizer=tensorizers["tokens"].torchscriptify(),
+            tensorizer=script_tensorizer,
         )

--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -5,7 +5,16 @@ from typing import List
 
 import torch
 from pytext.torchscript.tensorizer.tensorizer import ScriptTensorizer
-from pytext.torchscript.utils import squeeze_1d, squeeze_2d
+from pytext.torchscript.utils import ScriptInputType, squeeze_1d, squeeze_2d
+
+
+def get_script_module_cls(input_type: ScriptInputType) -> torch.jit.ScriptModule:
+    if input_type.is_text():
+        return ScriptTextModule
+    elif input_type.is_token():
+        return ScriptTokenModule
+    else:
+        raise RuntimeError("Only support text or token input type...")
 
 
 class ScriptTextModule(torch.jit.ScriptModule):

--- a/pytext/torchscript/tests/test_tensorizer.py
+++ b/pytext/torchscript/tests/test_tensorizer.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 import torch
 from pytext.torchscript.tensorizer import ScriptBERTTensorizer, ScriptRoBERTaTensorizer
 from pytext.torchscript.tensorizer.tensorizer import VocabLookup
+from pytext.torchscript.tokenizer.tokenizer import ScriptTextTokenizerBase
 from pytext.torchscript.vocab import ScriptVocabulary
 
 
@@ -19,11 +20,12 @@ class TensorizerTest(unittest.TestCase):
         )
 
     def _mock_tokenizer(self):
-        class MockTokenizer(torch.jit.ScriptModule):
+        class MockTokenizer(ScriptTextTokenizerBase):
             def __init__(self, tokens: List[Tuple[str, int, int]]):
                 super().__init__()
                 self.tokens = torch.jit.Attribute(tokens, List[Tuple[str, int, int]])
 
+            @torch.jit.script_method
             def tokenize(self, text: str) -> List[Tuple[str, int, int]]:
                 return self.tokens
 

--- a/pytext/torchscript/tokenizer/__init__.py
+++ b/pytext/torchscript/tokenizer/__init__.py
@@ -2,6 +2,16 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .bpe import ScriptBPE
+from .tokenizer import (
+    ScriptDoNothingTokenizer,
+    ScriptTextTokenizerBase,
+    ScriptTokenTokenizerBase,
+)
 
 
-__all__ = ["ScriptBPE"]
+__all__ = [
+    "ScriptBPE",
+    "ScriptDoNothingTokenizer",
+    "ScriptTextTokenizerBase",
+    "ScriptTokenTokenizerBase",
+]

--- a/pytext/torchscript/tokenizer/tokenizer.py
+++ b/pytext/torchscript/tokenizer/tokenizer.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import List, Tuple
+
+import torch
+from pytext.torchscript.utils import ScriptInputType
+
+
+class ScriptTokenizerBase(torch.jit.ScriptModule):
+    @torch.jit.script_method
+    def tokenize(self, input: str) -> List[Tuple[str, int, int]]:
+        """
+        Process a single line of raw inputs into tokens, it supports
+        two input formats:
+            1) a single text
+            2) a token
+
+        Returns a list of tokens with start and end indices in original input.
+        """
+        raise NotImplementedError
+
+    def input_type(self) -> ScriptInputType:
+        """
+        Determine TorchScript module input type, currently it have four types
+            1) text: batch with a single text in each row, List[str]
+            2) tokens: batch with a list of tokens from single text
+                in each row, List[List[str]]
+            3) multi_text: batch with multiple texts in each row,
+                List[List[str]]
+            4) multi_tokens: batch with multiple lists of tokens from
+                multiple texts in each row, List[List[List[str]]]
+        """
+        raise NotImplementedError
+
+
+class ScriptTextTokenizerBase(ScriptTokenizerBase):
+    def input_type(self) -> ScriptInputType:
+        return ScriptInputType.text
+
+
+class ScriptTokenTokenizerBase(ScriptTokenizerBase):
+    def input_type(self) -> ScriptInputType:
+        return ScriptInputType.token
+
+
+class ScriptDoNothingTokenizer(ScriptTokenTokenizerBase):
+    @torch.jit.script_method
+    def tokenize(self, raw_token: str) -> List[Tuple[str, int, int]]:
+        return [(raw_token, -1, -1)]

--- a/pytext/torchscript/utils.py
+++ b/pytext/torchscript/utils.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from enum import Enum
 from typing import List, Optional, Tuple
 
 import torch
+
+
+class ScriptInputType(Enum):
+    text = 1  # row contains a single sentence
+    token = 2  # row contains a list of tokens from a single sentence
+
+    def is_text(self):
+        return self is ScriptInputType.text
+
+    def is_token(self):
+        return self is ScriptInputType.token
 
 
 # ===== the following section should be replaced once JIT provide native support


### PR DESCRIPTION
Summary:
The core part of this diff is to determine use ScriptTextModule or ScriptTokenModule in RoBERTa.torchscriptify().
Given concrete example: GPT2BPE need use ScriptTextModule and SentencePiece need to use ScriptTokenModule

This diff have few changes
1) Introduce ScriptInputType to determine to use ScriptTextModule or ScriptTokenModule
2) ScriptTokenizer have API: input_type() to determine which ScriptInputType to support
3) Add torchscriptify() API for SentencePieceTokenizer

Differential Revision: D18487692

