### PR TITLE
Infer dimension from input data in FloatListTensorizer

### DIFF
--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -622,6 +622,28 @@ class TensorizersTest(unittest.TestCase):
             round_list(output),
         )
 
+    def test_float_list_tensor_infer_dim(self):
+        class DummyData:
+            __slots__ = ["train"]
+
+            def __init__(self, train):
+                self.train = train
+
+        data = DummyData([{"dense": [1.0, 1.0, 1.0]}, {"dense": [1.0, 1.0, 1.0]}])
+        tensorizer = FloatListTensorizer(
+            column="dense", error_check=True, normalize=False, dim=None
+        )
+        self._initialize_tensorizer(tensorizer, data)
+        self.assertEqual(3, tensorizer.dim)
+
+        self.assertEqual(
+            [1.0, 1.0, 1.0], tensorizer.numberize({"dense": [1.0, 1.0, 1.0]})
+        )
+        with self.assertRaises(Exception) as context:
+            # dim mismatch
+            tensorizer.numberize({"dense": [1.0, 1.0]})
+            self.assertTrue("didn't match expected" in context.exception)
+
     def test_annotation_num(self):
         data = TSVDataSource(
             SafeFileWrapper(tests_module.test_file("compositional_seq2seq_unit.tsv")),


### PR DESCRIPTION
Summary: If dim is None, infer the dim from input when initializing the tensorizer, it's very useful when the dim of the dense feature changes whenever the training data change.

Differential Revision: D18525590

