### PR TITLE
Fix OSS pytext

### DIFF
--- a/pytext/models/representations/traced_transformer_encoder.py
+++ b/pytext/models/representations/traced_transformer_encoder.py
@@ -14,6 +14,7 @@ from fairseq.modules import (
 class TraceableTransformerWrapper(nn.Module):
     def __init__(self, eager_encoder: TransformerSentenceEncoderModule) -> None:
         super().__init__()
+        assert hasattr(eager_encoder, "traceable")
         assert eager_encoder.traceable
         self.eager_encoder = eager_encoder
 

--- a/pytext/models/representations/transformer_sentence_encoder.py
+++ b/pytext/models/representations/transformer_sentence_encoder.py
@@ -106,8 +106,11 @@ class TransformerSentenceEncoder(TransformerSentenceEncoderBase):
             freeze_embeddings=config.freeze_embeddings,
             n_trans_layers_to_freeze=config.n_trans_layers_to_freeze,
             export=self.export,
-            traceable=self.use_torchscript,
         )
+        if self.use_torchscript:
+            assert hasattr(self.sentence_encoder, "traceable")
+            self.sentence_encoder.traceable = self.use_torchscript
+
         self.projection = (
             torch.nn.Linear(self.representation_dim, config.projection_dim)
             if config.projection_dim > 0


### PR DESCRIPTION
Summary:
OSS pytext depends on a release of fairseq that doesn't have the latest
changes, new functionality added earlier requires them - adding a check to
avoid breakage

Differential Revision: D18534042

