### PR TITLE
Torchscript export of XLM Intent Slot Models

### DIFF
--- a/pytext/models/crf.py
+++ b/pytext/models/crf.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import List
+
 import torch
+import torch.jit as jit
 import torch.nn as nn
 from caffe2.python.crf_predict import apply_crf
-from pytext.common.constants import Padding
-from pytext.utils.cuda import GetTensor
-from torch.autograd import Variable
+from pytext.utils.cuda import convert_tensor
 
 
 class CRF(nn.Module):
@@ -17,7 +18,9 @@ class CRF(nn.Module):
         num_tags: The number of tags
     """
 
-    def __init__(self, num_tags: int, ignore_index: int) -> None:
+    def __init__(
+        self, num_tags: int, ignore_index: int, default_label_pad_index: int
+    ) -> None:
         if num_tags <= 0:
             raise ValueError(f"Invalid number of tags: {num_tags}")
         super().__init__()
@@ -29,6 +32,7 @@ class CRF(nn.Module):
         self.end_tag = num_tags + 1
         self.reset_parameters()
         self.ignore_index = ignore_index
+        self.default_label_pad_index = default_label_pad_index
 
     def reset_parameters(self) -> None:
         nn.init.uniform_(self.transitions, -0.1, 0.1)
@@ -42,8 +46,8 @@ class CRF(nn.Module):
         self.transitions.data = transitions
 
     def forward(
-        self, emissions: torch.FloatTensor, tags: torch.LongTensor, reduce: bool = True
-    ) -> Variable:
+        self, emissions: torch.Tensor, tags: torch.Tensor, reduce: bool = True
+    ) -> torch.Tensor:
         """
         Compute log-likelihood of input.
 
@@ -62,9 +66,8 @@ class CRF(nn.Module):
         llh = numerator - denominator
         return llh if not reduce else torch.mean(llh)
 
-    def decode(
-        self, emissions: torch.FloatTensor, seq_lens: torch.LongTensor
-    ) -> torch.Tensor:
+    @jit.export
+    def decode(self, emissions: torch.Tensor, seq_lens: torch.Tensor) -> torch.Tensor:
         """
         Given a set of emission probabilities, return the predicted tags.
 
@@ -78,10 +81,7 @@ class CRF(nn.Module):
         return result
 
     def _compute_joint_llh(
-        self,
-        emissions: torch.FloatTensor,
-        tags: torch.LongTensor,
-        mask: torch.FloatTensor,
+        self, emissions: torch.Tensor, tags: torch.Tensor, mask: torch.Tensor
     ) -> torch.Tensor:
         seq_len = emissions.shape[1]
 
@@ -115,7 +115,7 @@ class CRF(nn.Module):
         return llh.squeeze(1)
 
     def _compute_log_partition_function(
-        self, emissions: torch.FloatTensor, mask: torch.FloatTensor
+        self, emissions: torch.Tensor, mask: torch.Tensor
     ) -> torch.Tensor:
         seq_len = emissions.shape[1]
 
@@ -139,7 +139,7 @@ class CRF(nn.Module):
         return torch.logsumexp(log_prob.squeeze(1), 1)
 
     def _viterbi_decode(
-        self, emissions: torch.FloatTensor, mask: torch.FloatTensor
+        self, emissions: torch.Tensor, mask: torch.Tensor
     ) -> torch.Tensor:
         seq_len = emissions.shape[1]
         mask = mask.to(torch.uint8)
@@ -153,10 +153,14 @@ class CRF(nn.Module):
             : self.start_tag, self.end_tag
         ].unsqueeze(0)
 
-        best_scores_list = []
+        best_scores_list: List[torch.Tensor] = []
+        # Needed for Torchscript as empty list is assumed to be list of tensors
+        empty_data: List[int] = []
         # If the element has only token, empty tensor in best_paths helps
         # torch.cat() from crashing
-        best_paths_list = [GetTensor(torch.Tensor().long())]
+        best_paths_list = [
+            convert_tensor(torch.tensor(empty_data).long(), emissions.is_cuda)
+        ]
         best_scores_list.append(end_scores.unsqueeze(1))
 
         for idx in range(1, seq_len):
@@ -185,12 +189,14 @@ class CRF(nn.Module):
 
         _, max_indices_from_scores = torch.max(best_scores, 2)
 
-        valid_index_tensor = GetTensor(torch.tensor(0)).long()
-        if self.ignore_index == Padding.DEFAULT_LABEL_PAD_IDX:
+        valid_index_tensor = convert_tensor(torch.tensor(0), emissions.is_cuda).long()
+        if self.ignore_index == self.default_label_pad_index:
             # No label for padding, so use 0 index.
             padding_tensor = valid_index_tensor
         else:
-            padding_tensor = GetTensor(torch.tensor(self.ignore_index)).long()
+            padding_tensor = convert_tensor(
+                torch.tensor(self.ignore_index), emissions.is_cuda
+            ).long()
 
         # Label for the last position is always based on the index with max score
         # For illegal timesteps, we set as ignore_index
@@ -256,7 +262,9 @@ class CRF(nn.Module):
     def _make_mask_from_seq_lens(self, seq_lens):
         seq_lens = seq_lens.view(-1, 1)
         max_len = torch.max(seq_lens)
-        range_tensor = GetTensor(torch.arange(max_len)).unsqueeze(0)
+        range_tensor = convert_tensor(
+            torch.arange(max_len), seq_lens.is_cuda
+        ).unsqueeze(0)
         range_tensor = range_tensor.expand(seq_lens.size(0), range_tensor.size(1))
         mask = (range_tensor < seq_lens).float()
         return mask

--- a/pytext/models/decoders/intent_slot_model_decoder.py
+++ b/pytext/models/decoders/intent_slot_model_decoder.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -77,7 +77,7 @@ class IntentSlotModelDecoder(DecoderBase):
 
     def forward(
         self, x_d: torch.Tensor, x_w: torch.Tensor, dense: Optional[torch.Tensor] = None
-    ) -> List[torch.Tensor]:
+    ) -> Tuple[torch.Tensor]:
         if dense is not None:
             logit_d = self.doc_decoder(torch.cat((x_d, dense), 1))
         else:
@@ -95,7 +95,7 @@ class IntentSlotModelDecoder(DecoderBase):
             dense = dense.unsqueeze(1).repeat(1, word_input_shape[1], 1)
             x_w = torch.cat((x_w, dense), 2)
 
-        return [logit_d, self.word_decoder(x_w)]
+        return (logit_d, self.word_decoder(x_w))
 
     def get_decoder(self) -> List[nn.Module]:
         """Returns the document and word decoder modules.

--- a/pytext/models/output_layers/intent_slot_output_layer.py
+++ b/pytext/models/output_layers/intent_slot_output_layer.py
@@ -4,14 +4,41 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+import torch.nn as nn
 from caffe2.python import core
 from pytext.common.constants import DatasetFieldName
 from pytext.data.utils import Vocabulary
 from pytext.models.module import create_module
+from torch import jit
 
 from .doc_classification_output_layer import ClassificationOutputLayer
 from .output_layer_base import OutputLayerBase
 from .word_tagging_output_layer import CRFOutputLayer, WordTaggingOutputLayer
+
+
+class IntentSlotScores(nn.Module):
+    def __init__(self, doc_scores: jit.ScriptModule, word_scores: jit.ScriptModule):
+        super().__init__()
+        self.doc_scores = doc_scores
+        self.word_scores = word_scores
+
+    def forward(
+        self,
+        logits: Tuple[torch.Tensor, torch.Tensor],
+        seq_lengths: torch.Tensor,
+        token_indices: Optional[torch.Tensor] = None,
+    ) -> Tuple[List[Dict[str, float]], List[List[Dict[str, float]]]]:
+        d_logits, w_logits = logits
+        if token_indices is not None:
+            w_logits = torch.gather(
+                w_logits,
+                1,
+                token_indices.unsqueeze(2).expand(-1, -1, w_logits.size(-1)),
+            )
+
+        d_results = self.doc_scores(d_logits)
+        w_results = self.word_scores(w_logits, seq_lengths)
+        return (d_results, w_results)
 
 
 class IntentSlotOutputLayer(OutputLayerBase):
@@ -161,3 +188,8 @@ class IntentSlotOutputLayer(OutputLayerBase):
         ) + self.word_output.export_to_caffe2(
             workspace, init_net, predict_net, model_out[1], word_out_name
         )
+
+    def torchscript_predictions(self):
+        doc_scores = self.doc_output.torchscript_predictions()
+        word_scores = self.word_output.torchscript_predictions()
+        return jit.script(IntentSlotScores(doc_scores, word_scores))

--- a/pytext/models/output_layers/word_tagging_output_layer.py
+++ b/pytext/models/output_layers/word_tagging_output_layer.py
@@ -4,13 +4,14 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+import torch.jit as jit
+import torch.nn as nn
 import torch.nn.functional as F
 from caffe2.python import core
 from pytext.common import Padding
 from pytext.config.component import create_loss
 from pytext.config.serialize import MissingValueError
 from pytext.data.utils import Vocabulary
-from pytext.fields import FieldMeta
 from pytext.loss import (
     AUCPRHingeLoss,
     BinaryCrossEntropyLoss,
@@ -24,6 +25,35 @@ from pytext.utils.label import get_label_weights
 
 from .output_layer_base import OutputLayerBase
 from .utils import OutputLayerUtils
+
+
+class WordTaggingScores(nn.Module):
+    classes: List[str]
+
+    def __init__(self, classes):
+        super().__init__()
+        self.classes = classes
+
+    def forward(
+        self, logits: torch.Tensor, seq_lengths: Optional[torch.Tensor] = None
+    ) -> List[List[Dict[str, float]]]:
+        scores: torch.Tensor = F.log_softmax(logits, 2)
+        return _get_prediction_from_scores(scores, self.classes)
+
+
+class CRFWordTaggingScores(WordTaggingScores):
+    def __init__(self, classes: List[str], crf):
+        super().__init__(classes)
+        self.crf = crf
+        self.crf.eval()
+
+    def forward(
+        self, logits: torch.Tensor, seq_lengths: torch.Tensor
+    ) -> List[List[Dict[str, float]]]:
+        pred = self.crf.decode(logits, seq_lengths)
+        logits_rearranged = _rearrange_output(logits, pred)
+        scores: torch.Tensor = F.log_softmax(logits_rearranged, 2)
+        return _get_prediction_from_scores(scores, self.classes)
 
 
 class WordTaggingOutputLayer(OutputLayerBase):
@@ -138,6 +168,9 @@ class WordTaggingOutputLayer(OutputLayerBase):
             predict_net, probability_out, model_out, output_name, self.target_names
         )
 
+    def torchscript_predictions(self):
+        return jit.script(WordTaggingScores(self.target_names))
+
 
 class CRFOutputLayer(OutputLayerBase):
     """
@@ -160,7 +193,11 @@ class CRFOutputLayer(OutputLayerBase):
 
     def __init__(self, num_tags, labels: Vocabulary, *args) -> None:
         super().__init__(list(labels), *args)
-        self.crf = CRF(num_tags, labels.get_pad_index(Padding.DEFAULT_LABEL_PAD_IDX))
+        self.crf = CRF(
+            num_tags=num_tags,
+            ignore_index=labels.get_pad_index(Padding.DEFAULT_LABEL_PAD_IDX),
+            default_label_pad_index=Padding.DEFAULT_LABEL_PAD_IDX,
+        )
 
     def get_loss(
         self,
@@ -240,7 +277,11 @@ class CRFOutputLayer(OutputLayerBase):
             predict_net, probability_out, model_out, output_name, self.target_names
         )
 
+    def torchscript_predictions(self):
+        return jit.script(CRFWordTaggingScores(self.target_names, jit.script(self.crf)))
 
+
+@jit.script
 def _rearrange_output(logit, pred):
     """
     Rearrange the word logits so that the decoded word has the highest valued
@@ -252,3 +293,29 @@ def _rearrange_output(logit, pred):
     logit_rearranged = logit.scatter(2, pred_indices, max_logits)
     logit_rearranged.scatter_(2, max_logit_indices, pred_logits)
     return logit_rearranged
+
+
+@jit.script
+def _get_prediction_from_scores(
+    scores: torch.Tensor, classes: List[str]
+) -> List[List[Dict[str, float]]]:
+    """
+    Given scores for a batch, get the prediction for each word in the form of a
+    List[List[Dict[str, float]]] for callers of the torchscript model to consume.
+    The outer list iterates over batches of sentences and the inner iterates
+    over each token in the sentence. The dictionary consists of
+    `label:score` for each word.
+    """
+    results: List[List[Dict[str, float]]] = []
+    # Extra verbosity because jit doesn't support zip
+    for sentence_scores in scores.chunk(len(scores)):
+        sentence_scores = sentence_scores.squeeze(0)
+        sentence_response: List[Dict[str, float]] = []
+        for word_scores in sentence_scores.chunk(len(sentence_scores)):
+            word_scores = word_scores.squeeze(0)
+            word_response: Dict[str, float] = {}
+            for i in range(len(classes)):
+                word_response[classes[i]] = float(word_scores[i].item())
+            sentence_response.append(word_response)
+        results.append(sentence_response)
+    return results

--- a/pytext/models/test/crf_test.py
+++ b/pytext/models/test/crf_test.py
@@ -20,7 +20,11 @@ class CRFTest(hu.HypothesisTestCase):
     )
     def test_crf_forward(self, num_tags, seq_lens):
 
-        crf_model = CRF(num_tags, ignore_index=Padding.WORD_LABEL_PAD_IDX)
+        crf_model = CRF(
+            num_tags,
+            ignore_index=Padding.WORD_LABEL_PAD_IDX,
+            default_label_pad_index=Padding.DEFAULT_LABEL_PAD_IDX,
+        )
 
         total_manual_loss = 0
 
@@ -97,3 +101,48 @@ class CRFTest(hu.HypothesisTestCase):
         binary_scores = sum(transitions[a][b] for a, b in zip(labels[:-1], labels[1:]))
         loss = total_score - (binary_scores + unary_scores)
         return loss
+
+    @given(
+        num_tags=st.integers(2, 10),
+        seq_lens=st.lists(
+            elements=st.integers(min_value=1, max_value=10), min_size=1, max_size=10
+        ),
+    )
+    def test_crf_decode_torchscript(self, num_tags, seq_lens):
+        crf_model = CRF(
+            num_tags,
+            ignore_index=Padding.WORD_LABEL_PAD_IDX,
+            default_label_pad_index=Padding.DEFAULT_LABEL_PAD_IDX,
+        )
+        crf_model.eval()
+        scripted_crf_model = torch.jit.script(crf_model)
+
+        max_num_words = max(seq_lens)
+        padded_inputs = []
+        for seq_len in seq_lens:
+            input_emission = np.random.rand(seq_len, num_tags)
+            padded_inputs.append(
+                np.concatenate(
+                    [input_emission, np.zeros((max_num_words - seq_len, num_tags))],
+                    axis=0,
+                )
+            )
+            crf_decode = crf_model.decode(
+                torch.tensor(input_emission, dtype=torch.float).unsqueeze(0),
+                torch.tensor([seq_len]),
+            )
+
+            scripted_crf_decode = scripted_crf_model.decode(
+                torch.tensor(input_emission, dtype=torch.float).unsqueeze(0),
+                torch.tensor([seq_len]),
+            )
+
+            self.assertTrue(torch.allclose(crf_decode, scripted_crf_decode))
+
+        batched_emissions = torch.tensor(padded_inputs, dtype=torch.float)
+        batched_seq_lens = torch.tensor(seq_lens)
+        crf_batch_decode = crf_model.decode(batched_emissions, batched_seq_lens)
+        scriped_crf_batch_decode = scripted_crf_model.decode(
+            batched_emissions, batched_seq_lens
+        )
+        self.assertTrue(torch.allclose(crf_batch_decode, scriped_crf_batch_decode))

--- a/pytext/models/test/output_layer_test.py
+++ b/pytext/models/test/output_layer_test.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import unittest
+import random
+import string
+from typing import Dict, List
 
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
 import numpy as np
+import torch
+from hypothesis import given
 from pytext.data.tensorizers import LabelTensorizer
 from pytext.data.utils import Vocabulary
-from pytext.models.output_layers.word_tagging_output_layer import WordTaggingOutputLayer
+from pytext.models.output_layers.word_tagging_output_layer import (
+    CRFOutputLayer,
+    WordTaggingOutputLayer,
+)
 
 
-class OutputLayerTest(unittest.TestCase):
+class OutputLayerTest(hu.HypothesisTestCase):
     def test_create_word_tagging_output_layer(self):
         tensorizer = LabelTensorizer()
         tensorizer.vocab = Vocabulary(["foo", "bar"])
@@ -20,3 +29,95 @@ class OutputLayerTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             np.array([2.2, 1]), layer.loss_fn.weight.detach().numpy()
         )
+
+    @given(
+        num_labels=st.integers(2, 6),
+        seq_lens=st.lists(
+            elements=st.integers(min_value=1, max_value=10), min_size=1, max_size=10
+        ),
+    )
+    def test_torchscript_word_tagging_output_layer(self, num_labels, seq_lens):
+        batch_size = len(seq_lens)
+        tensorizer = LabelTensorizer()
+        vocab_toks: List[str] = [
+            OutputLayerTest._generate_random_string() for _ in range(num_labels)
+        ]
+        tensorizer.vocab = Vocabulary(vocab_toks)
+        tensorizer.pad_idx = 0
+
+        word_layer = WordTaggingOutputLayer.from_config(
+            config=WordTaggingOutputLayer.Config(), labels=tensorizer.vocab
+        )
+        crf_layer = CRFOutputLayer.from_config(
+            config=CRFOutputLayer.Config(), labels=tensorizer.vocab
+        )
+
+        logits, seq_lens_tensor = OutputLayerTest._generate_word_tagging_inputs(
+            batch_size, num_labels, seq_lens
+        )
+        context = {"seq_lens": seq_lens_tensor}
+
+        torchsript_word_layer = word_layer.torchscript_predictions()
+        torchscript_crf_layer = crf_layer.torchscript_predictions()
+
+        self._validate_word_tagging_result(
+            word_layer.get_pred(logits, None, context)[1],
+            torchsript_word_layer(logits, seq_lens_tensor),
+            tensorizer.vocab,
+        )
+        self._validate_word_tagging_result(
+            crf_layer.get_pred(logits, None, context)[1],
+            torchscript_crf_layer(logits, seq_lens_tensor),
+            tensorizer.vocab,
+        )
+
+    @staticmethod
+    def _generate_random_string(min_size: int = 2, max_size: int = 8) -> str:
+        size = random.randint(min_size, max_size)
+        return "".join([random.choice(string.ascii_lowercase) for _ in range(size)])
+
+    @staticmethod
+    def _generate_word_tagging_inputs(bsize: int, num_labels: int, seq_lens: List[int]):
+        max_seq_length = max(seq_lens)
+        logits = torch.randn(bsize, max_seq_length, num_labels)
+        return logits, torch.tensor(seq_lens, dtype=torch.int)
+
+    def _validate_word_tagging_result(
+        self,
+        scores: torch.Tensor,
+        ts_results: List[List[Dict[str, float]]],
+        vocab: Vocabulary,
+    ):
+        bsize, max_seq_len, num_labels = scores.size()
+        self.assertEqual(
+            len(ts_results),
+            bsize,
+            "Batch size must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0]),
+            max_seq_len,
+            "Max seq length must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0][0]),
+            num_labels,
+            "Number of labels must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0][0]),
+            len(vocab),
+            "Number of labels should be same as vocab length",
+        )
+
+        for i in range(bsize):
+            for j in range(max_seq_len):
+                for label, score in ts_results[i][j].items():
+                    self.assertAlmostEqual(
+                        score,
+                        scores[i][j][vocab.idx[label]],
+                        (
+                            "Scores for [{}][{}][{}] element must match for "
+                            "pytorch and torchscript class"
+                        ).format(i, j, vocab.idx[label]),
+                    )

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -230,7 +230,10 @@ class _NewTask(TaskBase):
             batches = self.data.batcher.batchify(numberized_rows)
             _, inputs = next(pad_and_tensorize_batches(self.data.tensorizers, batches))
             model_inputs = self.model.arrange_model_inputs(inputs)
-            predictions, scores = self.model.get_pred(self.model(*model_inputs))
+            model_context = self.model.arrange_model_context(inputs)
+            predictions, scores = self.model.get_pred(
+                self.model(*model_inputs), context=model_context
+            )
             results.append({"prediction": predictions, "score": scores})
         return results
 

--- a/pytext/utils/cuda.py
+++ b/pytext/utils/cuda.py
@@ -44,6 +44,14 @@ def GetTensor(tensor):
         return tensor
 
 
+@torch.jit.script
+def convert_tensor(tensor: torch.Tensor, is_cuda: bool = False):
+    if is_cuda:
+        return tensor.cuda()
+    else:
+        return tensor
+
+
 def tensor(data, dtype):
     return torch.tensor(data, dtype=dtype, device=device())
 


### PR DESCRIPTION
Summary:
This diff does the following:

1. Adds support for torchscript export of XLM Intent Slot models
2. Modifies `IntentSlotOutputLayer`, `WordTaggingOutputLayer` and `CRFOutputLayer` for torchscript export
3. Makes CRF implementation torchscriptable
4. Fixes `predict` method of `NewTask` to make sure it passes model context as well to `get_pred`

Differential Revision: D18485174

