### PR TITLE
Add support for Torchscript export of IntentSlotOutputLayer and CRF

### DIFF
--- a/pytext/models/decoders/intent_slot_model_decoder.py
+++ b/pytext/models/decoders/intent_slot_model_decoder.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -77,7 +77,7 @@ class IntentSlotModelDecoder(DecoderBase):
 
     def forward(
         self, x_d: torch.Tensor, x_w: torch.Tensor, dense: Optional[torch.Tensor] = None
-    ) -> List[torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         if dense is not None:
             logit_d = self.doc_decoder(torch.cat((x_d, dense), 1))
         else:
@@ -95,7 +95,7 @@ class IntentSlotModelDecoder(DecoderBase):
             dense = dense.unsqueeze(1).repeat(1, word_input_shape[1], 1)
             x_w = torch.cat((x_w, dense), 2)
 
-        return [logit_d, self.word_decoder(x_w)]
+        return logit_d, self.word_decoder(x_w)
 
     def get_decoder(self) -> List[nn.Module]:
         """Returns the document and word decoder modules.

--- a/pytext/models/test/crf_test.py
+++ b/pytext/models/test/crf_test.py
@@ -20,7 +20,11 @@ class CRFTest(hu.HypothesisTestCase):
     )
     def test_crf_forward(self, num_tags, seq_lens):
 
-        crf_model = CRF(num_tags, ignore_index=Padding.WORD_LABEL_PAD_IDX)
+        crf_model = CRF(
+            num_tags,
+            ignore_index=Padding.WORD_LABEL_PAD_IDX,
+            default_label_pad_index=Padding.DEFAULT_LABEL_PAD_IDX,
+        )
 
         total_manual_loss = 0
 
@@ -97,3 +101,48 @@ class CRFTest(hu.HypothesisTestCase):
         binary_scores = sum(transitions[a][b] for a, b in zip(labels[:-1], labels[1:]))
         loss = total_score - (binary_scores + unary_scores)
         return loss
+
+    @given(
+        num_tags=st.integers(2, 10),
+        seq_lens=st.lists(
+            elements=st.integers(min_value=1, max_value=10), min_size=1, max_size=10
+        ),
+    )
+    def test_crf_decode_torchscript(self, num_tags, seq_lens):
+        crf_model = CRF(
+            num_tags,
+            ignore_index=Padding.WORD_LABEL_PAD_IDX,
+            default_label_pad_index=Padding.DEFAULT_LABEL_PAD_IDX,
+        )
+        crf_model.eval()
+        scripted_crf_model = torch.jit.script(crf_model)
+
+        max_num_words = max(seq_lens)
+        padded_inputs = []
+        for seq_len in seq_lens:
+            input_emission = np.random.rand(seq_len, num_tags)
+            padded_inputs.append(
+                np.concatenate(
+                    [input_emission, np.zeros((max_num_words - seq_len, num_tags))],
+                    axis=0,
+                )
+            )
+            crf_decode = crf_model.decode(
+                torch.tensor(input_emission, dtype=torch.float).unsqueeze(0),
+                torch.tensor([seq_len]),
+            )
+
+            scripted_crf_decode = scripted_crf_model.decode(
+                torch.tensor(input_emission, dtype=torch.float).unsqueeze(0),
+                torch.tensor([seq_len]),
+            )
+
+            self.assertTrue(torch.allclose(crf_decode, scripted_crf_decode))
+
+        batched_emissions = torch.tensor(padded_inputs, dtype=torch.float)
+        batched_seq_lens = torch.tensor(seq_lens)
+        crf_batch_decode = crf_model.decode(batched_emissions, batched_seq_lens)
+        scriped_crf_batch_decode = scripted_crf_model.decode(
+            batched_emissions, batched_seq_lens
+        )
+        self.assertTrue(torch.allclose(crf_batch_decode, scriped_crf_batch_decode))

--- a/pytext/models/test/output_layer_test.py
+++ b/pytext/models/test/output_layer_test.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import unittest
+import random
+import string
+from typing import Dict, List
 
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
 import numpy as np
+import torch
+from hypothesis import given
 from pytext.data.tensorizers import LabelTensorizer
 from pytext.data.utils import Vocabulary
-from pytext.models.output_layers.word_tagging_output_layer import WordTaggingOutputLayer
+from pytext.models.output_layers.intent_slot_output_layer import IntentSlotOutputLayer
+from pytext.models.output_layers.word_tagging_output_layer import (
+    CRFOutputLayer,
+    WordTaggingOutputLayer,
+)
 
 
-class OutputLayerTest(unittest.TestCase):
+class OutputLayerTest(hu.HypothesisTestCase):
     def test_create_word_tagging_output_layer(self):
         tensorizer = LabelTensorizer()
         tensorizer.vocab = Vocabulary(["foo", "bar"])
@@ -20,3 +30,205 @@ class OutputLayerTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             np.array([2.2, 1]), layer.loss_fn.weight.detach().numpy()
         )
+
+    @given(
+        num_labels=st.integers(2, 6),
+        seq_lens=st.lists(
+            elements=st.integers(min_value=1, max_value=10), min_size=1, max_size=10
+        ),
+    )
+    def test_torchscript_word_tagging_output_layer(self, num_labels, seq_lens):
+        batch_size = len(seq_lens)
+        vocab = Vocabulary(
+            [OutputLayerTest._generate_random_string() for _ in range(num_labels)]
+        )
+
+        word_layer = WordTaggingOutputLayer.from_config(
+            config=WordTaggingOutputLayer.Config(), labels=vocab
+        )
+        crf_layer = CRFOutputLayer.from_config(
+            config=CRFOutputLayer.Config(), labels=vocab
+        )
+
+        logits, seq_lens_tensor = OutputLayerTest._generate_word_tagging_inputs(
+            batch_size, num_labels, seq_lens
+        )
+        context = {"seq_lens": seq_lens_tensor}
+
+        torchsript_word_layer = word_layer.torchscript_predictions()
+        torchscript_crf_layer = crf_layer.torchscript_predictions()
+
+        self._validate_word_tagging_result(
+            word_layer.get_pred(logits, None, context)[1],
+            torchsript_word_layer(logits, seq_lens_tensor),
+            vocab,
+        )
+        self._validate_word_tagging_result(
+            crf_layer.get_pred(logits, None, context)[1],
+            torchscript_crf_layer(logits, seq_lens_tensor),
+            vocab,
+        )
+
+    @given(
+        num_doc_labels=st.integers(2, 6),
+        num_word_labels=st.integers(2, 6),
+        seq_lens=st.lists(
+            elements=st.integers(min_value=4, max_value=10), min_size=1, max_size=10
+        ),
+    )
+    def test_torchscript_intent_slot_output_layer(
+        self, num_doc_labels, num_word_labels, seq_lens
+    ):
+        batch_size = len(seq_lens)
+        doc_vocab = Vocabulary(
+            [OutputLayerTest._generate_random_string() for _ in range(num_doc_labels)]
+        )
+        word_vocab = Vocabulary(
+            [OutputLayerTest._generate_random_string() for _ in range(num_word_labels)]
+        )
+        intent_slot_output_layer = IntentSlotOutputLayer.from_config(
+            config=IntentSlotOutputLayer.Config(),
+            doc_labels=doc_vocab,
+            word_labels=word_vocab,
+        )
+        doc_logits = OutputLayerTest._generate_doc_classification_inputs(
+            batch_size, num_doc_labels
+        )
+        word_logits, seq_lens_tensor = OutputLayerTest._generate_word_tagging_inputs(
+            batch_size, num_word_labels, seq_lens
+        )
+        context = {"seq_lens": seq_lens_tensor}
+        torchscript_output_layer = intent_slot_output_layer.torchscript_predictions()
+
+        pt_output = intent_slot_output_layer.get_pred(
+            (doc_logits, word_logits), None, context
+        )[1]
+        ts_output = torchscript_output_layer((doc_logits, word_logits), seq_lens_tensor)
+
+        self._validate_doc_classification_result(pt_output[0], ts_output[0], doc_vocab)
+        self._validate_word_tagging_result(pt_output[1], ts_output[1], word_vocab)
+
+        (
+            word_bpe_logits,
+            seq_lens_tensor,
+            token_indices_tensor,
+        ) = OutputLayerTest._generate_bpe_tagging_inputs(
+            batch_size, num_word_labels, seq_lens
+        )
+        context = {"seq_lens": seq_lens_tensor, "token_indices": token_indices_tensor}
+        pt_output = intent_slot_output_layer.get_pred(
+            (doc_logits, word_bpe_logits), None, context
+        )[1]
+        ts_output = torchscript_output_layer(
+            (doc_logits, word_bpe_logits), seq_lens_tensor, token_indices_tensor
+        )
+
+        self._validate_doc_classification_result(pt_output[0], ts_output[0], doc_vocab)
+        self._validate_word_tagging_result(pt_output[1], ts_output[1], word_vocab)
+
+    @staticmethod
+    def _generate_random_string(min_size: int = 2, max_size: int = 8) -> str:
+        size = random.randint(min_size, max_size)
+        return "".join([random.choice(string.ascii_lowercase) for _ in range(size)])
+
+    @staticmethod
+    def _generate_word_tagging_inputs(bsize: int, num_labels: int, seq_lens: List[int]):
+        max_seq_length = max(seq_lens)
+        logits = torch.randn(bsize, max_seq_length, num_labels)
+        return logits, torch.tensor(seq_lens, dtype=torch.int)
+
+    @staticmethod
+    def _generate_bpe_tagging_inputs(bsize: int, num_labels: int, seq_lens: List[int]):
+        max_seq_length = max(seq_lens)
+        max_bpe_length = max_seq_length * 2 + random.randint(
+            1, max_seq_length
+        )  # Arbitrary length greater than max_seq_length
+        logits = torch.randn(bsize, max_bpe_length, num_labels)
+        token_begin_indices = []
+        for l in seq_lens:
+            token_begin_indices.append(
+                sorted(random.sample(range(max_bpe_length), l))
+                + [0] * (max_seq_length - l)
+            )
+        return (
+            logits,
+            torch.tensor(seq_lens, dtype=torch.int),
+            torch.tensor(token_begin_indices, dtype=torch.long),
+        )
+
+    @staticmethod
+    def _generate_doc_classification_inputs(bsize: int, num_labels: int):
+        return torch.randn(bsize, num_labels)
+
+    def _validate_doc_classification_result(
+        self,
+        scores: torch.Tensor,
+        ts_results: List[Dict[str, float]],
+        vocab: Vocabulary,
+    ):
+        bsize, num_labels = scores.size()
+        self.assertEqual(
+            len(ts_results),
+            bsize,
+            "Batch size must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0]),
+            num_labels,
+            "Number of labels must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0]),
+            len(vocab),
+            "Number of labels should be same as vocab length",
+        )
+        for i in range(bsize):
+            for label, score in ts_results[i].items():
+                self.assertAlmostEqual(
+                    score,
+                    scores[i][vocab.idx[label]],
+                    (
+                        "Scores for [{}][{}] element must match for "
+                        "pytorch and torchscript class"
+                    ).format(i, vocab.idx[label]),
+                )
+
+    def _validate_word_tagging_result(
+        self,
+        scores: torch.Tensor,
+        ts_results: List[List[Dict[str, float]]],
+        vocab: Vocabulary,
+    ):
+        bsize, max_seq_len, num_labels = scores.size()
+        self.assertEqual(
+            len(ts_results),
+            bsize,
+            "Batch size must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0]),
+            max_seq_len,
+            "Max seq length must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0][0]),
+            num_labels,
+            "Number of labels must match for pytorch and torchscript class",
+        )
+        self.assertEqual(
+            len(ts_results[0][0]),
+            len(vocab),
+            "Number of labels should be same as vocab length",
+        )
+
+        for i in range(bsize):
+            for j in range(max_seq_len):
+                for label, score in ts_results[i][j].items():
+                    self.assertAlmostEqual(
+                        score,
+                        scores[i][j][vocab.idx[label]],
+                        (
+                            "Scores for [{}][{}][{}] element must match for "
+                            "pytorch and torchscript class"
+                        ).format(i, j, vocab.idx[label]),
+                    )

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -230,7 +230,10 @@ class _NewTask(TaskBase):
             batches = self.data.batcher.batchify(numberized_rows)
             _, inputs = next(pad_and_tensorize_batches(self.data.tensorizers, batches))
             model_inputs = self.model.arrange_model_inputs(inputs)
-            predictions, scores = self.model.get_pred(self.model(*model_inputs))
+            model_context = self.model.arrange_model_context(inputs)
+            predictions, scores = self.model.get_pred(
+                self.model(*model_inputs), context=model_context
+            )
             results.append({"prediction": predictions, "score": scores})
         return results
 


### PR DESCRIPTION
Summary:
This diff does the following:

1. Modifies `IntentSlotOutputLayer`, `WordTaggingOutputLayer` and `CRFOutputLayer` for torchscript export.

1. Makes CRF implementation torchscriptable
1. Fixes `predict` method of `NewTask` to make sure it passes model context as well to `get_pred`
1. Fixes return type of the `forward` method of the decoder to return tuples of tensors instead of lists of tensors.

Differential Revision: D18565235

