### PR TITLE
Decouple decoder configs for pos and has_answer in BERT-QA

### DIFF
--- a/pytext/models/qna/bert_squad_qa.py
+++ b/pytext/models/qna/bert_squad_qa.py
@@ -38,8 +38,11 @@ class BertSquadQAModel(NewBertModel):
             )
 
         inputs: ModelInput = ModelInput()
-        encoder: TransformerSentenceEncoderBase.Config = HuggingFaceBertSentenceEncoder.Config()
-        decoder: MLPDecoder.Config = MLPDecoder.Config(out_dim=2)
+        encoder: TransformerSentenceEncoderBase.Config = (
+            HuggingFaceBertSentenceEncoder.Config()
+        )
+        pos_decoder: MLPDecoder.Config = MLPDecoder.Config(out_dim=2)
+        has_ans_decoder: MLPDecoder.Config = MLPDecoder.Config(out_dim=2)
         output_layer: SquadOutputLayer.Config = SquadOutputLayer.Config()
 
     @classmethod
@@ -47,22 +50,26 @@ class BertSquadQAModel(NewBertModel):
         has_answer_labels = ["False", "True"]
         tensorizers["has_answer"].vocab = Vocabulary(has_answer_labels)
         vocab = tensorizers["squad_input"].vocab
+
         encoder = create_module(
             config.encoder,
             output_encoded_layers=True,
             padding_idx=vocab.get_pad_index(),
             vocab_size=vocab.__len__(),
         )
-        decoder = create_module(
-            config.decoder, in_dim=encoder.representation_dim, out_dim=2
+
+        pos_decoder = create_module(
+            config.pos_decoder, in_dim=encoder.representation_dim, out_dim=2
         )
         has_ans_decoder = create_module(
-            config.decoder,
+            config.has_ans_decoder,
             in_dim=encoder.representation_dim,
             out_dim=len(has_answer_labels),
         )
+
         output_layer = create_module(config.output_layer, labels=has_answer_labels)
-        return cls(encoder, decoder, has_ans_decoder, output_layer)
+
+        return cls(encoder, pos_decoder, has_ans_decoder, output_layer)
 
     def __init__(
         self, encoder, decoder, has_ans_decoder, output_layer, stage=Stage.TRAIN
@@ -97,21 +104,22 @@ class BertSquadQAModel(NewBertModel):
 
     def forward(self, *inputs):
         encoded_layers, cls_embed = self.encoder(inputs)
-        logits = self.decoder(encoded_layers[-1])
-        if isinstance(logits, (list, tuple)):
-            logits = logits[0]
+        pos_logits = self.decoder(encoded_layers[-1])
+        if isinstance(pos_logits, (list, tuple)):
+            pos_logits = pos_logits[0]
 
-        label = (
-            torch.zeros((logits.size(0), 2))  # dummy tensor
+        has_ans_logits = (
+            torch.zeros((pos_logits.size(0), 2))  # dummy tensor
             if self.output_layer.ignore_impossible
             else self.has_ans_decoder(cls_embed)
         )
         # Shape of logits is (batch_size, seq_len, 2)
-        start_logits, end_logits = logits.split(1, dim=-1)
+        start_logits, end_logits = pos_logits.split(1, dim=-1)
 
         # Shape of start_logits and end_logits is (batch_size, seq_len, 1)
         # Hence, remove the last dimension and reduce them to the dimensions to
         # (batch_size, seq_len)
         start_logits = start_logits.squeeze(-1)
         end_logits = end_logits.squeeze(-1)
-        return start_logits, end_logits, label
+
+        return start_logits, end_logits, has_ans_logits


### PR DESCRIPTION
Summary: Position and has_answer decoders share the config with each other. This is an issue when we want to save the modules since one will over-write another. This diff introduces one config for each.

Differential Revision: D18588025

