### PR TITLE
Proper behavior for do_eval=False

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -456,12 +456,16 @@ class Trainer(TrainerBase):
         if self.optimizer.finalize():
             state.stage = Stage.EVAL
             model.eval(Stage.EVAL)
-            print(f"start evaluating finalized state")
-            with torch.no_grad():
-                eval_metric = self.run_epoch(state, eval_data, metric_reporter)
-            better_model = metric_reporter.compare_metric(
-                eval_metric, state.best_model_metric
-            )
+            if self.config.do_eval:
+                print(f"start evaluating finalized state")
+                with torch.no_grad():
+                    eval_metric = self.run_epoch(state, eval_data, metric_reporter)
+                better_model = metric_reporter.compare_metric(
+                    eval_metric, state.best_model_metric
+                )
+            else:
+                eval_metric = None
+                better_model = True
             if better_model:
                 self.update_best_model(state, train_config, eval_metric)
             if better_model or train_config.save_all_checkpoints:


### PR DESCRIPTION
Summary:
In trainer, the option `do_eval` (https://fburl.com/diffusion/lopy7hig) can be set to `False` to skip eval stage in training. However, the eval stage is always run in the finalize step (see changes in this diff). This can cause issues when eval data is not provided, see the failed workflow for example:
f151938461

In this diff, if `do_eval` is set to `False`, we also skip the eval operation in the finalize step.

Differential Revision: D18590815

