### PR TITLE
fix OSS import issue by adding __init__.py

### DIFF
--- a/pytext/torchscript/tokenizer/tokenizer.py
+++ b/pytext/torchscript/tokenizer/tokenizer.py
@@ -15,8 +15,8 @@ class ScriptTokenizerBase(torch.jit.ScriptModule):
         """
         Process a single line of raw inputs into tokens, it supports
         two input formats:
-            1) a single text
-            2) a token
+        1) a single text
+        2) a token
 
         Returns a list of tokens with start and end indices in original input.
         """
@@ -25,13 +25,13 @@ class ScriptTokenizerBase(torch.jit.ScriptModule):
     def input_type(self) -> ScriptInputType:
         """
         Determine TorchScript module input type, currently it have four types
-            1) text: batch with a single text in each row, List[str]
-            2) tokens: batch with a list of tokens from single text
-                in each row, List[List[str]]
-            3) multi_text: batch with multiple texts in each row,
-                List[List[str]]
-            4) multi_tokens: batch with multiple lists of tokens from
-                multiple texts in each row, List[List[List[str]]]
+        1) text: batch with a single text in each row, List[str]
+        2) tokens: batch with a list of tokens from single text
+        in each row, List[List[str]]
+        3) multi_text: batch with multiple texts in each row,
+        List[List[str]]
+        4) multi_tokens: batch with multiple lists of tokens from
+        multiple texts in each row, List[List[List[str]]]
         """
         raise NotImplementedError
 

--- a/pytext/utils/path.py
+++ b/pytext/utils/path.py
@@ -21,13 +21,14 @@ def get_pytext_home():
     return pytext_home
 
 
-# all relateive path in PyText is based on PYTEXT_HOME
+# relateive path in PyText is either based on PYTEXT_HOME or current work directory
 PYTEXT_HOME = get_pytext_home()
 
 
-def get_absolute_path(file_path):
-    return (
-        file_path
-        if os.path.isabs(file_path)
-        else os.path.realpath(os.path.join(PYTEXT_HOME, file_path))
-    )
+def get_absolute_path(file_path: str) -> str:
+    if os.path.isabs(file_path):
+        return file_path
+    absolute_path = os.path.realpath(os.path.join(PYTEXT_HOME, file_path))
+    if os.path.exists(absolute_path):
+        return absolute_path
+    return file_path


### PR DESCRIPTION
Summary:
Although empty __init__.py is not required since python3.3+, Google Colab's python3.6 still requires it. Missing this file causes error during "from pytext import workflow"

ModuleNotFoundError: No module named 'pytext.torchscript'

Differential Revision: D18648432

