### PR TITLE
Start, End index calculations fix for unicode characters.

### DIFF
--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -210,6 +210,13 @@ class GPT2BPETokenizer(Tokenizer):
     def tokenize(self, input_str: str) -> List[Token]:
         bpe_ids = self.bpe.encode(input_str)
         char_tokens = [self.bpe.decoder[id].lstrip(u"\u0120") for id in bpe_ids]
+        # fix for incorrect decoding of utf-8 chars
+        char_tokens = [
+            bytearray([self.bpe.byte_decoder[char] for char in char_token]).decode(
+                "utf-8"
+            )
+            for char_token in char_tokens
+        ]
         lengths = [len(token) for token in char_tokens]
         tokens = []
         end = 0


### PR DESCRIPTION
Summary:
The existing GPT2BPETokenizer incorrectly calculates the start and end indices for unicode characters.
This is because for multi-byte characters, we need to additionally use the byte decoder on the decoded bytes to get back the original token that was encoded.

Differential Revision: D18697646

