### PR TITLE
Resolve dependency conflict by specifying python-dateutil==2.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ hypothesis<4.0
 joblib
 numpy
 onnx==1.5.0
+# pytorch-pretrained-bert requires python-dateutil < 2.8.1
+python-dateutil==2.8.0
 pandas
 pytorch-pretrained-bert
 requests


### PR DESCRIPTION
Summary:
1. pandas is introduced recently. It requires python-dateutil >=2.6.1
2. pytorch-pretrained-bert depends on python-dateutil [required: >=2.1,<2.8.1]
3. latest python-dateutil is 2.8.1

Before this diff, pandas is installed first with latest python-dateutil == 2.8.1. Then it causes error during installing pytorch-pretrained-bert

**This issue is happening in CircleCI but not captured by unit test! https://circleci.com/gh/facebookresearch/pytext/16257**

  $ ./install_deps

  ERROR: botocore 1.13.28 has requirement python-dateutil<2.8.1,>=2.1; python_version >= "2.7", but you''ll have python-dateutil 2.8.1 which is   incompatible.

  $ pipdeptree
  Warning!!! Possibly conflicting dependencies found:
  * botocore==1.13.28
   - python-dateutil [required: >=2.1,<2.8.1, installed: 2.8.1]
  ------------------------------------------------------------------------
  pipdeptree==0.13.2
    - pip [required: >=6.0.0, installed: 19.3.1]
  pytext-nlp==0.2.3
    ...
    - pandas [required: Any, installed: 0.25.3]
      - numpy [required: >=1.13.3, installed: 1.17.4]
      - python-dateutil [required: >=2.6.1, installed: 2.8.1]
        - six [required: >=1.5, installed: 1.13.0]
      - pytz [required: >=2017.2, installed: 2019.3]
    - pytorch-pretrained-bert [required: Any, installed: 0.6.2]
      - boto3 [required: Any, installed: 1.10.28]
        - botocore [required: >=1.13.28,<1.14.0, installed: 1.13.28]
          - docutils [required: >=0.10,<0.16, installed: 0.15.2]
          - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
          - python-dateutil [required: >=2.1,<2.8.1, installed: 2.8.1]
            - six [required: >=1.5, installed: 1.13.0]
          - urllib3 [required: >=1.20,<1.26, installed: 1.25.7]
    ...

Differential Revision: D18753252

