### PR TITLE
Back out "Start, End index calculations fix for unicode characters." Due to the way BPE happens - This doesn't work - n180158 while this works - n180157

### DIFF
--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -210,13 +210,6 @@ class GPT2BPETokenizer(Tokenizer):
     def tokenize(self, input_str: str) -> List[Token]:
         bpe_ids = self.bpe.encode(input_str)
         char_tokens = [self.bpe.decoder[id].lstrip(u"\u0120") for id in bpe_ids]
-        # fix for incorrect decoding of utf-8 chars
-        char_tokens = [
-            bytearray([self.bpe.byte_decoder[char] for char in char_token]).decode(
-                "utf-8"
-            )
-            for char_token in char_tokens
-        ]
         lengths = [len(token) for token in char_tokens]
         tokens = []
         end = 0


### PR DESCRIPTION
Summary: Original commit changeset: 8f4d32a1caa4

Differential Revision: D18769684

