### PR TITLE
Fix zero loss tensor in SquadOutputLayer

### DIFF
--- a/pytext/models/output_layers/squad_output_layer.py
+++ b/pytext/models/output_layers/squad_output_layer.py
@@ -157,12 +157,8 @@ class SquadOutputLayer(OutputLayerBase):
 
         num_answers = start_pos_target.size()[-1]
         if num_answers == 0:
-            start_loss = torch.tensor(
-                0.0, dtype=torch.float, requires_grad=True
-            ).type_as(end_pos_logit)
-            end_loss = torch.tensor(0.0, dtype=torch.float, requires_grad=True).type_as(
-                end_pos_logit
-            )
+            start_loss = torch.tensor(0.0, dtype=torch.float).type_as(end_pos_logit)
+            end_loss = torch.tensor(0.0, dtype=torch.float).type_as(end_pos_logit)
         else:
             start_loss = self.loss_fn(
                 start_pos_logit.repeat((num_answers, 1)),


### PR DESCRIPTION
Summary:
In SquadOutputLayer we set start and end position losses to zeros. Those tensor objects have `requires_grad` set to True which leads to unused param error.
```
RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss.
```

Reviewed By: borguz

Differential Revision: D18801364

