### PR TITLE
Allow model to take byte-level input and make byte-level prediction

### DIFF
--- a/pytext/data/utils.py
+++ b/pytext/data/utils.py
@@ -87,6 +87,10 @@ EOS = SpecialToken("__END_OF_SENTENCE__")
 BOL = SpecialToken("__BEGIN_OF_LIST__")
 EOL = SpecialToken("__END_OF_LIST__")
 MASK = SpecialToken("__MASK__")
+# BOS and EOS is too long for Byte-level Language Model.
+# Todo: find out conbination of bytes with low-frequency and shorter length
+BYTE_BOS = SpecialToken("^")
+BYTE_EOS = SpecialToken("#")
 
 UNK_INDEX = 0
 PAD_INDEX = 1

--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -49,6 +49,7 @@ class LanguageModelMetricReporter(MetricReporter):
     UTTERANCE_COLUMN = "utterance"
     RAW_TEXT_COLUMN = "text"
     TOKENS_COLUMN = "tokens"
+    LABELS_COLUMN = "labels"
     lower_is_better = True
 
     class Config(MetricReporter.Config):
@@ -84,7 +85,14 @@ class LanguageModelMetricReporter(MetricReporter):
         if metadata:
             self.pad_index = metadata.target.pad_token_idx
         if tensorizers:
-            self.pad_index = tensorizers[self.TOKENS_COLUMN].vocab.get_pad_index()
+            if self.TOKENS_COLUMN in tensorizers:
+                column = self.TOKENS_COLUMN
+            elif self.LABELS_COLUMN in tensorizers:
+                column = self.LABELS_COLUMN
+            if hasattr(tensorizers[column], "vocab"):
+                self.pad_index = tensorizers[column].vocab.get_pad_index()
+            else:
+                self.pad_index = tensorizers[column].PAD_BYTE
         self.perplexity_func = get_perplexity_func(perplexity_type)
 
     def add_batch_stats(


### PR DESCRIPTION
Summary:
This diff creates a BiteLM model to take byte-level input and produce byte-level output.
1. Add BYTE_BOS and BYTE_EOS to ByteTensorizer as they are needed in language model
2. Create a byte_lm_output_layer

Reviewed By: kmalik22

Differential Revision: D18834414

