### PR TITLE
Use PathManager for all I/O

### DIFF
--- a/demo/atis_joint_model/data_processor.py
+++ b/demo/atis_joint_model/data_processor.py
@@ -5,6 +5,7 @@ import os
 import random
 
 import click
+from pytext.utils.file_io import PathManager
 
 
 VALIDATION_SPLIT = 0.25
@@ -17,7 +18,7 @@ def read_vocab(file_path):
     (line_no - 1) is the key
     """
     vocab = {}
-    with open(file_path, "r") as file_contents:
+    with PathManager.open(file_path, "r") as file_contents:
         for idx, word in enumerate(file_contents):
             vocab[idx] = word.strip()
     return vocab
@@ -99,15 +100,15 @@ def process_train_set(
     train_file_name = os.path.join(output_directory, "atis.processed.train.csv")
     validation_file_name = os.path.join(output_directory, "atis.processed.val.csv")
 
-    with open(
+    with PathManager.open(
         os.path.join(download_folder, "atis.train.intent.csv"), "r"
-    ) as intents, open(
+    ) as intents, PathManager.open(
         os.path.join(download_folder, "atis.train.slots.csv"), "r"
-    ) as slots, open(
+    ) as slots, PathManager.open(
         os.path.join(download_folder, "atis.train.query.csv"), "r"
-    ) as queries, open(
+    ) as queries, PathManager.open(
         train_file_name, "w"
-    ) as train_file, open(
+    ) as train_file, PathManager.open(
         validation_file_name, "w"
     ) as validation_file:
 
@@ -135,13 +136,13 @@ def process_test_set(
 ):
     test_file_name = os.path.join(output_directory, "atis.processed.test.csv")
 
-    with open(
+    with PathManager.open(
         os.path.join(download_folder, "atis.test.intent.csv"), "r"
-    ) as intents, open(
+    ) as intents, PathManager.open(
         os.path.join(download_folder, "atis.test.slots.csv"), "r"
-    ) as slots, open(
+    ) as slots, PathManager.open(
         os.path.join(download_folder, "atis.test.query.csv"), "r"
-    ) as queries, open(
+    ) as queries, PathManager.open(
         test_file_name, "w"
     ) as test_file:
         for _idx, (intent, slot, query) in enumerate(zip(intents, slots, queries)):
@@ -159,7 +160,7 @@ def process_test_set(
 
 
 def print_sample(file_name):
-    with open(file_name, "r") as given_file:
+    with PathManager.open(file_name, "r") as given_file:
         for _i in range(SAMPLE_PRINT_COUNT):
             line = next(given_file).strip()
             print(line)

--- a/demo/datasource/source.py
+++ b/demo/datasource/source.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Type
 
 from pytext.data.sources.data_source import RootDataSource
 from pytext.data.utils import UNK
+from pytext.utils.file_io import PathManager
 
 
 def load_vocab(file_path):
@@ -15,14 +16,14 @@ def load_vocab(file_path):
     (line_no - 1) is the key
     """
     vocab = {}
-    with open(file_path, "r") as file_contents:
+    with PathManager.open(file_path, "r") as file_contents:
         for idx, word in enumerate(file_contents):
             vocab[str(idx)] = word.strip()
     return vocab
 
 
 def reader(file_path, vocab):
-    with open(file_path, "r") as r:
+    with PathManager.open(file_path, "r") as r:
         for line in r:
             yield " ".join(
                 vocab.get(s.strip(), UNK)
@@ -32,7 +33,7 @@ def reader(file_path, vocab):
 
 
 def reader_raw(file_path, vocab):
-    with open(file_path, "r") as r:
+    with PathManager.open(file_path, "r") as r:
         for line in r:
             yield vocab[line.strip()]
 

--- a/demo/my_tagging/source.py
+++ b/demo/my_tagging/source.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Type
 
 from pytext.data.sources.data_source import RootDataSource
 from pytext.data.utils import UNK
+from pytext.utils.file_io import PathManager
 
 
 def load_vocab(file_path):
@@ -15,14 +16,14 @@ def load_vocab(file_path):
     (line_no - 1) is the key
     """
     vocab = {}
-    with open(file_path, "r") as file_contents:
+    with PathManager.open(file_path, "r") as file_contents:
         for idx, word in enumerate(file_contents):
             vocab[str(idx)] = word.strip()
     return vocab
 
 
 def reader(file_path, vocab):
-    with open(file_path, "r") as reader:
+    with PathManager.open(file_path, "r") as reader:
         for line in reader:
             yield " ".join(
                 vocab.get(s.strip(), UNK)

--- a/pytext/__init__.py
+++ b/pytext/__init__.py
@@ -11,6 +11,7 @@ from caffe2.python.predictor import predictor_exporter
 from pytext.data.sources.data_source import DataSource
 from pytext.task import load
 from pytext.task.new_task import NewTask
+from pytext.utils.file_io import PathManager
 from pytext.workflow import _set_cuda
 
 from .builtin_task import register_builtin_tasks
@@ -59,7 +60,7 @@ def load_config(filename: str) -> PyTextConfig:
     Load a PyText configuration file from a file path.
     See pytext.config.pytext_config for more info on configs.
     """
-    with open(filename) as file:
+    with PathManager.open(filename) as file:
         config_json = json.loads(file.read())
     if "config" not in config_json:
         return pytext_config_from_json(config_json)

--- a/pytext/builtin_task.py
+++ b/pytext/builtin_task.py
@@ -28,6 +28,7 @@ from pytext.task.tasks import (
     SquadQATask,
     WordTaggingTask,
 )
+from pytext.utils.file_io import PathManager
 
 
 USER_TASKS_DIR = "user_tasks"
@@ -42,7 +43,7 @@ def add_include(path):
     all = [
         os.path.basename(f)[:-3].replace("/", ".")
         for f in modules
-        if os.path.isfile(f) and not f.endswith("__init__.py")
+        if PathManager.isfile(f) and not f.endswith("__init__.py")
     ]
     for mod_name in all:
         mod_path = path.replace("/", ".") + "." + mod_name

--- a/pytext/config/test/config_adapter_test.py
+++ b/pytext/config/test/config_adapter_test.py
@@ -9,6 +9,7 @@ import unittest
 from pytext.builtin_task import register_builtin_tasks
 from pytext.config import LATEST_VERSION, pytext_config_from_json
 from pytext.config.config_adapter import ADAPTERS, upgrade_one_version
+from pytext.utils.file_io import PathManager
 
 
 register_builtin_tasks()
@@ -31,7 +32,7 @@ class ConfigAdapterTest(unittest.TestCase):
             os.path.join(os.path.dirname(__file__), "json_config/*.json")
         ):
             print("Trying to upgrade file:" + p)
-            with open(p) as f:
+            with PathManager.open(p) as f:
                 test_data = json.load(f)
                 for test_case in test_data:
                     old_config = test_case["original"]
@@ -44,7 +45,7 @@ class ConfigAdapterTest(unittest.TestCase):
             os.path.join(os.path.dirname(__file__), "json_config/*.json")
         ):
             print("Trying to upgrade file:" + p)
-            with open(p) as f:
+            with PathManager.open(p) as f:
                 test_data = json.load(f)
                 for test_case in test_data:
                     # make sure the config can be instantiated, don't need return value

--- a/pytext/config/test/pytext_all_config_test.py
+++ b/pytext/config/test/pytext_all_config_test.py
@@ -8,6 +8,7 @@ import unittest
 
 from pytext.builtin_task import register_builtin_tasks
 from pytext.config.serialize import parse_config
+from pytext.utils.file_io import PathManager
 from pytext.utils.path import PYTEXT_HOME, get_absolute_path
 
 
@@ -43,7 +44,7 @@ class LoadAllConfigTest(unittest.TestCase):
             if any(filepath.startswith(prefix) for prefix in exclude_json_dir):
                 continue
             print("--- loading:", filepath)
-            with open(filepath) as file:
+            with PathManager.open(filepath) as file:
                 config_json = json.load(file)
                 config = parse_config(config_json)
                 self.assertIsNotNone(config)

--- a/pytext/data/data_handler.py
+++ b/pytext/data/data_handler.py
@@ -4,7 +4,6 @@
 import csv
 import math
 import multiprocessing
-import os
 from copy import deepcopy
 from typing import (
     Any,
@@ -29,6 +28,7 @@ from pytext.data.featurizer import Featurizer
 from pytext.fields import Field, FieldMeta, RawField, VocabUsingField
 from pytext.utils import cuda, distributed, embeddings as embeddings_utils
 from pytext.utils.data import parse_json_array
+from pytext.utils.file_io import PathManager
 from pytext.utils.path import get_absolute_path
 from torchtext import data as textdata
 
@@ -251,8 +251,8 @@ class DataHandler(Component):
         """
         vocab: Set[str] = set()
         vocab_file = get_absolute_path(vocab_file)
-        if os.path.isfile(vocab_file):
-            with open(vocab_file, "r") as f:
+        if PathManager.isfile(vocab_file):
+            with PathManager.open(vocab_file, "r") as f:
                 for i, line in enumerate(f):
                     if vocab_size > 0 and len(vocab) == vocab_size:
                         print(
@@ -737,7 +737,9 @@ class DataHandler(Component):
                 for name, idx in zip(columns_to_use, range(len(columns_to_use)))
             }
 
-        with open(file_name, "r", encoding="utf-8", errors="replace") as f_handle:
+        with PathManager.open(
+            file_name, "r", encoding="utf-8", errors="replace"
+        ) as f_handle:
             csv_reader = csv.reader(f_handle, delimiter="\t", quoting=csv.QUOTE_NONE)
             i = 0
             while True:

--- a/pytext/data/sources/squad.py
+++ b/pytext/data/sources/squad.py
@@ -3,7 +3,6 @@
 
 import json
 import math
-import os
 from typing import List, Optional
 
 from pytext.data.sources.data_source import (
@@ -13,6 +12,7 @@ from pytext.data.sources.data_source import (
     generator_property,
 )
 from pytext.data.sources.tsv import TSV
+from pytext.utils.file_io import PathManager
 from pytext.utils.path import get_absolute_path
 
 
@@ -72,11 +72,11 @@ def _split_document(
 def process_squad_json(fname, ignore_impossible, max_character_length, min_overlap):
     if not fname:
         return
-    if not os.path.exists(fname):
+    if not PathManager.exists(fname):
         print(f"{fname} does not exist. Not unflattening.")
         return
 
-    with open(fname) as infile:
+    with PathManager.open(fname) as infile:
         dump = json.load(infile)
 
     id = 0

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -21,6 +21,7 @@ from pytext.data.tokenizers import Token, Tokenizer
 from pytext.torchscript.tensorizer import VectorNormalizer
 from pytext.utils import cuda, precision
 from pytext.utils.data import Slot
+from pytext.utils.file_io import PathManager
 
 from .utils import (
     BOL,
@@ -425,7 +426,7 @@ class TokenTensorizer(Tensorizer):
 
     def _add_vocab_from_files(self):
         for vocab_file in self.vocab_config.vocab_files:
-            with open(vocab_file.filepath) as f:
+            with PathManager.open(vocab_file.filepath) as f:
                 self.vocab_builder.add_from_file(
                     f,
                     vocab_file.skip_header_line,

--- a/pytext/data/xlm_dictionary.py
+++ b/pytext/data/xlm_dictionary.py
@@ -7,6 +7,7 @@ from logging import getLogger
 
 import numpy as np
 import torch
+from pytext.utils.file_io import PathManager
 
 
 logger = getLogger()
@@ -134,12 +135,12 @@ class Dictionary(object):
         Create a dictionary from a vocabulary file.
         """
         skipped = 0
-        assert os.path.isfile(vocab_path), vocab_path
+        assert PathManager.isfile(vocab_path), vocab_path
         word2id = {BOS_WORD: 0, EOS_WORD: 1, PAD_WORD: 2, UNK_WORD: 3}
         for i in range(SPECIAL_WORDS):
             word2id[SPECIAL_WORD % i] = 4 + i
         counts = {k: 0 for k in word2id.keys()}
-        f = open(vocab_path, "r", encoding="utf-8")
+        f = PathManager.open(vocab_path, "r", encoding="utf-8")
         for i, line in enumerate(f):
             if "\u2028" in line:
                 skipped += 1
@@ -175,7 +176,7 @@ class Dictionary(object):
         """
         Index sentences with a dictionary.
         """
-        if bin_path is not None and os.path.isfile(bin_path):
+        if bin_path is not None and PathManager.isfile(bin_path):
             print("Loading data from %s ..." % bin_path)
             data = torch.load(bin_path)
             assert dico == data["dico"]
@@ -186,7 +187,7 @@ class Dictionary(object):
         unk_words = {}
 
         # index sentences
-        f = open(path, "r", encoding="utf-8")
+        f = PathManager.open(path, "r", encoding="utf-8")
         for i, line in enumerate(f):
             if i % 1000000 == 0 and i > 0:
                 print(i)

--- a/pytext/docs/make_config_docs.py
+++ b/pytext/docs/make_config_docs.py
@@ -11,6 +11,7 @@ import typing
 from pytext.config import ConfigBase, PyTextConfig
 from pytext.config.component import Registry
 from pytext.config.serialize import config_to_json
+from pytext.utils.file_io import PathManager
 from sphinx.ext.napoleon import GoogleDocstring
 from sphinx.pycode import ModuleAnalyzer
 
@@ -320,13 +321,13 @@ def main():
     for config_path, config in ALL_CONFIGS.items():
         file_path = os.path.join(CONFIG_DIR, f"{config_path}.rst")
         print("Creating file", os.path.relpath(file_path, common_prefix))
-        with open(file_path, "w") as config_rst:
+        with PathManager.open(file_path, "w") as config_rst:
             config_rst.write(format_config_rst(config))
 
     for package, subpackages, configs in toctree_files(ALL_CONFIGS):
         file_path = os.path.join(CONFIG_DIR, f"{package}.rst")
         print("Creating file", os.path.relpath(file_path, common_prefix))
-        with open(file_path, "w") as toctree_file:
+        with PathManager.open(file_path, "w") as toctree_file:
             toctree_file.write(format_toctree_rst(package, subpackages, configs))
 
 

--- a/pytext/exporters/custom_exporters.py
+++ b/pytext/exporters/custom_exporters.py
@@ -11,10 +11,11 @@ from pytext.config.module_config import ExporterType
 from pytext.exporters.exporter import ModelExporter
 from pytext.fields import FieldMeta
 from pytext.utils import mobile_onnx
+from pytext.utils.file_io import PathManager
 
 
 def save_caffe2_pb_net(path, model):
-    with open(path, "wb") as f:
+    with PathManager.open(path, "wb") as f:
         f.write(model.SerializeToString())
 
 

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -32,6 +32,7 @@ from pytext.utils.documentation import (
     pretty_print_config_class,
     replace_components,
 )
+from pytext.utils.file_io import PathManager
 from pytext.workflow import (
     export_saved_model_to_caffe2,
     export_saved_model_to_torchscript,
@@ -206,7 +207,7 @@ def main(context, config_file, config_json, config_module, include):
                 context.obj.config = import_module(config_module).config
             else:
                 if config_file:
-                    with open(config_file) as file:
+                    with PathManager.open(config_file) as file:
                         config = json.load(file)
                 elif config_json:
                     config = json.loads(config_json)

--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import torch
 from pytext.common.constants import Stage
+from pytext.utils.file_io import PathManager
 from torch.utils.tensorboard import SummaryWriter
 
 
@@ -119,7 +120,7 @@ class FileChannel(Channel):
         *args,
     ):
         print(f"saving result to file {self.file_path}")
-        with open(self.file_path, "w", encoding="utf-8") as of:
+        with PathManager.open(self.file_path, "w", encoding="utf-8") as of:
             tsv_writer = csv.writer(
                 of,
                 delimiter="\t",

--- a/pytext/models/representations/huggingface_bert_sentence_encoder.py
+++ b/pytext/models/representations/huggingface_bert_sentence_encoder.py
@@ -9,6 +9,7 @@ from pytext.config import ConfigBase
 from pytext.models.representations.transformer_sentence_encoder_base import (
     TransformerSentenceEncoderBase,
 )
+from pytext.utils.file_io import PathManager
 from pytorch_pretrained_bert.modeling import BertConfig, BertModel
 
 
@@ -35,7 +36,7 @@ class HuggingFaceBertSentenceEncoder(TransformerSentenceEncoderBase):
         model = BertModel(bert_config)
         weights_path = os.path.join(config.bert_cpt_dir, "pytorch_model.bin")
         # load pre-trained weights if weights_path exists
-        if config.load_weights and os.path.isfile(weights_path):
+        if config.load_weights and PathManager.isfile(weights_path):
             state_dict = torch.load(weights_path)
 
             missing_keys: List[str] = []

--- a/pytext/torchscript/tokenizer/bpe.py
+++ b/pytext/torchscript/tokenizer/bpe.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 
 import torch
 from pytext.torchscript.utils import utf8_chars
+from pytext.utils.file_io import PathManager
 
 
 class ScriptBPE(torch.jit.ScriptModule):
@@ -64,7 +65,7 @@ class ScriptBPE(torch.jit.ScriptModule):
 
     @classmethod
     def from_vocab_filename(cls, vocab_filename: str) -> "ScriptBPE":
-        with open(vocab_filename) as vocab_file:
+        with PathManager.open(vocab_filename) as vocab_file:
             return cls(cls.load_vocab(vocab_file))
 
     @staticmethod

--- a/pytext/utils/file_io.py
+++ b/pytext/utils/file_io.py
@@ -16,13 +16,13 @@ except ImportError:
 
     class PathManager:
         @staticmethod
-        def open(path: str, mode: str = "r"):
-            return open(path, mode)
+        def open(*args, **kwargs):
+            return open(*args, **kwargs)
 
         @staticmethod
-        def copy(src_path: str, dst_path: str, overwrite: bool = False) -> bool:
+        def copy(*args, **kwargs) -> bool:
             try:
-                shutil.copyfile(src_path, dst_path)
+                shutil.copyfile(*args, **kwargs)
                 return True
             except Exception as e:
                 print("Error in file copy - {}".format(str(e)))
@@ -49,9 +49,9 @@ except ImportError:
             return os.listdir(path)
 
         @staticmethod
-        def mkdirs(path: str):
-            os.makedirs(path, exist_ok=True)
+        def mkdirs(*args, **kwargs):
+            os.makedirs(*args, exist_ok=True, **kwargs)
 
         @staticmethod
-        def rm(path: str):
-            os.remove(path)
+        def rm(*args, **kwargs):
+            os.remove(*args, **kwargs)

--- a/pytext/utils/path.py
+++ b/pytext/utils/path.py
@@ -2,15 +2,17 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import os
 
+from pytext.utils.file_io import PathManager
+
 
 def get_pytext_home():
     internal_home = os.path.realpath(os.path.join(__file__, "../../"))
     oss_home = os.path.realpath(os.path.join(__file__, "../../../"))
     default_home = ""
     # use tests as anchor which will always in PYTEXT_HOME/tests
-    if os.path.exists(os.path.join(internal_home, "tests")):
+    if PathManager.exists(os.path.join(internal_home, "tests")):
         default_home = internal_home
-    elif os.path.exists(os.path.join(oss_home, "tests")):
+    elif PathManager.exists(os.path.join(oss_home, "tests")):
         default_home = oss_home
     else:
         # when PyText is used as a module and packed as part of a single file X
@@ -29,6 +31,6 @@ def get_absolute_path(file_path: str) -> str:
     if os.path.isabs(file_path):
         return file_path
     absolute_path = os.path.realpath(os.path.join(PYTEXT_HOME, file_path))
-    if os.path.exists(absolute_path):
+    if PathManager.exists(absolute_path):
         return absolute_path
     return file_path

--- a/pytext/utils/tests/utils_test.py
+++ b/pytext/utils/tests/utils_test.py
@@ -15,6 +15,7 @@ from pytext.utils.data import (
     unkify,
 )
 from pytext.utils.distributed import get_shard_range
+from pytext.utils.file_io import PathManager
 from pytext.utils.meter import TimeMeter
 from pytext.utils.test import import_tests_module
 
@@ -24,7 +25,7 @@ RAW_TEST_PATH = tests_module.test_file("test_music_samples.json")
 
 
 def get_test_sample():
-    with open(RAW_TEST_PATH, "r") as f:
+    with PathManager.open(RAW_TEST_PATH, "r") as f:
         data = json.load(f)
     return data
 

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -310,7 +310,9 @@ def get_logits(
         task.data.sort_key = None
         batches = task.data.batches(Stage.TEST, data_source=data_source)
 
-        with open(output_path, "w", encoding="utf-8") as fout, torch.no_grad():
+        with PathManager.open(
+            output_path, "w", encoding="utf-8"
+        ) as fout, torch.no_grad():
             for (raw_batch, tensor_dict) in batches:
                 raw_input_tuple = (
                     dict_zip(*raw_batch, value_only=True) if dump_raw_input else ()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -6,6 +6,7 @@ import unittest
 from click.testing import CliRunner
 from pytext.main import main
 from pytext.utils import test
+from pytext.utils.file_io import PathManager
 from pytext.utils.path import PYTEXT_HOME
 
 
@@ -19,7 +20,7 @@ class TestMain(unittest.TestCase):
     def run_from_command(self, args, config_filename):
         runner = CliRunner()
         config_path = os.path.join(tests_module.TEST_CONFIG_DIR, config_filename)
-        with open(config_path, "r") as f:
+        with PathManager.open(config_path, "r") as f:
             config_str = f.read()
         return runner.invoke(main, args=args, input=config_str)
 


### PR DESCRIPTION
Summary: Any I/O API X (open, exists, isfile, etc) need to use "PathManager.X()", such that either file, manifold uri, http uri, etc can be supported in PyText without any code changes(handle for each storage type)

Differential Revision: D19085748

