### PR TITLE
Fix CircleCI failure caused by black and regex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ onnx==1.5.0
 python-dateutil==2.8.0
 pandas
 pytorch-pretrained-bert
+regex==2019.11.1
 requests
 scipy
-torchtext
+sentencepiece
 tensorboard==1.14
 torch
-sentencepiece
+torchtext


### PR DESCRIPTION
Summary:
CircleCI failed due to a recent change in regex, black detected it and broke the CircleCI
https://github.com/psf/black/issues/1207

Workaround: pin regex version to last working version

Differential Revision: D19129020

