### PR TITLE
Make tensorboard robust to NaN and Inf in model params

### DIFF
--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -230,12 +230,28 @@ class TensorBoardChannel(Channel):
                     limit = 9.9e19
                     grad = val.grad
                     val = torch.clamp(val.float(), -limit, limit)
-                    self.summary_writer.add_histogram(key, val, epoch)
+                    try:
+                        self.summary_writer.add_histogram(key, val, epoch)
+                    except Exception:
+                        print(
+                            f"WARNING: Param {key} cannot be sent to Tensorboard",
+                            file=sys.stderr,
+                        )
+                        traceback.print_exc(file=sys.stderr)
+
                     if grad is not None and len(grad) > 0 and not (grad == 0).all():
                         grad = torch.clamp(grad.float(), -limit, limit)
-                        self.summary_writer.add_histogram(
-                            key + "_gradients", grad, epoch
-                        )
+                        try:
+                            self.summary_writer.add_histogram(
+                                key + "_gradients", grad, epoch
+                            )
+                        except Exception:
+                            print(
+                                f"WARNING: Grad for param {key} "
+                                "cannot be sent to Tensorboard",
+                                file=sys.stderr,
+                            )
+                            traceback.print_exc(file=sys.stderr)
 
     def add_texts(self, tag, metrics):
         """

--- a/pytext/metric_reporters/tests/tensorboard_test.py
+++ b/pytext/metric_reporters/tests/tensorboard_test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from unittest import TestCase
+
+from pytext.common.constants import Stage
+from pytext.metric_reporters.channel import TensorBoardChannel
+from torch import nn, optim
+
+
+class FCModelWithNanAndInfWts(nn.Module):
+    """ Simple FC model
+    """
+
+    def __init__(self):
+        super(FCModelWithNanAndInfWts, self).__init__()
+        self.fc1 = nn.Linear(10, 5)
+        self.fc2 = nn.Linear(5, 3)
+        self.fc1.weight.data.fill_(float("NaN"))
+        self.fc2.weight.data.fill_(float("Inf"))
+
+    def forward(self, x):
+        x = self.fc1(x)
+        return self.fc2(x)
+
+
+class TensorboardTest(TestCase):
+    def test_report_metrics_with_nan(self):
+        """ Check that tensorboard channel catches errors when model has
+            Inf or NaN weights
+        """
+        tensorboard_channel = TensorBoardChannel()
+        # create simple model and optimizers
+        model = FCModelWithNanAndInfWts()
+
+        optimizer = optim.SGD(model.parameters(), lr=0.1)
+        tensorboard_channel.report(
+            stage=Stage.TRAIN,
+            epoch=1,
+            metrics=0.0,
+            model_select_metric=0.0,
+            loss=1.0,
+            preds=[1],
+            targets=[1],
+            scores=[1],
+            context={},
+            meta={},
+            model=model,
+            optimizer=optimizer,
+        )


### PR DESCRIPTION
Summary:
PyText FBLearner training runs with `tensorboard` will fail if the model has any `NaN` or `Inf` parameters during training with the following error:
`ValueError: The histogram is empty, please file a bug report.`

NaN/Inf params show up quite often in hyperparam sweep runs if a bad initial value of hyperparam is chosen.
When this happens, the whole sweep can fail.

Some examples just from the past two days:
f156398891
f156398480
f156398264
f156399047
f156399125

This diff:
- Catches tensorboard exceptions, and prints an error to stderr. Note that `TensordboardChannel` already catches some exceptions while exporting the model
- Adds a unit-test with a model that has `NaN` and `Inf` parameters, to verify no Tensorboard errors

Reviewed By: psuzhanhy

Differential Revision: D19048506

