### PR TITLE
Exit LM task if special token exists in text for ByteTensorizer

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -2,6 +2,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import contextlib
+import copy
+import sys
 from typing import List, Optional
 
 import torch
@@ -513,6 +515,7 @@ class ByteTensorizer(Tensorizer):
     def numberize(self, row):
         """Convert text to characters."""
         text = row[self.text_column].strip()
+
         if self.lower:
             text = text.lower()
 
@@ -522,8 +525,18 @@ class ByteTensorizer(Tensorizer):
             bytes = bytes[: self.max_seq_len]
         if self.add_bos_token:
             bos = BYTE_EOS if self.use_eos_token_for_bos else BYTE_BOS
+            if bos in text:
+                print('Special token "{}" exists in text "{}". Exit.'.format(bos, text))
+                sys.exit(1)
             bytes = list(bos.encode()) + bytes
         if self.add_eos_token:
+            if BYTE_EOS in text:
+                print(
+                    'Special token "{}" exists in text "{}". Exit.'.format(
+                        BYTE_EOS, text
+                    )
+                )
+                sys.exit(1)
             bytes = bytes + list(BYTE_EOS.encode())
         return bytes, len(bytes)
 

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -248,6 +248,21 @@ class TensorizersTest(unittest.TestCase):
         tensors = [tensorizer.numberize(row) for row in rows]
         self.assertEqual([(bytes, len(bytes)) for bytes in expected], tensors)
 
+    def test_byte_tensors_error_code(self):
+        tensorizer = ByteTensorizer(
+            text_column="text", lower=False, add_bos_token=True, add_eos_token=True
+        )
+        s1 = "I want some coffee#"
+        s2 = "This is ^the best show I've ever seen"
+
+        rows = [{"text": s1}, {"text": s2}]
+        expected_error_code = 1
+        with self.assertRaises(SystemExit) as cm:
+            for row in rows:
+                tensorizer.numberize(row)
+
+        self.assertEqual(cm.exception.code, expected_error_code)
+
     def test_create_byte_token_tensors(self):
         tensorizer = ByteTokenTensorizer(
             text_column="text", max_seq_len=4, max_byte_len=5


### PR DESCRIPTION
Summary:
1. In Language Model task, if data contains BYTE_BOS or BYTE_EOS special tokens, exit and print out the message. This will prevent training from failing silently.
2. Add a test

Reviewed By: kmalik22

Differential Revision: D19084083

