### PR TITLE
Back out "Back out "[PyText][Unify Tensorizer and ScriptTensorizer][4/x] Use TensorizerImpl for both training and inference for BERT, RoBERTa and XLM tensorizer""

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -1,30 +1,20 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import itertools
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from fairseq.data.dictionary import Dictionary
 from fairseq.data.legacy.masked_lm_dictionary import BertDictionary
 from pytext.config.component import ComponentType, create_component
-from pytext.data.tensorizers import Tensorizer, TensorizerScriptImpl, lookup_tokens
+from pytext.data.tensorizers import Tensorizer, TensorizerScriptImpl
 from pytext.data.tokenizers import Tokenizer, WordPieceTokenizer
-from pytext.data.utils import (
-    BOS,
-    EOS,
-    MASK,
-    PAD,
-    UNK,
-    SpecialToken,
-    Vocabulary,
-    pad_and_tensorize,
-)
-from pytext.torchscript.tensorizer import ScriptBERTTensorizer
+from pytext.data.utils import BOS, EOS, MASK, PAD, UNK, SpecialToken, Vocabulary
 from pytext.torchscript.tensorizer.tensorizer import VocabLookup
 from pytext.torchscript.utils import pad_2d, pad_2d_mask
 from pytext.torchscript.vocab import ScriptVocabulary
 from pytext.utils.file_io import PathManager
+from pytext.utils.lazy import lazy_property
 
 
 def build_fairseq_vocab(
@@ -294,46 +284,11 @@ class BERTTensorizerBase(Tensorizer):
     def column_schema(self):
         return [(column, str) for column in self.columns]
 
-    def _lookup_tokens(self, text: str, seq_len: int = None):
-        """
-        This function knows how to call lookup_tokens with the correct
-        settings for this model. The default behavior is to wrap the
-        numberized text with distinct BOS and EOS tokens. The resulting
-        vector would look something like this:
-            [BOS, token1_id, . . . tokenN_id, EOS]
-
-        The function also takes an optional seq_len parameter which is
-        used to customize truncation in case we have multiple text fields.
-        By default max_seq_len is used. It's upto the numberize function of
-        the class to decide how to use the seq_len param.
-
-        For example:
-        - In the case of sentence pair classification, we might want both
-        pieces of text have the same length which is half of the
-        max_seq_len supported by the model.
-        - In the case of QA, we might want to truncate the context by a
-        seq_len which is longer than what we use for the question.
-        """
-        return lookup_tokens(
-            text,
-            tokenizer=self.tokenizer,
-            vocab=self.vocab,
-            bos_token=self.vocab.bos_token,
-            eos_token=self.vocab.eos_token,
-            max_seq_len=seq_len if seq_len else self.max_seq_len,
+    @lazy_property
+    def tensorizer_script_impl(self):
+        return self.__TENSORIZER_SCRIPT_IMPL__(
+            tokenizer=self.tokenizer, vocab=self.vocab, max_seq_len=self.max_seq_len
         )
-
-    def _wrap_numberized_text(
-        self, numberized_sentences: List[List[str]]
-    ) -> List[List[str]]:
-        """
-        If a class has a non-standard way of generating the final numberized text
-        (eg: BERT) then a class specific version of wrap_numberized_text function
-        should be implemented. This allows us to share the numberize
-        function across classes without having to copy paste code. The default
-        implementation doesnt do anything.
-        """
-        return numberized_sentences
 
     def numberize(self, row: Dict) -> Tuple[Any, ...]:
         """
@@ -341,27 +296,16 @@ class BERTTensorizerBase(Tensorizer):
         the specified vocab. It also outputs, for each instance, the vectors
         needed to run the actual model.
         """
-        sentences = [self._lookup_tokens(row[column])[0] for column in self.columns]
-        sentences = self._wrap_numberized_text(sentences)
-        seq_lens = (len(sentence) for sentence in sentences)
-        segment_labels = ([i] * seq_len for i, seq_len in enumerate(seq_lens))
-        tokens = list(itertools.chain(*sentences))
-        segment_labels = list(itertools.chain(*segment_labels))
-        seq_len = len(tokens)
-        positions = list(range(seq_len))
-        # tokens, segment_label, seq_len
-        return tokens, segment_labels, seq_len, positions
+        per_sentence_tokens = [
+            self.tokenizer.tokenize(row[column]) for column in self.columns
+        ]
+        return self.tensorizer_script_impl.numberize(per_sentence_tokens)
 
     def tensorize(self, batch) -> Tuple[torch.Tensor, ...]:
         """
         Convert instance level vectors into batch level tensors.
         """
-        tokens, segment_labels, seq_lens, positions = zip(*batch)
-        tokens = pad_and_tensorize(tokens, self.vocab.get_pad_index())
-        pad_mask = (tokens != self.vocab.get_pad_index()).long()
-        segment_labels = pad_and_tensorize(segment_labels)
-        positions = pad_and_tensorize(positions)
-        return tokens, pad_mask, segment_labels, positions
+        return self.tensorizer_script_impl.tensorize_wrapper(*zip(*batch))
 
     def initialize(self, vocab_builder=None, from_scratch=True):
         # vocab for BERT is already set
@@ -454,32 +398,4 @@ class BERTTensorizer(BERTTensorizerBase):
     ) -> None:
         super().__init__(
             columns=columns, vocab=vocab, tokenizer=tokenizer, max_seq_len=max_seq_len
-        )
-
-    def _lookup_tokens(self, text: str, seq_len: int = None):
-        return lookup_tokens(
-            text,
-            tokenizer=self.tokenizer,
-            vocab=self.vocab,
-            bos_token=None,
-            eos_token=self.vocab.eos_token,
-            max_seq_len=seq_len if seq_len else self.max_seq_len,
-        )
-
-    def _wrap_numberized_text(
-        self, numberized_sentences: List[List[str]]
-    ) -> List[List[str]]:
-        numberized_sentences[0] = [self.vocab.get_bos_index()] + numberized_sentences[0]
-        return numberized_sentences
-
-    def torchscriptify(self):
-        return ScriptBERTTensorizer(
-            tokenizer=self.tokenizer.torchscriptify(),
-            vocab=ScriptVocabulary(
-                list(self.vocab),
-                pad_idx=self.vocab.get_pad_index(),
-                bos_idx=self.vocab.get_bos_index(),
-                eos_idx=self.vocab.get_eos_index(),
-            ),
-            max_seq_len=self.max_seq_len,
         )

--- a/pytext/data/roberta_tensorizer.py
+++ b/pytext/data/roberta_tensorizer.py
@@ -59,18 +59,6 @@ class RoBERTaTensorizer(BERTTensorizerBase):
             base_tokenizer=base_tokenizer,
         )
 
-    def torchscriptify(self):
-        return ScriptRoBERTaTensorizer(
-            tokenizer=self.tokenizer.torchscriptify(),
-            vocab=ScriptVocabulary(
-                list(self.vocab),
-                pad_idx=self.vocab.get_pad_index(),
-                bos_idx=self.vocab.get_bos_index(),
-                eos_idx=self.vocab.get_eos_index(),
-            ),
-            max_seq_len=self.max_seq_len,
-        )
-
 
 class RoBERTaTokenLevelTensorizer(RoBERTaTensorizer):
     """
@@ -199,3 +187,15 @@ class RoBERTaTokenLevelTensorizer(RoBERTaTensorizer):
         positions = pad_and_tensorize(positions)
         padded_labels = pad_and_tensorize(labels, self.labels_pad_idx)
         return tokens, pad_mask, segment_labels, positions, padded_labels
+
+    def torchscriptify(self):
+        return ScriptRoBERTaTensorizer(
+            tokenizer=self.tokenizer.torchscriptify(),
+            vocab=ScriptVocabulary(
+                list(self.vocab),
+                pad_idx=self.vocab.get_pad_index(),
+                bos_idx=self.vocab.get_bos_index(),
+                eos_idx=self.vocab.get_eos_index(),
+            ),
+            max_seq_len=self.max_seq_len,
+        )

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -23,6 +23,7 @@ from pytext.data.tokenizers import Token, Tokenizer
 from pytext.torchscript.tensorizer import VectorNormalizer
 from pytext.utils import cuda, precision
 from pytext.utils.data import Slot
+from pytext.utils.lazy import lazy_property
 
 from .utils import (
     BOL,
@@ -271,8 +272,20 @@ class Tensorizer(Component):
         # we need yield here to make this function a generator
         yield
 
-    def torchscriptify(self):
+    @lazy_property
+    def tensorizer_script_impl(self):
+        # Script tensorizer is unpickleable, we use lazy_property for
+        # lazy initialization to construct the object during run time.
         raise NotImplementedError
+
+    def __getstate__(self):
+        # make a shallow copy of state to avoid side effect on the original object
+        state = copy.copy(vars(self))
+        state.pop("tensorizer_script_impl", None)
+        return state
+
+    def torchscriptify(self):
+        return self.tensorizer_script_impl.torchscriptify()
 
 
 class VocabFileConfig(Component.Config):

--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -37,7 +37,7 @@ class ScriptTextModule(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, texts: List[str]):
-        input_tensors = self.tensorizer.tensorize(texts=squeeze_1d(texts))
+        input_tensors = self.tensorizer(texts=squeeze_1d(texts))
         logits = self.model(input_tensors)
         return self.output_layer(logits)
 
@@ -56,7 +56,7 @@ class ScriptTokenModule(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, tokens: List[List[str]]):
-        input_tensors = self.tensorizer.tensorize(tokens=squeeze_2d(tokens))
+        input_tensors = self.tensorizer(pre_tokenized=squeeze_2d(tokens))
         logits = self.model(input_tensors)
         return self.output_layer(logits)
 
@@ -75,8 +75,8 @@ class ScriptTokenLanguageModule(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, tokens: List[List[str]], languages: Optional[List[str]] = None):
-        input_tensors = self.tensorizer.tensorize(
-            tokens=squeeze_2d(tokens), languages=squeeze_1d(languages)
+        input_tensors = self.tensorizer(
+            pre_tokenized=squeeze_2d(tokens), languages=squeeze_1d(languages)
         )
         logits = self.model(input_tensors)
         return self.output_layer(logits)
@@ -101,8 +101,8 @@ class ScriptTokenLanguageModuleWithDenseFeature(ScriptModule):
         dense_feat: List[List[float]],
         languages: Optional[List[str]] = None,
     ):
-        input_tensors = self.tensorizer.tensorize(
-            tokens=squeeze_2d(tokens), languages=squeeze_1d(languages)
+        input_tensors = self.tensorizer(
+            pre_tokenized=squeeze_2d(tokens), languages=squeeze_1d(languages)
         )
         logits = self.model(input_tensors, torch.tensor(dense_feat).float())
         return self.output_layer(logits)

--- a/pytext/utils/lazy.py
+++ b/pytext/utils/lazy.py
@@ -8,6 +8,26 @@ import torch
 from torch import nn
 
 
+class lazy_property(object):
+    """
+    More or less copy-pasta: http://stackoverflow.com/a/6849299
+    Meant to be used for lazy evaluation of an object attribute.
+    property should represent non-mutable data, as it replaces itself.
+    """
+
+    def __init__(self, fget):
+        self._fget = fget
+        self.__doc__ = fget.__doc__
+        self.__name__ = fget.__name__
+
+    def __get__(self, obj, obj_cls_type):
+        if obj is None:
+            return None
+        value = self._fget(obj)
+        setattr(obj, self.__name__, value)
+        return value
+
+
 class UninitializedLazyModuleError(Exception):
     """A lazy module was used improperly."""
 


### PR DESCRIPTION
Summary: Original commit changeset: e22e20a33707

Differential Revision: D19164896

