### PR TITLE
support using RoundRobin ProcessGroup in Distributed training

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -91,6 +91,8 @@ class PyTextConfig(ConfigBase):
     use_fp16: bool = False
     # Total Number of GPUs to run the training on (for CPU jobs this has to be 1)
     distributed_world_size: int = 1
+    # Total number of GPU streams for gradient sync in distributed training
+    gpu_streams_for_distributed_training: int = 1
     # load either model or checkpoint(model + config + training_state etc)
     # load model file for inference only, load checkpont file to continue training
     load_snapshot_path: str = ""

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -27,7 +27,7 @@ from pytext.optimizer.scheduler import Scheduler
 from pytext.optimizer.sparsifiers.sparsifier import Sparsifier
 from pytext.task.serialize import save
 from pytext.trainers.training_state import TrainingState
-from pytext.utils import cuda, precision, timing
+from pytext.utils import cuda, distributed, precision, timing
 
 
 class TrainerBase(Component):
@@ -173,6 +173,7 @@ class Trainer(TrainerBase):
                 output_device=device_id,
                 broadcast_buffers=False,
                 find_unused_parameters=state.model.find_unused_parameters,
+                process_group=distributed._round_robin_process_group,
             )
         state.start_time = time.time()
 

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -66,10 +66,12 @@ def _set_fp16(use_fp16: bool, rank: int) -> None:
 
 
 def _set_distributed(
-    rank: int, world_size: int, dist_init_url: str, device_id: int
+    rank: int, world_size: int, dist_init_url: str, device_id: int, gpu_streams: int = 1
 ) -> None:
     if dist_init_url and world_size > 1:
-        distributed.dist_init(rank, world_size, dist_init_url, device_id)
+        distributed.dist_init(
+            rank, world_size, dist_init_url, device_id, gpu_streams=gpu_streams
+        )
 
 
 def prepare_task_metadata(config: PyTextConfig) -> CommonMetadata:
@@ -120,7 +122,13 @@ def prepare_task(
         print("\nParameters: {}\n".format(config), flush=True)
     _set_cuda(config.use_cuda_if_available, device_id, world_size)
     _set_fp16(config.use_fp16, rank)
-    _set_distributed(rank, world_size, dist_init_url, device_id)
+    _set_distributed(
+        rank,
+        world_size,
+        dist_init_url,
+        device_id,
+        config.gpu_streams_for_distributed_training,
+    )
 
     if config.random_seed is not None:
         set_random_seeds(config.random_seed, config.use_deterministic_cudnn)


### PR DESCRIPTION
Summary:
support using RoundRobin ProcessGroup in Distributed training
RoundRobin ProcessGroup will use multi-stream for gradient sync.

Usually it could give us 15%+ speed up with no gradient accumulation.

Reviewed By: hudeven

Differential Revision: D19138726

