### PR TITLE
tidy file path in help text for invocation of docnn.json example

### DIFF
--- a/pytext/docs/source/train_your_first_model.rst
+++ b/pytext/docs/source/train_your_first_model.rst
@@ -18,7 +18,7 @@ You can use PyText as a library either in your own scripts or in a Jupyter noteb
 
     Example:
 
-      pytext train < demos/docnn.json
+      pytext train < demo/configs/docnn.json
 
   Options:
     --config-file TEXT

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -191,7 +191,7 @@ def main(context, config_file, config_json, config_module, include):
 
     Example:
 
-      pytext train < demos/docnn.json
+      pytext train < demo/configs/docnn.json
     """
     for path in include or []:
         # remove possible trailing / from autocomplete in --include


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Help text in docs and for pytext executable had an incorrect file path for the example config file.

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

Tested via docker

```shell
docker run --rm -it --gpus all --entrypoint=/bin/bash --net host pytorch/pytorch:1.3-cuda10.1-cudnn7-runtime

export LC_ALL=C.UTF-8
export LANG=C.UTF-8

apt update && \
  apt install -y cmake protobuf-compiler libprotoc-dev ssh

git clone http://github.com/mgoldey/pytext.git

cd pytext
git checkout mgoldey/FixHelpText

source activation_venv && \
pip install torch pytest && \
./install_deps && \
python3 setup.py build && \
python3 setup.py install && \
python3 setup.py test

```

Output
```text
----------------------------------------------------------------------
Ran 81 tests in 5.945s

OK
```

I've confirmed in that docker container that `pytext --help` gives
```shell
    pytext train < demo/configs/docnn.json
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
Enforced via black and isort invocations per CONTRIBUTING.md
- [X] My change requires a change to the documentation.
This is a change to the documentation
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
~- [ ] I have added tests to cover my changes.~ N/A
~- [ ] All new and existing tests passed.~ N/A
