### PR TITLE
PyText option to disable CUDA when testing.

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -129,6 +129,12 @@ class PyTextConfig(ConfigBase):
     include_dirs: Optional[List[str]] = None
     # config version
     version: int
+    # Use CUDA for testing. Set to false for models where testing on CPU is
+    # preferred. This option allows one to train on GPU and test on CPU by
+    # setting use_cuda_if_available=True and use_cuda_for_testing=False. Note
+    # that if use_cuda_if_available=False or CUDA is not available, this
+    # parameter has no effect.
+    use_cuda_for_testing: bool = True
 
     # TODO these two configs are only kept only to be backward comptible with
     # RNNG, should be removed once RNNG refactoring is done

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -344,7 +344,9 @@ def _get_model_snapshot(context, model_snapshot, use_cuda, use_tensorboard):
         print(f"No model snapshot provided, loading from config")
         config = context.obj.load_config()
         model_snapshot = config.save_snapshot_path
-        use_cuda = config.use_cuda_if_available
+        use_cuda = config.use_cuda_if_available and getattr(
+            config, "use_cuda_for_testing", True
+        )
         use_tensorboard = config.use_tensorboard
         print(f"Configured model snapshot {model_snapshot}")
     return model_snapshot, use_cuda, use_tensorboard


### PR DESCRIPTION
Summary: Useful for models that have optimized CPU operators for inference, but which we still want to train on GPU.

Differential Revision: D19275453

