### PR TITLE
Printing out error's underlying reason

### DIFF
--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -86,7 +86,11 @@ def _union_from_json(subclasses, json_obj):
         return _value_from_json(subclasses_dict[type_name], json_obj)
     except Exception as e:
         raise UnionTypeError(
-            f"failed to parse union {subclasses} from json payload {json_obj}"
+            (
+                f"failed to parse union {subclasses} from"
+                f"json payload {json_obj} \n"
+                f"Reason: {e}"
+            )
         ) from e
 
 


### PR DESCRIPTION
Summary:
Even though the root exception is added in the "raise from" clause, the logs don't show the underlying root cause.

It's faster to find problems if we print it out this way

Reviewed By: hikushalhere

Differential Revision: D19171878

