### PR TITLE
Add support for returning start & end indices.

### DIFF
--- a/pytext/data/test/tokenizers_test.py
+++ b/pytext/data/test/tokenizers_test.py
@@ -69,17 +69,17 @@ class SentencePieceTokenizerTest(unittest.TestCase):
     def test_tokenize(self):
         sentence = "Testing out sentencepiece"
         expected = [
-            "▁T",
-            "est",
-            "ing",
-            "▁out",
-            "▁sen",
-            "t",
-            "ence",
-            "p",
-            "i",
-            "e",
-            "ce",
+            Token(value="▁T", start=0, end=1),
+            Token(value="est", start=1, end=4),
+            Token(value="ing", start=4, end=7),
+            Token(value="▁out", start=8, end=11),
+            Token(value="▁sen", start=12, end=15),
+            Token(value="t", start=15, end=16),
+            Token(value="ence", start=16, end=20),
+            Token(value="p", start=20, end=21),
+            Token(value="i", start=21, end=22),
+            Token(value="e", start=22, end=23),
+            Token(value="ce", start=23, end=25),
         ]
         sp_tokenizer = SentencePieceTokenizer.from_config(
             SentencePieceTokenizer.Config(
@@ -87,5 +87,4 @@ class SentencePieceTokenizerTest(unittest.TestCase):
             )
         )
         tokens = sp_tokenizer.tokenize(sentence)
-        tokens = [token.value for token in tokens]
         self.assertEqual(tokens, expected)

--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -274,7 +274,15 @@ class SentencePieceTokenizer(Tokenizer, CppProcessorMixin):
 
     def tokenize(self, input_str: str) -> List[Token]:
         pieces = self.processor.EncodeAsPieces(input_str)
-        return [Token(piece, -1, -1) for piece in pieces]
+        tokens = []
+        # calculate start and end indices of each piece.
+        end = 0
+        for piece in pieces:
+            original_piece = piece.lstrip("\u2581")
+            start = input_str.find(original_piece, end)
+            end = start + len(original_piece)
+            tokens.append(Token(piece, start, end))
+        return tokens
 
     def _load_processor(self):
         self.processor = SentencePieceProcessor()


### PR DESCRIPTION
Summary:
The SentencePieceTokenizer currently returns -1s as start and end indices. This diff adds support for returning the correct start and end indices which would be useful for some word tagging and span extraction models.

SPM tokenizes the first piece of every word by prefixing a separator character "\u2581" which looks like "▁". For example, see the expected tokens in the attached unit test.
We need to strip this character off to get the original token in order to locate it and compute the correct start and end index.

Reviewed By: chenyangyu1988

Differential Revision: D19626317

