### PR TITLE
Vocab Limited Pretrained Embedding [2/5]

### DIFF
--- a/pytext/utils/embeddings.py
+++ b/pytext/utils/embeddings.py
@@ -64,6 +64,9 @@ class PretrainedEmbedding(object):
             self.stoi = {}  # type: Dict[str, int]
             self.embedding_vectors = None  # type: torch.Tensor
 
+    def filter_criteira(self, token: str) -> bool:
+        return True
+
     def load_pretrained_embeddings(
         self,
         raw_embeddings_path: str,
@@ -108,7 +111,7 @@ class PretrainedEmbedding(object):
                         # lowercase here so that returned matrix doesn't contain
                         # the same token twice (lower and upper cases).
                         token = token.lower()
-                    if token not in tokens:
+                    if token not in tokens and self.filter_criteira(token):
                         chunk_vocab.append(token)
                         for item in split_line[1:]:
                             yield dtype(item)


### PR DESCRIPTION
Summary: In local bento experiments, often nearest neighbors / items nearby in the embedding space tended to be misspellings of the original word. This isn't really useful for spoken language since there won't be many misspellings, so instead this diff adds a subclass of `PretrainedEmbeddings` that restricts the embedding space to only contain known vocab words. From local experiments, the results here seem much more consistent with what is expected from kNN in the embedding space.

Reviewed By: geof90

Differential Revision: D19818803

