### PR TITLE
support diffrent features for teacher and student model in PyTextTransformer

### DIFF
--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -49,6 +49,8 @@ class MetricReporter(Component):
     class Config(ConfigBase):
         output_path: str = "/tmp/test_out.txt"
         pep_format: bool = False
+        #: Useful for KD training, column names that used by student but not teacher.
+        student_column_names: List[str] = []
 
     def __init__(self, channels, pep_format=False) -> None:
         self._reset()

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -127,9 +127,11 @@ class _NewTask(TaskBase):
     def _init_tensorizers(cls, config: Config, tensorizers=None, rank=0, world_size=1):
         # Pull extra columns from the metric reporter config to pass into
         # the data source schema.
-        extra_columns = list(
-            getattr(config.metric_reporter, "text_column_names", ())
-        ) + list(getattr(config.metric_reporter, "additional_column_names", ()))
+        extra_columns = (
+            getattr(config.metric_reporter, "text_column_names", [])
+            + getattr(config.metric_reporter, "additional_column_names", [])
+            + getattr(config.metric_reporter, "student_column_names", [])
+        )
         extra_schema = {column: Any for column in extra_columns}
 
         init_tensorizers = not tensorizers


### PR DESCRIPTION
Summary:
support diffrent features for teacher and student model in PyTextTransformer
- Knowledge distilltion training:
    You need to create 2 PyTextTransformer for KD training (one for teacher and
    the other for student), and you should only pass the student transformer to
    your domains.

    For example:
    teacher_transformer = PyTextTransformer(
        features=teacher_features,
    )
    student_transformer = PyTextTransformer(
        features=student_features, teacher_transformer=teacher_transformer,
    )

    The idea behinds is that teacher and student model could use different
    tokenization logic (example: teacher use SPM and student use GPT2BPE), which
    means they might expect different input features.
    The general KD flow will be:
    1) teacher trained based on teacher_features
    2) teacher generate student training data based on student features
        * teacher need be able to read student features
        * teacher need to generate column for student features
    3) student trained on the generated training data by teacher

Differential Revision: D19842767

