### PR TITLE
Return len of tokens of each sequence in SeqTokenTensorizer

### DIFF
--- a/pytext/models/seq_models/contextual_intent_slot.py
+++ b/pytext/models/seq_models/contextual_intent_slot.py
@@ -74,7 +74,7 @@ class ContextualIntentSlotModel(IntentSlotModel):
     def arrange_model_inputs(self, tensor_dict):
         tokens, seq_lens, _ = tensor_dict["tokens"]
         arranged_inputs = [tokens]
-        seq_emb_inputs, seq_word_lens = tensor_dict.get("seq_tokens")
+        seq_emb_inputs, _, seq_word_lens = tensor_dict.get("seq_tokens")
         arranged_inputs.append(seq_emb_inputs)
         arranged_inputs.append(seq_lens)
         arranged_inputs.append(seq_word_lens)

--- a/pytext/models/seq_models/seqnn.py
+++ b/pytext/models/seq_models/seqnn.py
@@ -44,7 +44,7 @@ class SeqNNModel(DocModel):
         representation: SeqRepresentation.Config = SeqRepresentation.Config()
 
     def arrange_model_inputs(self, tensor_dict):
-        tokens, seq_lens = tensor_dict["tokens"]
+        tokens, _, seq_lens = tensor_dict["tokens"]
         model_inputs = (tokens, seq_lens)
         if "dense" in tensor_dict:
             model_inputs += (tensor_dict["dense"],)


### PR DESCRIPTION
Summary: Right now only the len of the sequence is returned. However len of tokens of each sequence is required for RNN models.

Reviewed By: shivanipoddariiith

Differential Revision: D19943135

