### PR TITLE
Unify input for TorchScript Tensorizers and Models

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -11,7 +11,7 @@ from pytext.data.tensorizers import Tensorizer, TensorizerScriptImpl
 from pytext.data.tokenizers import Tokenizer, WordPieceTokenizer
 from pytext.data.utils import BOS, EOS, MASK, PAD, UNK, SpecialToken, Vocabulary
 from pytext.torchscript.tensorizer.tensorizer import VocabLookup
-from pytext.torchscript.utils import pad_2d, pad_2d_mask
+from pytext.torchscript.utils import ScriptBatchInput, pad_2d, pad_2d_mask
 from pytext.torchscript.vocab import ScriptVocabulary
 from pytext.utils.file_io import PathManager
 from pytext.utils.lazy import lazy_property
@@ -207,9 +207,7 @@ class BERTTensorizerBaseScriptImpl(TensorizerScriptImpl):
         return per_sentence_tokens
 
     def forward(
-        self,
-        texts: Optional[List[List[str]]] = None,
-        pre_tokenized: Optional[List[List[List[str]]]] = None,
+        self, inputs: ScriptBatchInput
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Wire up tokenize(), numberize() and tensorize() functions for data
@@ -223,10 +221,10 @@ class BERTTensorizerBaseScriptImpl(TensorizerScriptImpl):
         seq_lens_1d: List[int] = []
         positions_2d: List[List[int]] = []
 
-        for idx in range(self.batch_size(texts, pre_tokenized)):
+        for idx in range(self.batch_size(inputs)):
             tokens: List[List[Tuple[str, int, int]]] = self.tokenize(
-                self.get_texts_by_index(texts, idx),
-                self.get_tokens_by_index(pre_tokenized, idx),
+                self.get_texts_by_index(inputs.texts, idx),
+                self.get_tokens_by_index(inputs.tokens, idx),
             )
 
             numberized: Tuple[List[int], List[int], int, List[int]] = self.numberize(

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -21,6 +21,7 @@ from pytext.data.data_structures.annotation import (
 from pytext.data.sources.data_source import Gazetteer
 from pytext.data.tokenizers import Token, Tokenizer
 from pytext.torchscript.tensorizer import VectorNormalizer
+from pytext.torchscript.utils import ScriptBatchInput
 from pytext.utils import cuda, precision
 from pytext.utils.data import Slot
 from pytext.utils.file_io import PathManager
@@ -115,9 +116,9 @@ class TensorizerScriptImpl(torch.nn.Module):
     def set_device(self, device: str):
         self.device = device
 
-    def batch_size(
-        self, texts: Optional[List[List[str]]], tokens: Optional[List[List[List[str]]]]
-    ) -> int:
+    def batch_size(self, inputs: ScriptBatchInput) -> int:
+        texts: Optional[List[List[str]]] = inputs.texts
+        tokens: Optional[List[List[List[str]]]] = inputs.tokens
         if texts is not None:
             return len(texts)
         elif tokens is not None:
@@ -125,9 +126,9 @@ class TensorizerScriptImpl(torch.nn.Module):
         else:
             raise RuntimeError("Empty input for both texts and tokens.")
 
-    def row_size(
-        self, texts: Optional[List[List[str]]], tokens: Optional[List[List[List[str]]]]
-    ) -> int:
+    def row_size(self, inputs: ScriptBatchInput) -> int:
+        texts: Optional[List[List[str]]] = inputs.texts
+        tokens: Optional[List[List[List[str]]]] = inputs.tokens
         if texts is not None:
             return len(texts[0])
         elif tokens is not None:
@@ -138,14 +139,14 @@ class TensorizerScriptImpl(torch.nn.Module):
     def get_texts_by_index(
         self, texts: Optional[List[List[str]]], index: int
     ) -> Optional[List[str]]:
-        if texts is None:
+        if texts is None or len(texts) == 0:
             return None
         return texts[index]
 
     def get_tokens_by_index(
         self, tokens: Optional[List[List[List[str]]]], index: int
     ) -> Optional[List[List[str]]]:
-        if tokens is None:
+        if tokens is None or len(tokens) == 0:
             return None
         return tokens[index]
 

--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -118,7 +118,15 @@ class DocModel(Model):
                 self.pad_idx = jit.Attribute(input_vocab.idx[PAD], int)
 
             @jit.script_method
-            def forward(self, tokens: List[List[str]]):
+            def forward(
+                self,
+                texts: Optional[List[str]] = None,
+                tokens: Optional[List[List[str]]] = None,
+                languages: Optional[List[str]] = None,
+            ):
+                if tokens is None:
+                    raise RuntimeError("tokens is required")
+
                 seq_lens = make_sequence_lengths(tokens)
                 word_ids = self.vocab.lookup_indices_2d(tokens)
                 word_ids = pad_2d(word_ids, seq_lens, self.pad_idx)
@@ -135,11 +143,23 @@ class DocModel(Model):
                 self.pad_idx = jit.Attribute(input_vocab.idx[PAD], int)
 
             @jit.script_method
-            def forward(self, tokens: List[List[str]], dense_feat: List[List[float]]):
+            def forward(
+                self,
+                texts: Optional[List[str]] = None,
+                tokens: Optional[List[List[str]]] = None,
+                languages: Optional[List[str]] = None,
+                dense_feat: Optional[List[List[float]]] = None,
+            ):
+                if tokens is None:
+                    raise RuntimeError("tokens is required")
+
                 seq_lens = make_sequence_lengths(tokens)
                 word_ids = self.vocab.lookup_indices_2d(tokens)
                 word_ids = pad_2d(word_ids, seq_lens, self.pad_idx)
-                dense_feat = self.normalizer.normalize(dense_feat)
+                if dense_feat is not None:
+                    dense_feat = self.normalizer.normalize(dense_feat)
+                else:
+                    raise RuntimeError("dense is required")
                 logits = self.model(
                     torch.tensor(word_ids),
                     torch.tensor(seq_lens),

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 import torch
 from pytext.common.constants import Stage
@@ -25,7 +25,7 @@ from pytext.models.representations.transformer import (
 from pytext.models.representations.transformer_sentence_encoder_base import (
     TransformerSentenceEncoderBase,
 )
-from pytext.torchscript.module import get_script_module_cls
+from pytext.torchscript.module import ScriptPyTextModule
 from pytext.utils.file_io import PathManager
 from pytext.utils.usage import log_class_usage
 from torch.serialization import default_restore_location
@@ -152,11 +152,7 @@ class RoBERTa(NewBertModel):
         values according to the output layer (eg. as a dict mapping class name to score)
         """
         script_tensorizer = tensorizers["tokens"].torchscriptify()
-        script_module_cls = get_script_module_cls(
-            script_tensorizer.tokenizer.input_type()
-        )
-
-        return script_module_cls(
+        return ScriptPyTextModule(
             model=traced_model,
             output_layer=self.output_layer.torchscript_predictions(),
             tensorizer=script_tensorizer,

--- a/pytext/torchscript/tests/test_tensorizer.py
+++ b/pytext/torchscript/tests/test_tensorizer.py
@@ -13,7 +13,7 @@ from pytext.torchscript.tensorizer import (
 )
 from pytext.torchscript.tensorizer.tensorizer import VocabLookup
 from pytext.torchscript.tokenizer import ScriptDoNothingTokenizer
-from pytext.torchscript.tokenizer.tokenizer import ScriptTextTokenizerBase
+from pytext.torchscript.tokenizer.tokenizer import ScriptTokenizerBase
 from pytext.torchscript.utils import squeeze_1d, squeeze_2d
 from pytext.torchscript.vocab import ScriptVocabulary
 
@@ -26,7 +26,7 @@ class TensorizerTest(unittest.TestCase):
         )
 
     def _mock_tokenizer(self):
-        class MockTokenizer(ScriptTextTokenizerBase):
+        class MockTokenizer(ScriptTokenizerBase):
             def __init__(self, tokens: List[Tuple[str, int, int]]):
                 super().__init__()
                 self.tokens = torch.jit.Attribute(tokens, List[Tuple[str, int, int]])

--- a/pytext/torchscript/tokenizer/__init__.py
+++ b/pytext/torchscript/tokenizer/__init__.py
@@ -2,18 +2,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .bpe import ScriptBPE
-from .tokenizer import (
-    ScriptBPETokenizer,
-    ScriptDoNothingTokenizer,
-    ScriptTextTokenizerBase,
-    ScriptTokenTokenizerBase,
-)
+from .tokenizer import ScriptBPETokenizer, ScriptDoNothingTokenizer, ScriptTokenizerBase
 
 
 __all__ = [
     "ScriptBPE",
     "ScriptBPETokenizer",
     "ScriptDoNothingTokenizer",
-    "ScriptTextTokenizerBase",
-    "ScriptTokenTokenizerBase",
+    "ScriptTokenizerBase",
 ]

--- a/pytext/torchscript/tokenizer/tokenizer.py
+++ b/pytext/torchscript/tokenizer/tokenizer.py
@@ -4,7 +4,6 @@
 from typing import List, Tuple
 
 import torch
-from pytext.torchscript.utils import ScriptInputType
 
 from .bpe import ScriptBPE
 
@@ -22,37 +21,14 @@ class ScriptTokenizerBase(torch.jit.ScriptModule):
         """
         raise NotImplementedError
 
-    def input_type(self) -> ScriptInputType:
-        """
-        Determine TorchScript module input type, currently it have four types
-        1) text: batch with a single text in each row, List[str]
-        2) tokens: batch with a list of tokens from single text
-        in each row, List[List[str]]
-        3) multi_text: batch with multiple texts in each row,
-        List[List[str]]
-        4) multi_tokens: batch with multiple lists of tokens from
-        multiple texts in each row, List[List[List[str]]]
-        """
-        raise NotImplementedError
 
-
-class ScriptTextTokenizerBase(ScriptTokenizerBase):
-    def input_type(self) -> ScriptInputType:
-        return ScriptInputType.text
-
-
-class ScriptTokenTokenizerBase(ScriptTokenizerBase):
-    def input_type(self) -> ScriptInputType:
-        return ScriptInputType.token
-
-
-class ScriptDoNothingTokenizer(ScriptTokenTokenizerBase):
+class ScriptDoNothingTokenizer(ScriptTokenizerBase):
     @torch.jit.script_method
     def tokenize(self, raw_token: str) -> List[Tuple[str, int, int]]:
         return [(raw_token, -1, -1)]
 
 
-class ScriptBPETokenizer(ScriptTokenTokenizerBase):
+class ScriptBPETokenizer(ScriptTokenizerBase):
     def __init__(self, bpe: ScriptBPE):
         super().__init__()
         self.bpe = bpe

--- a/pytext/torchscript/utils.py
+++ b/pytext/torchscript/utils.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from enum import Enum
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 import torch
 
 
-class ScriptInputType(Enum):
-    text = 1  # row contains a single sentence
-    token = 2  # row contains a list of tokens from a single sentence
+class ScriptBatchInput(NamedTuple):
+    """A batch of inputs for TorchScript Module(bundle of Tensorizer and Model)
+    texts or tokens is required but multually exclusive
+    Args:
+        texts: a batch of raw text inputs
+        tokens: a batch of pre-tokenized inputs
+        languages: language for each input in the batch
+    """
 
-    def is_text(self):
-        return self is ScriptInputType.text
-
-    def is_token(self):
-        return self is ScriptInputType.token
+    texts: Optional[List[List[str]]]
+    tokens: Optional[List[List[List[str]]]]
+    languages: Optional[List[List[str]]]
 
 
 # ===== the following section should be replaced once JIT provide native support


### PR DESCRIPTION
Summary:
## Dataflow from PyText client to TorchScript model in predictor

1. Client sends optional "texts", "tokens", "languages", "dense_feat" args in predictor request
2. Predictor pass them to forward() of TorchScript Module(Tensorizer + Model)
3. In ScriptPyTextModule(texts, tokens, languages, dense_feat), the args are converted to ScriptBatchInput(NamedTuple)  => Tensorizer.forward() => tuple of Tensors => Model.forward()

## Before:
We need a wrapper for each combination of (texts, tokens, languages, dense)

## After:
a wrapper for with dense, another wrapper for without dense feature

## Alternative:
ScriptPyTextModule(inputs: ScriptBatchInput)
after NamedTuple is supported in client example => predictor => ScriptPyTextModule
https://fb.workplace.com/groups/811605488888068/permalink/3266598560055403/

Reviewed By: chenyangyu1988

Differential Revision: D19900062

