### PR TITLE
Add option to skip 2 stage tokenizer and bpe decode sequences in the debug file

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -285,6 +285,16 @@ class Tensorizer(Component):
         state.pop("tensorizer_script_impl", None)
         return state
 
+    def stringify(self, token_indices):
+        # Used in metric reporter to convert from tokens to string
+        res = ""
+        if hasattr(self, "vocab"):
+            res = " ".join([self.vocab._vocab[index] for index in token_indices])
+            if hasattr(self, "tokenizer"):
+                if hasattr(self.tokenizer, "decode"):
+                    res = self.tokenizer.decode(res)
+        return res
+
     def torchscriptify(self):
         return self.tensorizer_script_impl.torchscriptify()
 

--- a/pytext/data/tokenizers/tokenizer.py
+++ b/pytext/data/tokenizers/tokenizer.py
@@ -63,6 +63,10 @@ class Tokenizer(Component):
     def torchscriptify(self):
         raise NotImplementedError
 
+    def decode(self, sentence: str):
+        ## To be overridden by subword level tokenizers to convert to string
+        return sentence
+
 
 class DoNothingTokenizer(Tokenizer):
     """
@@ -233,6 +237,13 @@ class GPT2BPETokenizer(Tokenizer):
             if len(tokens) > 1 and end < tokens[-2].end:
                 end = tokens[-2].end
         return [token for token in tokens if token.value]
+
+    def decode(self, sentence: str):
+        bpe_tokens = []
+        for i in sentence.split():
+            if i.isdigit():
+                bpe_tokens.append(int(i))
+        return self.bpe.decode(bpe_tokens)
 
 
 class CppProcessorMixin:

--- a/pytext/metric_reporters/seq2seq_metric_reporter.py
+++ b/pytext/metric_reporters/seq2seq_metric_reporter.py
@@ -16,8 +16,6 @@ from pytext.metric_reporters.metric_reporter import MetricReporter
 from pytext.metrics import safe_division
 from pytext.metrics.seq2seq_metrics import Seq2SeqMetrics
 
-from .seq2seq_utils import stringify
-
 
 class Seq2SeqFileChannel(FileChannel):
     def __init__(self, stages, file_path, tensorizers):
@@ -28,15 +26,14 @@ class Seq2SeqFileChannel(FileChannel):
         return ("doc_index", "raw_input", "predictions", "targets")
 
     def gen_content(self, metrics, loss, preds, targets, scores, context):
-        target_vocab = self.tensorizers["trg_seq_tokens"].vocab
         batch_size = len(targets)
         assert batch_size == len(context[DatasetFieldName.RAW_SEQUENCE]) == len(preds)
         for i in range(batch_size):
             yield [
                 context[BatchContext.INDEX][i],
                 context[DatasetFieldName.RAW_SEQUENCE][i],
-                stringify(preds[i][0], target_vocab._vocab),
-                stringify(targets[i], target_vocab._vocab),
+                self.tensorizers["trg_seq_tokens"].stringify(preds[i][0]),
+                self.tensorizers["trg_seq_tokens"].stringify(targets[i]),
             ]
 
 


### PR DESCRIPTION
Summary:
- When using the transformer decoupled model for normal text sequences we want to directly use the GPT2 tokenizer
- The debug files had bpe tokens which were not human readable this diff decodes them before creating the file.

Reviewed By: einolghozati

Differential Revision: D19881420

