### PR TITLE
add Stage.OTHERS and allow TB to print to a seperate prefix not in (TRAIN, TEST, EVAL)

### DIFF
--- a/pytext/common/constants.py
+++ b/pytext/common/constants.py
@@ -86,6 +86,7 @@ class Stage(Enum):
     TRAIN = "Training"
     EVAL = "Evaluation"
     TEST = "Test"
+    OTHERS = "Others"
 
 
 class RawExampleFieldName:

--- a/pytext/metric_reporters/tests/tensorboard_test.py
+++ b/pytext/metric_reporters/tests/tensorboard_test.py
@@ -48,3 +48,27 @@ class TensorboardTest(TestCase):
             model=model,
             optimizer=optimizer,
         )
+
+    def test_report_metrics_to_others(self):
+        """ Check that tensorboard channel catches errors when model has
+            Inf or NaN weights
+        """
+        tensorboard_channel = TensorBoardChannel()
+        # create simple model and optimizers
+        model = FCModelWithNanAndInfWts()
+
+        optimizer = optim.SGD(model.parameters(), lr=0.1)
+        tensorboard_channel.report(
+            stage=Stage.OTHERS,
+            epoch=1,
+            metrics=0.0,
+            model_select_metric=0.0,
+            loss=1.0,
+            preds=[1],
+            targets=[1],
+            scores=[1],
+            context={},
+            meta={},
+            model=model,
+            optimizer=optimizer,
+        )


### PR DESCRIPTION
Summary:
In some training algorithms, we may want to use Tensorboard to produce summary on some fine-grained training results. However, currently this is not possible because Stage num is limited to (Train, Test, Eval). Further, TensorBoard maps each Stage enum to a prefix and aggregate the metrics for that prefix.

example scenarios where we need additional stage for metrics reporting:

1. federated learning: we need to distinguish the training curve on clients, and the training curve of the global model aggregated from multiple users but evaluated on the client's training data.

2. adverserial training: we want to distinguish and report the training curve on clean data and adverserial data seperately.

3. any training algorithms that performs averaging during the training process, where we can see the difference before and after averaging.

Reviewed By: geof90, snisarg

Differential Revision: D19783880

