### PR TITLE
support PoolingType in DocNN.

### DIFF
--- a/pytext/config/module_config.py
+++ b/pytext/config/module_config.py
@@ -33,6 +33,7 @@ class CNNParams(ConfigBase):
 class PoolingType(Enum):
     MEAN = "mean"
     MAX = "max"
+    LOGSUMEXP = "logsumexp"
     NONE = "none"
 
 


### PR DESCRIPTION
Summary: DeepText have a config to specify pooling type, to accommodate this feature, add the code to support PoolingType in DocNN.

Differential Revision: D19980058

