### PR TITLE
Integration

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp37-cp37m-manylinux1_x86_64.whl
+https://download.pytorch.org/whl/cpu/torch-1.4.0%2Bcpu-cp37-cp37m-linux_x86_64.whl
 click
 fairseq
 future
@@ -12,3 +12,4 @@ sentencepiece
 torchtext
 tensorboard==1.14
 pandas
+torchelastic

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -12,7 +12,7 @@ from pytext.data.sources.data_source import Schema
 from pytext.data.tensorizers import Tensorizer
 from pytext.metric_reporters import MetricReporter
 from pytext.models.model import BaseModel
-from pytext.trainers import TaskTrainer, TrainingState
+from pytext.trainers import ElasticTrainer, TaskTrainer, TrainingState
 from pytext.utils import cuda
 from pytext.utils.usage import log_class_usage
 from torch import jit
@@ -93,6 +93,7 @@ class _NewTask(TaskBase):
     class Config(ConfigBase):
         data: Data.Config = Data.Config()
         trainer: TaskTrainer.Config = TaskTrainer.Config()
+        use_elastic: Optional[bool] = None
 
     @classmethod
     def from_config(
@@ -114,7 +115,10 @@ class _NewTask(TaskBase):
         # features and tensors are being used. This is a strong tie between
         # the implementation of the model and the metric reporter.
         metric_reporter = cls.create_metric_reporter(config, tensorizers)
-        trainer = create_trainer(config.trainer, model)
+        if hasattr(config, "use_elastic") and config.use_elastic:
+            trainer = create_trainer(ElasticTrainer.Config(config.trainer), model)
+        else:
+            trainer = create_trainer(config.trainer, model)
         return cls(data, model, metric_reporter, trainer)
 
     @classmethod

--- a/pytext/trainers/__init__.py
+++ b/pytext/trainers/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from .elastic_trainer import ElasticTrainer
 from .ensemble_trainer import EnsembleTrainer
 from .hogwild_trainer import HogwildTrainer, HogwildTrainer_Deprecated
 from .trainer import TaskTrainer, Trainer
@@ -9,6 +11,7 @@ from .training_state import TrainingState
 __all__ = [
     "Trainer",
     "TrainingState",
+    "ElasticTrainer",
     "EnsembleTrainer",
     "HogwildTrainer",
     "HogwildTrainer_Deprecated",

--- a/pytext/trainers/elastic_trainer.py
+++ b/pytext/trainers/elastic_trainer.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+
+import copy
+import logging
+from typing import Any, Optional, Tuple
+
+import torch
+import torchelastic
+from pytext.config import PyTextConfig
+from pytext.data.data_handler import BatchIterator
+from pytext.metric_reporters import MetricReporter
+from pytext.trainers.training_state import TrainingState
+from pytext.utils import timing
+from torchelastic.p2p import CoordinatorP2P
+from torchelastic.worker_stats import WorkerStats
+
+from .trainer import TaskTrainer, Trainer
+
+
+log = logging.getLogger(__name__)
+
+
+class PytextWorkerStats(WorkerStats):
+    """
+    ClassyVision-specific implementation of WorkerStats,
+    which is used by torchelastic train_loop
+    to detect (and correct stragglers), or other progress-impeding issues.
+    """
+
+    def __init__(self, progress_rate: float):
+        self.progress_rate = progress_rate
+
+    def get_progress_rate(self) -> Optional[float]:
+        return self.progress_rate
+
+
+class PytextElasticState(torchelastic.State):
+    """
+    Rollback is disabled on this state since currently, data loaders are
+    too expensive to snapshot on every train_step
+    """
+
+    def __init__(self, train_state: TrainingState):
+        # WARNING: Make sure to add any members here to self.save() and self.load()
+        self.train_state = train_state
+        self.snapshot = None
+
+    def set_train_state(self, train_state: TrainingState):
+        self.train_state = train_state
+
+    def get_train_state(self):
+        return self.train_state
+
+    def sync(self, world_size: int, rank: int):
+        """
+        TODO: implement this
+        """
+        pass
+
+
+_coordinator = None
+
+
+def initialize_coordinator(rdzv_url, max_size):
+    global _coordinator
+    _coordinator = CoordinatorP2P(
+        c10d_backend="gloo",
+        init_method=rdzv_url,
+        max_num_trainers=max_size,
+        process_group_timeout=10000,
+    )
+
+
+def get_coordinator():
+    global _coordinator
+    assert _coordinator is not None, "coordinator not intialized."
+    return _coordinator
+
+
+class ElasticTrainer(TaskTrainer):
+    class Config(TaskTrainer.Config):
+        def __init__(self, config: Trainer.Config):
+            self.__dict__ = copy.deepcopy(config.__dict__)
+
+    @classmethod
+    def from_config(cls, config: Config, model: torch.nn.Module, *args, **kwargs):
+        return cls(config, model)
+
+    def __init__(self, config: Trainer.Config, model: torch.nn.Module):
+        super().__init__(config, model)
+
+    @timing.time("Trainer.train_from_state")
+    def train_from_state(
+        self,
+        state: TrainingState,
+        training_data: BatchIterator,
+        eval_data: BatchIterator,
+        metric_reporter: MetricReporter,
+        train_config: PyTextConfig,
+    ) -> Tuple[torch.nn.Module, Any]:
+
+        # initialize elastic state
+        elastic_state = PytextElasticState(state)
+
+        # define elastic state generator
+        def elastic_state_generator(pytext_train_state):
+            for pytext_train_state in self.train_from_state_internal(
+                pytext_train_state.train_state,
+                training_data,
+                eval_data,
+                metric_reporter,
+                train_config,
+            ):
+                elastic_state.set_train_state(pytext_train_state)
+                yield elastic_state, PytextWorkerStats(0)
+
+        coordinator = get_coordinator()
+
+        # run elastic
+        elastic_state = torchelastic.run_train(
+            coordinator, elastic_state_generator, elastic_state
+        )
+        return (
+            elastic_state.train_state.model,
+            elastic_state.train_state.best_model_metric,
+        )

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -372,6 +372,22 @@ class Trainer(TrainerBase):
         metric_reporter: MetricReporter,
         train_config: PyTextConfig,
     ) -> Tuple[torch.nn.Module, Any]:
+        last_state = None
+        for state in self.train_from_state_internal(
+            state, training_data, eval_data, metric_reporter, train_config
+        ):
+            last_state = state
+        return last_state.model, last_state.best_model_metric
+
+    @timing.time("Trainer.train_from_state_internal")
+    def train_from_state_internal(
+        self,
+        state: TrainingState,
+        training_data: BatchIterator,
+        eval_data: BatchIterator,
+        metric_reporter: MetricReporter,
+        train_config: PyTextConfig,
+    ):
         """
         Train and eval a model from a given training state will be modified.
         This function iterates epochs specified in config, and for each epoch do:
@@ -425,6 +441,7 @@ class Trainer(TrainerBase):
                         epoch_data, self.config.num_batches_per_epoch
                     )
                 self.run_epoch(state, epoch_data, metric_reporter)
+                yield state
 
             if not self.config.do_eval:
                 continue
@@ -476,7 +493,7 @@ class Trainer(TrainerBase):
         ):
             self.load_best_model(state)
 
-        return state.model, state.best_model_metric
+        yield state
 
     @timing.report_snapshot
     def run_epoch(

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -22,6 +22,7 @@ from pytext.task import (
 )
 from pytext.task.disjoint_multitask import NewDisjointMultitask
 from pytext.trainers import TrainingState
+from pytext.trainers.elastic_trainer import initialize_coordinator
 from pytext.utils import cuda, distributed, precision, set_random_seeds, timing
 from pytext.utils.file_io import PathManager
 
@@ -122,13 +123,16 @@ def prepare_task(
         print("\nParameters: {}\n".format(config), flush=True)
     _set_cuda(config.use_cuda_if_available, device_id, world_size)
     _set_fp16(config.use_fp16, rank)
-    _set_distributed(
-        rank,
-        world_size,
-        dist_init_url,
-        device_id,
-        config.gpu_streams_for_distributed_training,
-    )
+    if hasattr(config.task, "use_elastic") and config.task.use_elastic:
+        initialize_coordinator(dist_init_url, world_size)
+    else:
+        _set_distributed(
+            rank,
+            world_size,
+            dist_init_url,
+            device_id,
+            config.gpu_streams_for_distributed_training,
+        )
 
     if config.random_seed is not None:
         set_random_seeds(config.random_seed, config.use_deterministic_cudnn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sentencepiece
 tensorboard==1.14
 torch
 torchtext
+torchelastic


### PR DESCRIPTION
Summary:
First step integrate PET & Pytext, the idea is introduce a new trainer and by convert Pytext train_loop to a PET state generator. More things include in this diff:

 - create a unittest to make the E2E pass
 - create a flag to enable/disable PET in pytext
 - create util functions like intialize_coordinator

Differential Revision: D19806903

