### PR TITLE
If the snapshot path provided is not valid, throw error

### DIFF
--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -147,7 +147,8 @@ def prepare_task(
         if latest_snapshot_path:
             config.load_snapshot_path = latest_snapshot_path
 
-    if config.load_snapshot_path and PathManager.isfile(config.load_snapshot_path):
+    if config.load_snapshot_path:
+        assert PathManager.isfile(config.load_snapshot_path)
         if config.use_config_from_snapshot:
             task, _, training_state = load(config.load_snapshot_path)
         else:


### PR DESCRIPTION
Summary:
It was silently failing when i was trying to load a file from gluster. Shouldnt it throw error if the file is not readable?

Created from Diffusion's 'Open in Editor' feature.

```
config.load_snapshot_path : /mnt/vol/gfsfblearner-east3/flow/data/2020-02-27/4167d473-9a3a-4198-82b1-153c4db14afd/171027009/5924195916406591978/model.pt
PathManager.isfile(config.load_snapshot_path) : False
```

Reviewed By: hudeven

Differential Revision: D20144757

