### PR TITLE
avoid zero division error in metrics reporter

### DIFF
--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -113,6 +113,8 @@ class LanguageModelMetricReporter(MetricReporter):
             self.aggregate_context(context)
 
     def calculate_loss(self) -> float:
+        if self.total_num_tokens == 0:
+            return 0.0
         return self.aggregate_loss / float(self.total_num_tokens)
 
     def _reset(self):


### PR DESCRIPTION
Summary:
safe guard to report loss as 0 if number of tokens is zero.

previous failed flow: f172935356

Reviewed By: FanW123

Differential Revision: D20291550

