### PR TITLE
Update mean reduction in NLLLoss

### DIFF
--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -50,7 +50,7 @@ class NLLLoss(Loss):
             log_probs,
             targets,
             ignore_index=self.ignore_index,
-            reduction="elementwise_mean" if reduce else "none",
+            reduction="mean" if reduce else "none",
             weight=self.weight,
         )
 


### PR DESCRIPTION
Summary: `elementwise_mean` is being deprecated by PyTorch in favor of `mean` as an option for reduction. See https://fburl.com/diffusion/ywuy8gqv. Shouldn't have any impact on functionality.

Reviewed By: kartikayk

Differential Revision: D20347426

