### PR TITLE
Add projection layer to HuggingFace encoder

### DIFF
--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -50,7 +50,7 @@ class NLLLoss(Loss):
             log_probs,
             targets,
             ignore_index=self.ignore_index,
-            reduction="elementwise_mean" if reduce else "none",
+            reduction="mean" if reduce else "none",
             weight=self.weight,
         )
 


### PR DESCRIPTION
Summary: TransformerSentenceEncoder supports a projecting pooled output (https://github.com/facebookresearch/pytext/blob/master/pytext/models/representations/transformer_sentence_encoder.py#L61). Adding that support for HF BERT. Shouldn't change anything functionally for any existing model

Differential Revision: D20355562

