### PR TITLE
migrate pages.integrity.scam.docnn_models.xxx

### DIFF
--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -23,6 +23,9 @@ class Loss(Component):
 
 
 class CrossEntropyLoss(Loss):
+    class Config(ConfigBase):
+        pass
+
     def __init__(self, config, ignore_index=-100, weight=None, *args, **kwargs):
         self.ignore_index = ignore_index
         self.weight = weight


### PR DESCRIPTION
Summary:
Migrate domain pages.integrity.scam.docnn_models.fixed_gambling
1. In docnn_utils.py, API get_pytext_docnn_config return PyText config which have same functionality as DeepText
2. In docnn_models.py, API get_domain return PyTextDocumentClassifier when provide pytext_config instead of text_nn_config
3. In pytext/api.py, import all PyText necessary modules to use for page_integrity

Differential Revision: D20154527

