### PR TITLE
support XLM-R model Embedding in TorchScript

### DIFF
--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -79,6 +79,7 @@ class ScriptPyTextEmbeddingModule(ScriptModule):
         texts: Optional[List[str]] = None,
         tokens: Optional[List[List[str]]] = None,
         languages: Optional[List[str]] = None,
+        dense_feat: Optional[List[List[float]]] = None,
     ) -> torch.Tensor:
         inputs: ScriptBatchInput = ScriptBatchInput(
             texts=squeeze_1d(texts),


### PR DESCRIPTION
Summary:
The main purpose of the diff is to create a TorchScript model for XLM-R model with embedding as output

How to TorchScriptify model with embedding?

XLM-R model
 ---- PyText: torchscript_export_with_embedder ---> ScriptPyTextEmbeddingModule (texts: Optional[List[str]])
 ---- Fluent2 wrapper: DocumentEmbedder (texts: texts: Optional[List[Optional[str]]], e.g SingleTextFeature)

Details:
1. Create a general Script Embedding Module in PyText (e.g ScriptPyTextEmbeddingModule) ==> pytext/torchscript/module.py
2. Generalize the fluent2 Script Embedding Wrapper in fluent2 (e.g DocumentEmbedder), support both text and token feature
==> fblearner/flow/projects/fluent2/definition/transformers/contrib/pytext/torchscript.py
3. Combine xlm and xlm embedder (PyText one), implement embedding torchscriptify ==> pytext/pytext_embedder_helper.py
4. PyTextDocumentClassifierWithEmbedding support text_feature

Reviewed By: kartikayk

Differential Revision: D20320641

