### PR TITLE
add arrange_caffe2_model_inputs in BaseModel

### DIFF
--- a/pytext/__init__.py
+++ b/pytext/__init__.py
@@ -31,14 +31,7 @@ def _predict(workspace_id, predict_net, model, tensorizers, input):
         name: tensorizer.prepare_input(input)
         for name, tensorizer in tensorizers.items()
     }
-    model_inputs = model.arrange_model_inputs(tensor_dict)
-    flat_model_inputs = []
-    for model_input in model_inputs:
-        if isinstance(model_input, tuple):
-            flat_model_inputs.extend(model_input)
-        else:
-            flat_model_inputs.append(model_input)
-    model_inputs = flat_model_inputs
+    model_inputs = model.arrange_caffe2_model_inputs(tensor_dict)
     model_input_names = model.get_export_input_names(tensorizers)
     vocab_to_export = model.vocab_to_export(tensorizers)
     for blob_name, model_input in zip(model_input_names, model_inputs):

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -214,6 +214,20 @@ class BaseModel(nn.Module, Component):
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
         pass
 
+    def arrange_caffe2_model_inputs(self, tensor_dict):
+        """
+        Generate inputs for exported caffe2 model, default behavior is flatten the 
+        input tuples
+        """
+        model_inputs = self.arrange_model_inputs(tensor_dict)
+        flat_model_inputs = []
+        for model_input in model_inputs:
+            if isinstance(model_input, tuple):
+                flat_model_inputs.extend(model_input)
+            else:
+                flat_model_inputs.append(model_input)
+        return flat_model_inputs
+
 
 class Model(BaseModel):
     """


### PR DESCRIPTION
Summary: Move the flatten logic in _predict function to a dedicated function in BaseModel class, so child models can override when needed

Differential Revision: D20665394

