### PR TITLE
Replace unit-tests on LMModel and FLLanguageModelingTask by LiteLMModel and FLLiteLMTask

### DIFF
--- a/tests/data/test_lm_tiny.tsv
+++ b/tests/data/test_lm_tiny.tsv
@@ -1,5 +1,8 @@
-<s> I am an Arsenal fan . </s>
-<s> What is the weather today </s>
-<s> I want to sleep </s>
-<s> Where can I get some golf lessons? </s>
-<s> What the the shortest route to get to the airport? </s>
+I am an Arsenal fan.	user1
+What is the weather today?	user2
+I want to sleep.	user3
+Where can I get some golf lessons?	user4
+What the the shortest route to get to the airport?	user5
+When is the time for the Arsenal vs Liverpool match this week?	user6
+Nice to meet you!	user7
+Thank you very much.	user8


### PR DESCRIPTION
Summary:
Previously, fl_language_model_test.py covers unit-tests on LMModel by comparing LMTask and FLLMTask.

We will ship LiteLMModel instead of LMModel, hence the unit-tests should be using LiteLMModel, LiteLMTask, and FLLiteLMTask instead.

One caveat: we need to import LiteLMTask from fb/tasks.py, however, the import section in fb/tasks.py misses tons of dependencies (I guess no unit-tests was ran on tasks.py?), hence I have to replicate LiteLMTask.

Reviewed By: kmalik22

Differential Revision: D20651264

