### PR TITLE
delete caffe2 export

### DIFF
--- a/pytext/models/bert_classification_models.py
+++ b/pytext/models/bert_classification_models.py
@@ -83,7 +83,7 @@ class NewBertModel(BaseModel):
         return self.decoder(representation, *args)
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
-        pass
+        raise NotImplementedError
 
     @classmethod
     def from_config(cls, config: Config, tensorizers: Dict[str, Tensorizer]):

--- a/pytext/models/disjoint_multitask_model.py
+++ b/pytext/models/disjoint_multitask_model.py
@@ -70,4 +70,4 @@ class NewDisjointMultitaskModel(DisjointMultitaskModel):
         return self.current_model.arrange_model_context(tensor_dict)
 
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
-        pass
+        raise NotImplementedError


### PR DESCRIPTION
Summary:
delete caffe2 export
1. BiTransformer
2. NewBertModel
3. NewDisjointMultitaskModel

Reviewed By: snisarg

Differential Revision: D20907342

