### PR TITLE
Migrate serving tutorial to TorchScript

### DIFF
--- a/demo/predictor_service/Dockerfile
+++ b/demo/predictor_service/Dockerfile
@@ -1,71 +1,59 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
-# Install Caffe2 + dependencies
+# Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
+  ca-certificates \
+  cmake \
+  curl \
   git \
-  libgoogle-glog-dev \
-  libgtest-dev \
-  libiomp-dev \
-  libleveldb-dev \
-  liblmdb-dev \
-  libopencv-dev \
-  libopenmpi-dev \
-  libsnappy-dev \
-  openmpi-bin \
-  openmpi-doc \
-  python-dev \
-  python-pip
-RUN pip install --upgrade pip
-RUN pip install setuptools wheel
-RUN pip install future numpy protobuf typing hypothesis pyyaml
-RUN apt-get install -y --no-install-recommends \
-      libgflags-dev \
-      cmake
-RUN git clone https://github.com/pytorch/pytorch.git
-WORKDIR pytorch
-RUN git submodule update --init --recursive
-RUN python setup.py install
+  libcurl4-openssl-dev \
+  libgflags-dev \
+  unzip
 
 # Install Thrift + dependencies
 WORKDIR /
 RUN apt-get update && apt-get install -y \
-  libboost-dev \
-  libboost-test-dev \
-  libboost-program-options-dev \
-  libboost-filesystem-dev \
-  libboost-thread-dev \
-  libevent-dev \
-  automake \
-  libtool \
-  curl \
-  flex \
-  bison \
-  pkg-config \
-  libssl-dev
-RUN curl https://www-us.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz --output thrift-0.11.0.tar.gz
-RUN tar -xvf thrift-0.11.0.tar.gz
-WORKDIR thrift-0.11.0
-RUN ./bootstrap.sh
-RUN ./configure
-RUN make
-RUN make install
-
-# Install Pistache (REST framework)
+    libboost-dev \
+    libboost-test-dev \
+    libboost-program-options-dev \
+    libboost-filesystem-dev \
+    libboost-thread-dev \
+    libevent-dev \
+    automake \
+    libtool \
+    flex \
+    bison \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl https://downloads.apache.org/thrift/0.13.0/thrift-0.13.0.tar.gz --output thrift-0.13.0.tar.gz \
+    && tar -xvf thrift-0.13.0.tar.gz \
+    && rm thrift-0.13.0.tar.gz
+WORKDIR /thrift-0.13.0
+RUN ./bootstrap.sh \
+    && ./configure \
+    && make \
+    && make install
+    
+# Install Pistache (C++ REST framework)
 WORKDIR /
 RUN git clone https://github.com/oktal/pistache.git
 WORKDIR /pistache
-RUN git submodule update --init
-RUN mkdir build
+RUN git submodule update --init \
+    && mkdir build
 WORKDIR /pistache/build
-RUN cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
-RUN make
-RUN make install
+RUN cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release .. \
+    && make \
+    && make install
 
-# Install libcurl
-RUN apt-get install -y libcurl4-openssl-dev
+# Install libtorch
+WORKDIR /
+RUN curl https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.4.0%2Bcpu.zip --output libtorch.zip \
+    && unzip libtorch.zip \
+    && rm libtorch.zip
 
 # Copy local files to /app
 COPY . /app
@@ -76,10 +64,8 @@ RUN thrift -r --gen cpp predictor.thrift
 RUN make
 
 # Add library search paths
-RUN echo '/pytorch/build/lib/' >> /etc/ld.so.conf.d/local.conf
-RUN echo '/usr/local/lib/' >> /etc/ld.so.conf.d/local.conf
-RUN ldconfig
+ENV LD_LIBRARY_PATH /libtorch/lib:/usr/local/lib
 
-# Open ports
+# Expose ports for Thrift and REST
 EXPOSE 9090
 EXPOSE 8080

--- a/demo/predictor_service/Makefile
+++ b/demo/predictor_service/Makefile
@@ -1,13 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 CPPFLAGS += -g -std=c++11 -std=c++14 \
-  -I./gen-cpp \
-  -I/pytorch -I/pytorch/build \
-	-I/pytorch/aten/src/ \
-	-I/pytorch/third_party/protobuf/src/
+	-I./gen-cpp \
+	-I/libtorch/include \
+	-Wno-deprecated-declarations
 CLIENT_LDFLAGS += -lthrift
-SERVER_LDFLAGS += -L/pytorch/build/lib \
-  -lthrift -lpistache -lpthread -lcaffe2 -lprotobuf -lc10 -lcurl
+SERVER_LDFLAGS += -L/libtorch/lib \
+	-lthrift -lpistache -lpthread -ltorch -lc10 -lcurl -lgflags
 
 server: server.o gen-cpp/Predictor.o
 	g++ $^ $(SERVER_LDFLAGS) -o $@

--- a/demo/predictor_service/predictor.thrift
+++ b/demo/predictor_service/predictor.thrift
@@ -3,6 +3,6 @@
 namespace cpp predictor_service
 
 service Predictor {
-   // Returns list of scores for each label
-   map<string,list<double>> predict(1:string doc),
+   // Returns scores for each class
+   map<string,double> predict(1:string doc),
 }

--- a/demo/predictor_service/server.cpp
+++ b/demo/predictor_service/server.cpp
@@ -19,12 +19,15 @@
 
 #include <curl/curl.h>
 
-#include "caffe2/core/db.h"
-#include "caffe2/core/init.h"
-#include "caffe2/core/net.h"
-#include "caffe2/predictor/predictor_utils.h"
-#include "caffe2/proto/predictor_consts.pb.h"
-#include "caffe2/utils/proto_utils.h"
+#include <torch/script.h>
+
+#include <gflags/gflags.h>
+DEFINE_int32(
+    port_thrift,
+    9090,
+    "Port which the Thrift server should listen on");
+DEFINE_bool(rest, true, "Set up a REST proxy to the Thrift server");
+DEFINE_int32(port_rest, 8080, "Port which the REST proxy should listen on");
 
 using namespace std;
 
@@ -36,211 +39,162 @@ using namespace predictor_service;
 
 using namespace Pistache;
 
-using namespace caffe2;
-using namespace db;
-using namespace predictor_utils;
-
 // Main handler for the predictor service
 class PredictorHandler : virtual public PredictorIf {
-  private:
-    NetDef mPredictNet;
-    Workspace mWorkspace;
+ private:
+  torch::jit::script::Module mModule;
 
-    NetDef loadAndInitModel(Workspace& workspace, string& modelFile) {
-      auto db = unique_ptr<DBReader>(new DBReader("minidb", modelFile));
-      auto metaNetDef = runGlobalInitialization(move(db), &workspace);
-      const auto predictInitNet = getNet(
-        *metaNetDef.get(),
-        PredictorConsts::default_instance().predict_init_net_type()
-      );
-      CAFFE_ENFORCE(workspace.RunNetOnce(predictInitNet));
+  vector<string> mDummyVec;
+  vector<vector<string>> mDummyVecVec;
 
-      auto predictNet = NetDef(getNet(
-        *metaNetDef.get(),
-        PredictorConsts::default_instance().predict_net_type()
-      ));
-      CAFFE_ENFORCE(workspace.CreateNet(predictNet));
-
-      return predictNet;
-    }
-
-    void tokenize(vector<string>& tokens, string& doc) {
-      transform(doc.begin(), doc.end(), doc.begin(), ::tolower);
-      int start = 0;
-      int end = 0;
-      for (int i = 0; i < doc.length(); i++) {
-        if (isspace(doc.at(i))){
-          end = i;
-          if (end != start) {
-            tokens.push_back(doc.substr(start, end - start));
-          }
-
-          start = i + 1;
+  void tokenize(vector<string>& tokens, string& doc) {
+    transform(doc.begin(), doc.end(), doc.begin(), ::tolower);
+    size_t start = 0;
+    size_t end = 0;
+    for (size_t i = 0; i < doc.length(); i++) {
+      if (isspace(doc.at(i))){
+        end = i;
+        if (end != start) {
+          tokens.push_back(doc.substr(start, end - start));
         }
-      }
 
-      if (start < doc.length()) {
-        tokens.push_back(doc.substr(start, doc.length() - start));
-      }
-
-      if (tokens.size() == 0) {
-        // Add PAD_TOKEN in case of empty text
-        tokens.push_back("<pad>");
+        start = i + 1;
       }
     }
 
-  public:
-    PredictorHandler(string &modelFile): mWorkspace("workspace") {
-      mPredictNet = loadAndInitModel(mWorkspace, modelFile);
+    if (start < doc.length()) {
+      tokens.push_back(doc.substr(start, doc.length() - start));
     }
 
-    void predict(map<string, vector<double>>& _return, const string& doc) {
-      // Pre-process: tokenize input doc
-      vector<string> tokens;
-      string docCopy = doc;
-      tokenize(tokens, docCopy);
-
-      // Feed input to model as tensors
-      Tensor valTensor = TensorCPUFromValues<string>(
-        {static_cast<int64_t>(1), static_cast<int64_t>(tokens.size())}, {tokens}
-      );
-      BlobGetMutableTensor(mWorkspace.CreateBlob("tokens_vals_str:value"), CPU)
-        ->CopyFrom(valTensor);
-      Tensor lensTensor = TensorCPUFromValues<int>(
-        {static_cast<int64_t>(1)}, {static_cast<int>(tokens.size())}
-      );
-      BlobGetMutableTensor(mWorkspace.CreateBlob("tokens_lens"), CPU)
-        ->CopyFrom(lensTensor);
-
-      // Run the model
-      CAFFE_ENFORCE(mWorkspace.RunNet(mPredictNet.name()));
-
-      // Extract and populate results into the response
-      for (int i = 0; i < mPredictNet.external_output().size(); i++) {
-        string label = mPredictNet.external_output()[i];
-        _return[label] = vector<double>();
-        Tensor scoresTensor = mWorkspace.GetBlob(label)->Get<Tensor>();
-        for (int j = 0; j < scoresTensor.numel(); j++) {
-          float score = scoresTensor.data<float>()[j];
-          _return[label].push_back(score);
-        }
-      }
+    if (tokens.size() == 0) {
+      // Add PAD_TOKEN in case of empty text
+      tokens.push_back("<pad>");
     }
+  }
+
+ public:
+  PredictorHandler(string& modelFile) {
+    mModule = torch::jit::load(modelFile);
+  }
+
+  void predict(map<string, double>& _return, const string& doc) {
+    // Pre-process: tokenize input doc
+    vector<string> tokens;
+    string docCopy = doc;
+    tokenize(tokens, docCopy);
+
+    // Prepare input for the model as a batch
+    vector<vector<string>> batch{tokens};
+    vector<torch::jit::IValue> inputs{
+        mDummyVec, // texts in model.forward
+        mDummyVecVec, // multi_texts in model.forward
+        batch // tokens in model.forward
+    };
+
+    // Run the model
+    auto output =
+        mModule.forward(inputs).toGenericListRef().at(0).toGenericDict();
+
+    // Extract and populate results into the response
+    for (const auto& elem : output) {
+      _return.insert({elem.key().toStringRef(), elem.value().toDouble()});
+    }
+  }
 };
 
 // REST proxy for the predictor Thrift service (not covered in tutorial)
 class RestProxyHandler : public Http::Handler {
-  private:
-    shared_ptr<TTransport> mTransport;
-    shared_ptr<PredictorClient> mPredictorClient;
+ private:
+  shared_ptr<TTransport> mTransport;
+  shared_ptr<PredictorClient> mPredictorClient;
 
-    string urlDecode(const string &encoded)
-    {
-      CURL *curl = curl_easy_init();
-      int decodedLength;
-      char *decodedCstr = curl_easy_unescape(
+  string urlDecode(const string &encoded)
+  {
+    CURL *curl = curl_easy_init();
+    int decodedLength;
+    char *decodedCstr = curl_easy_unescape(
         curl, encoded.c_str(), encoded.length(), &decodedLength);
-      string decoded(decodedCstr, decodedCstr + decodedLength);
-      curl_free(decodedCstr);
-      curl_easy_cleanup(curl);
-      return decoded;
-    }
+    string decoded(decodedCstr, decodedCstr + decodedLength);
+    curl_free(decodedCstr);
+    curl_easy_cleanup(curl);
+    return decoded;
+  }
 
-  public:
-    HTTP_PROTOTYPE(RestProxyHandler)
+ public:
+  HTTP_PROTOTYPE(RestProxyHandler)
 
-    RestProxyHandler(
+  RestProxyHandler(
       shared_ptr<TTransport>& transport,
       shared_ptr<PredictorClient>& predictorClient
     ) {
-      mTransport = transport;
-      mPredictorClient = predictorClient;
+    mTransport = transport;
+    mPredictorClient = predictorClient;
+  }
+
+  void onRequest(const Http::Request& request, Http::ResponseWriter response) {
+    const string docParam = "doc";
+    if (!mTransport->isOpen()) {
+      mTransport->open();
     }
 
-    void onRequest(const Http::Request& request, Http::ResponseWriter response) {
-      const string docParam = "doc";
-      if (!mTransport->isOpen()) {
-        mTransport->open();
-      }
-
-      stringstream out;
-      if (request.query().has(docParam)) {
-        string doc = urlDecode(request.query().get(docParam).get());
-        map<string, vector<double>> labelScores;
-        mPredictorClient->predict(labelScores, doc);
-        map<string, vector<double>>::iterator it;
-        for (it = labelScores.begin(); it != labelScores.end(); it++) {
-          out << it->first << ":";
-          for (int i = 0; i < it->second.size(); i++) {
-            out << it->second.at(i) << " ";
-          }
-
-          out << endl;
+    stringstream out;
+    if (request.query().has(docParam)) {
+      string doc = urlDecode(request.query().get(docParam).get());
+      map<string, double> scores;
+      mPredictorClient->predict(scores, doc);
+      for (const auto& score : scores) {
+        out << score.first << ":" << score.second << endl;
         }
 
-        response.send(Http::Code::Ok, out.str());
-      }
-      else {
-        out << "Missing query parameter: " << docParam << endl;
-        response.send(Http::Code::Bad_Request, out.str());
-      }
+      response.send(Http::Code::Ok, out.str());
     }
+    else {
+      out << "Missing query parameter: " << docParam << endl;
+      response.send(Http::Code::Bad_Request, out.str());
+    }
+  }
 };
 
 int main(int argc, char **argv) {
   // Parse command line args
   if (argc < 2) {
     cerr << "Usage:" << endl;
-    cerr << "./server <miniDB file>" << endl;
-    cerr << "./server <miniDB file> --no-rest" << endl;
+    cerr << "./server <model file>" << endl;
     return 1;
   }
 
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   string modelFile = argv[1];
-  bool proxyEnabled = true;
-  if (argc >= 3) {
-    const string noRestOption = "--no-rest";
-    if (noRestOption.compare(argv[2]) == 0) {
-      proxyEnabled = false;
-    }
-    else {
-      cerr << "Unrecognized argument: " << argv[2] << endl;
-      return 1;
-    }
-  }
-
-  int thriftPort = 9090;
-  int restPort = 8080;
 
   // Initialize predictor thrift service
   shared_ptr<PredictorHandler> handler(new PredictorHandler(modelFile));
   shared_ptr<TProcessor> processor(new PredictorProcessor(handler));
-  shared_ptr<TServerTransport> serverTransport(new TServerSocket(thriftPort));
+  shared_ptr<TServerTransport> serverTransport(new TServerSocket(FLAGS_port_thrift));
   shared_ptr<TTransportFactory> transportFactory(
-    new TBufferedTransportFactory());
+      new TBufferedTransportFactory());
   shared_ptr<TProtocolFactory> protocolFactory(new TBinaryProtocolFactory());
   TSimpleServer thriftServer(
-    processor, serverTransport, transportFactory, protocolFactory);
+      processor, serverTransport, transportFactory, protocolFactory);
   thread thriftThread([&](){ thriftServer.serve(); });
-  cout << "Server running. Thrift port: " << thriftPort;
+  cout << "Server running. Thrift port: " << FLAGS_port_thrift;
 
-  if (proxyEnabled) {
+  if (FLAGS_rest) {
     // Initialize Thrift client used to foward requests from REST
-    shared_ptr<TTransport> socket(new TSocket("127.0.0.1", 9090));
+    shared_ptr<TTransport> socket(new TSocket("127.0.0.1", FLAGS_port_thrift));
     shared_ptr<TTransport> transport(new TBufferedTransport(socket));
     shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
     shared_ptr<PredictorClient> predictorClient(new PredictorClient(protocol));
 
     // Initialize REST proxy
-    Address addr(Ipv4::any(), Port(restPort));
+    Address addr(Ipv4::any(), Port(FLAGS_port_rest));
     auto opts = Http::Endpoint::options().threads(1);
     Http::Endpoint restServer(addr);
     restServer.init(opts);
     restServer.setHandler(
-      make_shared<RestProxyHandler>(transport, predictorClient));
+        make_shared<RestProxyHandler>(transport, predictorClient));
     thread restThread([&](){ restServer.serve(); });
 
-    cout << ", REST port: " << restPort << endl;
+    cout << ", REST port: " << FLAGS_port_rest << endl;
     restThread.join();
   }
 

--- a/pytext/docs/source/serving_models_in_production.rst
+++ b/pytext/docs/source/serving_models_in_production.rst
@@ -1,9 +1,9 @@
 Serve Models in Production
 ======================================================
 
-We have seen how to use PyText models in an app using Flask in the `previous tutorial <pytext_models_in_your_app.html>`_, but the server implementation still requires a Python runtime. Caffe2 models are designed to perform well even in production scenarios with high requirements for performance and scalability.
+We have seen how to use PyText models in an app using Flask in the `previous tutorial <pytext_models_in_your_app.html>`_, but the server implementation still requires a Python runtime. TorchScript models are designed to perform well even in production scenarios with high requirements for performance and scalability.
 
-In this tutorial, we will implement a Thrift server in C++, in order to extract the maximum performance from our exported Caffe2 intent-slot model trained on the ATIS dataset. We will also prepare a Docker image which can be deployed to your cloud provider of choice.
+In this tutorial, we will implement a Thrift server in C++, in order to extract the maximum performance from our exported TorchScript text classification model trained on the demo dataset. We will also prepare a Docker image which can be deployed to your cloud provider of choice.
 
 The full source code for the implemented server in this tutorial can be found in the `demos directory <https://github.com/facebookresearch/pytext/tree/master/demo/predictor_service>`_.
 
@@ -12,71 +12,66 @@ To complete this tutorial, you will need to have `Docker <https://www.docker.com
 1. Create a Dockerfile and install dependencies
 ------------------------------------------------------
 
-The first step is to prepare our Docker image with the necessary dependencies. In an empty, folder, create a *Dockerfile* with the `following contents <https://github.com/facebookresearch/pytext/tree/master/demo/predictor_service/Dockerfile>`_:
+The first step is to prepare our Docker image with the necessary dependencies (including `libtorch <https://pytorch.org/cppdocs/installing.html>`_ for running TorchScript models). In an empty, folder, create a *Dockerfile* with the `following contents <https://github.com/facebookresearch/pytext/tree/master/demo/predictor_service/Dockerfile>`_:
 
 **Dockerfile**
 
 .. code-block:: dockerfile
 
-  FROM ubuntu:16.04
+  FROM ubuntu:18.04
 
-  # Install Caffe2 + dependencies
+  # Install dependencies
   RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    git \
-    libgoogle-glog-dev \
-    libgtest-dev \
-    libiomp-dev \
-    libleveldb-dev \
-    liblmdb-dev \
-    libopencv-dev \
-    libopenmpi-dev \
-    libsnappy-dev \
-    openmpi-bin \
-    openmpi-doc \
-    python-dev \
-    python-pip
-  RUN pip install --upgrade pip
-  RUN pip install setuptools wheel
-  RUN pip install future numpy protobuf typing hypothesis pyyaml
-  RUN apt-get install -y --no-install-recommends \
-        libgflags-dev \
-        cmake
-  RUN git clone https://github.com/pytorch/pytorch.git
-  WORKDIR pytorch
-  RUN git submodule update --init --recursive
-  RUN python setup.py install
-
-  # Install Thrift + dependencies
-  WORKDIR /
-  RUN apt-get update && apt-get install -y \
-    libboost-dev \
-    libboost-test-dev \
-    libboost-program-options-dev \
-    libboost-filesystem-dev \
-    libboost-thread-dev \
-    libevent-dev \
-    automake \
-    libtool \
+    ca-certificates \
+    cmake \
     curl \
-    flex \
-    bison \
-    pkg-config \
-    libssl-dev
-  RUN curl https://www-us.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz --output thrift-0.11.0.tar.gz
-  RUN tar -xvf thrift-0.11.0.tar.gz
-  WORKDIR thrift-0.11.0
-  RUN ./bootstrap.sh
-  RUN ./configure
-  RUN make
-  RUN make install
+    git \
+    libcurl4-openssl-dev \
+    libgflags-dev \
+    unzip
+
+  # Install libtorch
+  WORKDIR /
+  RUN curl https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.4.0%2Bcpu.zip --output libtorch.zip \
+      && unzip libtorch.zip \
+      && rm libtorch.zip
 
 2. Add Thrift API
 ---------------------------------------------
 
 `Thrift <https://thrift.apache.org/>`_ is a software library for developing scalable cross-language services. It comes with a client code generation engine enabling services to be interfaced across the network on multiple languages or devices. We will use Thrift to create a service which serves our model.
 
-Our C++ server will expose a very simple API that receives an sentence/utterance as a string, and return a map of label names(`string`) -> scores(`list<double>`). For document scores, the list will only contain one score, and for word scores, the list will contain one score per word. The corresponding thrift spec fo the API is below:
+Add the dependency on Thrift in the Dockerfile:
+
+.. code-block:: dockerfile
+
+  # Install Thrift + dependencies
+  WORKDIR /
+  RUN apt-get update && apt-get install -y \
+      libboost-dev \
+      libboost-test-dev \
+      libboost-program-options-dev \
+      libboost-filesystem-dev \
+      libboost-thread-dev \
+      libevent-dev \
+      automake \
+      libtool \
+      flex \
+      bison \
+      pkg-config \
+      libssl-dev \
+      && rm -rf /var/lib/apt/lists/*
+  RUN curl https://downloads.apache.org/thrift/0.13.0/thrift-0.13.0.tar.gz --output thrift-0.13.0.tar.gz \
+      && tar -xvf thrift-0.13.0.tar.gz \
+      && rm thrift-0.13.0.tar.gz
+  WORKDIR /thrift-0.13.0
+  RUN ./bootstrap.sh \
+      && ./configure \
+      && make \
+      && make install
+
+Our C++ server will expose a very simple API that receives a sentence/utterance as a string, and return a map of label names(`string`) -> scores(`double`). The corresponding thrift spec fo the API is below:
 
 **predictor.thrift**
 
@@ -85,8 +80,8 @@ Our C++ server will expose a very simple API that receives an sentence/utterance
   namespace cpp predictor_service
 
   service Predictor {
-     // Returns list of scores for each label
-     map<string,list<double>> predict(1:string doc),
+    // Returns scores for each class
+    map<string,double> predict(1:string doc),
   }
 
 3. Implement server code
@@ -100,30 +95,11 @@ Now, we will write our server's code. The first thing our server needs to be abl
 
   class PredictorHandler : virtual public PredictorIf {
     private:
-      NetDef mPredictNet;
-      Workspace mWorkspace;
-
-      NetDef loadAndInitModel(Workspace& workspace, string& modelFile) {
-        auto db = unique_ptr<DBReader>(new DBReader("minidb", modelFile));
-        auto metaNetDef = runGlobalInitialization(move(db), &workspace);
-        const auto predictInitNet = getNet(
-          *metaNetDef.get(),
-          PredictorConsts::default_instance().predict_init_net_type()
-        );
-        CAFFE_ENFORCE(workspace.RunNetOnce(predictInitNet));
-
-        auto predictNet = NetDef(getNet(
-          *metaNetDef.get(),
-          PredictorConsts::default_instance().predict_net_type()
-        ));
-        CAFFE_ENFORCE(workspace.CreateNet(predictNet));
-
-        return predictNet;
-      }
+      torch::jit::script::Module mModule;
   ...
     public:
-      PredictorHandler(string &modelFile): mWorkspace("workspace") {
-        mPredictNet = loadAndInitModel(mWorkspace, modelFile);
+      PredictorHandler(string& modelFile) {
+        mModule = torch::jit::load(modelFile);
       }
   ...
   }
@@ -132,7 +108,7 @@ Now, we will write our server's code. The first thing our server needs to be abl
 Now that our model is loaded, we need to implement the `predict` API method which is our main interface to clients. The implementation needs to do the following:
 
 1. Pre-process the input sentence into tokens
-2. Feed the input as tensors to the model
+2. Prepare input for the model as a batch
 3. Run the model
 4. Extract and populate the results into the response
 
@@ -143,36 +119,27 @@ Now that our model is loaded, we need to implement the `predict` API method whic
   class PredictorHandler : virtual public PredictorIf {
   ...
     public:
-      void predict(map<string, vector<double>>& _return, const string& doc) {
+      void predict(map<string, double>& _return, const string& doc) {
         // Pre-process: tokenize input doc
         vector<string> tokens;
         string docCopy = doc;
         tokenize(tokens, docCopy);
 
-        // Feed input to model as tensors
-        Tensor valTensor = TensorCPUFromValues<string>(
-          {static_cast<int64_t>(1), static_cast<int64_t>(tokens.size())}, {tokens}
-        );
-        BlobGetMutableTensor(mWorkspace.CreateBlob("tokens_vals_str:value"), CPU)
-          ->CopyFrom(valTensor);
-        Tensor lensTensor = TensorCPUFromValues<int>(
-          {static_cast<int64_t>(1)}, {static_cast<int>(tokens.size())}
-        );
-        BlobGetMutableTensor(mWorkspace.CreateBlob("tokens_lens"), CPU)
-          ->CopyFrom(lensTensor);
+        // Prepare input for the model as a batch
+        vector<vector<string>> batch{tokens};
+        vector<torch::jit::IValue> inputs{
+            mDummyVec, // texts in model.forward
+            mDummyVecVec, // multi_texts in model.forward
+            batch // tokens in model.forward
+        };
 
         // Run the model
-        CAFFE_ENFORCE(mWorkspace.RunNet(mPredictNet.name()));
+        auto output =
+            mModule.forward(inputs).toGenericListRef().at(0).toGenericDict();
 
         // Extract and populate results into the response
-        for (int i = 0; i < mPredictNet.external_output().size(); i++) {
-          string label = mPredictNet.external_output()[i];
-          _return[label] = vector<double>();
-          Tensor scoresTensor = mWorkspace.GetBlob(label)->Get<Tensor>();
-          for (int j = 0; j < scoresTensor.numel(); j++) {
-            float score = scoresTensor.data<float>()[j];
-            _return[label].push_back(score);
-          }
+        for (const auto& elem : output) {
+          _return.insert({elem.key().toStringRef(), elem.value().toDouble()});
         }
       }
   ...
@@ -180,12 +147,12 @@ Now that our model is loaded, we need to implement the `predict` API method whic
 
 The full source code for *server.cpp* can be found `here <https://github.com/facebookresearch/pytext/tree/master/demo/predictor_service/server.cpp>`__.
 
-Note: The source code in the demo also implements a REST proxy for the Thrift server to make it easy to test and make calls over simple HTTP, however it is not covered in the scope of this tutorial since the Thrift protocol is what we'll use in production.
+Note: The source code in the demo also implements a REST proxy for the Thrift server to make it easy to test and make calls over simple HTTP. Feel free to use that if you don't need to pass raw tensors into your model.
 
 4. Build and compile scripts
 ------------------------------
 
-To build our server, we need to provide necessary headers during compile time and the required dependent libraries during link time: *libthrift.so*, *libcaffe2.so*, *libprotobuf.so* and *libc10.so*. The *Makefile* below does this:
+To build our server, we need to provide necessary headers during compile time and the required dependent libraries during link time. The *Makefile* below does this:
 
 **Makefile**
 
@@ -193,19 +160,17 @@ To build our server, we need to provide necessary headers during compile time an
 
   CPPFLAGS += -g -std=c++11 -std=c++14 \
     -I./gen-cpp \
-    -I/pytorch -I/pytorch/build \
-  	-I/pytorch/aten/src/ \
-  	-I/pytorch/third_party/protobuf/src/
+    -I/libtorch/include \
+    -Wno-deprecated-declarations
   CLIENT_LDFLAGS += -lthrift
-  SERVER_LDFLAGS += -L/pytorch/build/lib -lthrift -lcaffe2 -lprotobuf -lc10
-
-  # ...
+  SERVER_LDFLAGS += -L/libtorch/lib \
+    -lthrift -lpistache -lpthread -ltorch -lc10 -lcurl -lgflags
 
   server: server.o gen-cpp/Predictor.o
-  	g++ $^ $(SERVER_LDFLAGS) -o $@
+    g++ $^ $(SERVER_LDFLAGS) -o $@
 
   clean:
-  	rm -f *.o server
+    rm -f *.o server
 
 In our *Dockerfile*, we also add some steps to copy our local files into the docker image, compile the app, and add the necessary library search paths.
 
@@ -222,18 +187,21 @@ In our *Dockerfile*, we also add some steps to copy our local files into the doc
   RUN make
 
   # Add library search paths
-  RUN echo '/pytorch/build/lib/' >> /etc/ld.so.conf.d/local.conf
-  RUN echo '/usr/local/lib/' >> /etc/ld.so.conf.d/local.conf
-  RUN ldconfig
+  ENV LD_LIBRARY_PATH /libtorch/lib:/usr/local/lib
 
 5. Test/Run the server
 -------------------------
 
-This section assumes that your local files match the one found `here <https://github.com/facebookresearch/pytext/tree/master/demo/predictor>`__.
+To obtain a sample TorchScript model, run the following commads in your PyText directory:
 
-Now that you have implemented your server, we will run the following commands to take it for a test run. In your server folder:
+.. code-block:: console
 
-1. Build the image:
+  (pytext) $ pytext train < demo/configs/docnn.json
+  (pytext) $ pytext torchscript-export < demo/configs/docnn.json
+
+This creates a */tmp/model.pt.torchscript* file which you should copy into the server directory where you wrote the files in the previous section. This section assumes that this directory matches the one found `here <https://github.com/facebookresearch/pytext/blob/master/demo/predictor_service/>`__. 
+
+1. Build the Docker image:
 
 .. code-block:: console
 
@@ -241,26 +209,29 @@ Now that you have implemented your server, we will run the following commands to
 
 If successful, you should see the message "Successfully tagged predictor_service:latest".
 
-2. Run the server. We use *models/atis_joint_model.c2* as the local path to our model file (add your trained model there):
+2. Run the server:
 
 .. code-block:: console
 
-  $ docker run -it -p 8080:8080 predictor_service:latest ./server models/atis_joint_model.c2
+  $ docker run -it -p 8080:8080 predictor_service:latest ./server model.pt.torchscript
 
 If successful, you should see the message "Server running. Thrift port: 9090, REST port: 8080"
 
-3. Test our server by sending a test utterance "Flight from Seattle to San Francisco":
+3. Test our server by sending a test utterance "set an alarm":
 
 .. code-block:: console
 
-  $ curl -G "http://localhost:8080" --data-urlencode "doc=Flights from Seattle to San Francisco"
+  $ curl -G "http://localhost:8080" --data-urlencode "doc=set an alarm"
 
-If successful, you should see the scores printed out on the console. On further inspection, the doc score for "flight", the 3rd word score for "B-fromloc.city_name" corresponding to "Seattle", the 5th word score for "B-toloc.city_name" corresponding to "San", and the 6th word score for "I-toloc.city_name" corresponding to "Francisco" should be close to 0. ::
+If successful, you should see the scores printed out on the console. On further inspection, the score for "alarm/set_alarm" is the highest among the classes. ::
 
-  doc_scores:flight:-2.07426e-05
-  word_scores:B-fromloc.city_name:-14.5363 -12.8977 -0.000172928 -12.9868 -9.94603 -16.0366
-  word_scores:B-toloc.city_name:-15.2309 -15.9051 -9.89932 -12.077 -0.000134 -8.52712
-  word_scores:I-toloc.city_name:-13.1989 -16.8094 -15.9375 -12.5332 -10.7318 -0.000501401
+  alarm/modify_alarm:-1.99205
+  alarm/set_alarm:-1.8802
+  alarm/snooze_alarm:-1.89931
+  alarm/time_left_on_alarm:-2.00953
+  reminder/set_reminder:-2.00718
+  reminder/show_reminders:-1.91181
+  weather/find:-1.93019
 
 Congratulations! You have now built your own server that can serve your PyText models in production!
 


### PR DESCRIPTION
Summary:
Migrating serving tutorial Caffe2 --> TorchScript

Also pushed image to Docker hub at https://hub.docker.com/repository/docker/pytext/predictor_service_torchscript

Reviewed By: geof90

Differential Revision: D20939160

