### PR TITLE
Add onnx_trace_input function in model

### DIFF
--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -211,6 +211,10 @@ class BaseModel(nn.Module, Component):
         # should raise NotImplementedError after migration is done
         return None
 
+    def onnx_trace_input(self, tensor_dict):
+        # default behavior is the same as getting model inputs
+        return self.arrange_model_inputs(tensor_dict)
+
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
         pass
 

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -288,7 +288,7 @@ class _NewTask(TaskBase):
         unused_raw_batch, batch = next(
             iter(self.data.batches(Stage.TRAIN, load_early=True))
         )
-        inputs = model.arrange_model_inputs(batch)
+        inputs = model.onnx_trace_input(batch)
         # call model forward to set correct device types
         model(*inputs)
         if quantize:


### PR DESCRIPTION
Summary: add onnx_trace_input in BaseModel so it can be override when needed, should have no impact on any existing models

Differential Revision: D21033319

