### PR TITLE
add a new PyText get_num_examples_from_batch function in model

### DIFF
--- a/pytext/models/doc_model.py
+++ b/pytext/models/doc_model.py
@@ -88,6 +88,10 @@ class DocModel(Model):
     def arrange_targets(self, tensor_dict):
         return tensor_dict["labels"]
 
+    def get_num_examples_from_batch(self, tensor_dict):
+        targets = self.arrange_targets(tensor_dict)
+        return len(targets)
+
     def get_export_input_names(self, tensorizers):
         res = ["tokens_vals", "tokens_lens"]
         if "dense" in tensorizers:

--- a/pytext/models/language_models/lmlstm.py
+++ b/pytext/models/language_models/lmlstm.py
@@ -142,6 +142,11 @@ class LMLSTM(BaseModel):
         tokens, seq_lens, _ = tensor_dict["tokens"]
         return (tokens[:, 1:].contiguous(), seq_lens - 1)
 
+    def get_num_examples_from_batch(self, batch):
+        targets = self.arrange_targets(batch)
+        num_words_in_batch = targets[1].sum().item()
+        return num_words_in_batch
+
     def get_export_input_names(self, tensorizers):
         return ["tokens_vals", "tokens_lens"]
 

--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -228,6 +228,9 @@ class BaseModel(nn.Module, Component):
                 flat_model_inputs.append(model_input)
         return flat_model_inputs
 
+    def get_num_examples_from_batch(self, batch):
+        pass
+
 
 class Model(BaseModel):
     """

--- a/pytext/models/query_document_pairwise_ranking_model.py
+++ b/pytext/models/query_document_pairwise_ranking_model.py
@@ -86,6 +86,13 @@ class QueryDocPairwiseRankingModel(PairwiseModel):
     def arrange_targets(self, tensor_dict):
         return {}
 
+    def get_num_examples_from_batch(self, tensor_dict):
+        inputs = self.arrange_model_inputs(tensor_dict)
+        query = inputs[2]
+        query_lengths = query[1]
+        num_queries = query_lengths.shape[0]
+        return num_queries
+
     def forward(
         self,
         pos_response: Tuple[torch.Tensor, torch.Tensor],


### PR DESCRIPTION
Summary:
Usually in PyText dataloader, each row (sentence) is read as an example, i.e. create List[sentences], and the number of examples in the batch is simply len(List[data]).

This is not correct for language model: in LM, each word is considered as an example.

Reviewed By: kmalik22

Differential Revision: D21032297

