### PR TITLE
MultiLabel-MultiClass Model for Joint Sequence Tagging

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -853,8 +853,8 @@ class LabelListTensorizer(LabelTensorizer):
                     label_idx_list.append(self.pad_idx)
                 else:
                     raise Exception(
-                        "Found none or empty value in the list,"
-                        + " while pad_missing is disabled"
+                        "Found none or empty value in the list, \
+                        while pad_missing is disabled"
                     )
             else:
                 label_idx_list.append(self.vocab.lookup_all(label))

--- a/pytext/metric_reporters/__init__.py
+++ b/pytext/metric_reporters/__init__.py
@@ -15,6 +15,7 @@ from .pairwise_ranking_metric_reporter import PairwiseRankingMetricReporter
 from .regression_metric_reporter import RegressionMetricReporter
 from .squad_metric_reporter import SquadMetricReporter
 from .word_tagging_metric_reporter import (
+    MultiLabelSequenceTaggingMetricReporter,
     NERMetricReporter,
     SequenceTaggingMetricReporter,
     WordTaggingMetricReporter,
@@ -26,6 +27,7 @@ __all__ = [
     "MetricReporter",
     "ClassificationMetricReporter",
     "MultiLabelClassificationMetricReporter",
+    "MultiLabelSequenceTaggingMetricReporter",
     "RegressionMetricReporter",
     "IntentSlotMetricReporter",
     "LanguageModelMetricReporter",

--- a/pytext/metrics/__init__.py
+++ b/pytext/metrics/__init__.py
@@ -753,6 +753,37 @@ def compute_multi_label_soft_metrics(
     return soft_metrics
 
 
+def compute_multi_label_multi_class_soft_metrics(
+    predictions: Sequence[Sequence[LabelListPrediction]],
+    label_names: Sequence[str],
+    label_vocabs: Sequence[Sequence[str]],
+    recall_at_precision_thresholds: Sequence[float] = RECALL_AT_PRECISION_THRESHOLDS,
+    precision_at_recall_thresholds: Sequence[float] = PRECISION_AT_RECALL_THRESHOLDS,
+) -> Dict[int, SoftClassificationMetrics]:
+    """
+
+    Computes multi-label soft classification metrics with multi-class accommodation
+
+    Args:
+        predictions: multi-label predictions,
+                     including the confidence score for each label.
+        label_names: Indexed label names.
+        recall_at_precision_thresholds: precision thresholds at which to calculate
+            recall
+        precision_at_recall_thresholds: recall thresholds at which to calculate
+            precision
+
+
+    Returns:
+        Dict from label strings to their corresponding soft metrics.
+    """
+    soft_metrics = {}
+    for label_idx, label_vocab in enumerate(label_vocabs):
+        label = list(label_names)[label_idx]
+        soft_metrics[label] = compute_soft_metrics(predictions[label_idx], label_vocab)
+    return soft_metrics
+
+
 def compute_matthews_correlation_coefficients(
     TP: int, FP: int, FN: int, TN: int
 ) -> float:

--- a/pytext/models/decoders/multilabel_decoder.py
+++ b/pytext/models/decoders/multilabel_decoder.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+from pytext.utils.usage import log_class_usage
+
+from .decoder_base import DecoderBase
+
+
+class MultiLabelDecoder(DecoderBase):
+    """
+    Implements a 'n-tower' MLP: one for each of the multi labels
+    Used in USM/EA: the user satisfaction modeling, pTSR prediction and
+    Error Attribution are all 3 label sets that need predicting.
+
+    """
+
+    class Config(DecoderBase.Config):
+        # Intermediate hidden dimensions
+        hidden_dims: List[int] = []
+
+    def __init__(
+        self,
+        config: Config,
+        in_dim: int,
+        output_dim: Dict[str, int],
+        label_names: List[str],
+    ) -> None:
+        super().__init__(config)
+        self.label_mlps = nn.ModuleDict({})
+        # Store the ordered list to preserve the ordering of the labels
+        # when generating the output layer
+        self.label_names = label_names
+        aggregate_out_dim = 0
+        for label_, _ in output_dim.items():
+            self.label_mlps[label_] = MultiLabelDecoder.get_mlp(
+                in_dim, output_dim[label_], config.hidden_dims
+            )
+            aggregate_out_dim += output_dim[label_]
+        self.out_dim = (1, aggregate_out_dim)
+        log_class_usage(__class__)
+
+    @staticmethod
+    def get_mlp(in_dim: int, out_dim: int, hidden_dims: List[int]):
+        layers = []
+        current_dim = in_dim
+        for dim in hidden_dims or []:
+            layers.append(nn.Linear(current_dim, dim))
+            layers.append(nn.ReLU())
+            current_dim = dim
+        layers.append(nn.Linear(current_dim, out_dim))
+        return nn.Sequential(*layers)
+
+    def forward(self, *input: torch.Tensor):
+        logits = tuple(
+            self.label_mlps[x](torch.cat(input, 1)) for x in self.label_names
+        )
+        return logits
+
+    def get_decoder(self) -> List[nn.Module]:
+        return self.label_mlps

--- a/pytext/models/output_layers/doc_classification_output_layer.py
+++ b/pytext/models/output_layers/doc_classification_output_layer.py
@@ -128,7 +128,7 @@ class ClassificationScores(jit.ScriptModule):
 class BinaryClassificationOutputLayer(ClassificationOutputLayer):
     def get_pred(self, logit, *args, **kwargs):
         """See `OutputLayerBase.get_pred()`."""
-        preds = torch.max(logit, 1)[1]
+        preds = torch.max(logit, -1)[1]
         scores = F.logsigmoid(logit)
         return preds, scores
 
@@ -153,7 +153,7 @@ class BinaryClassificationOutputLayer(ClassificationOutputLayer):
 class MulticlassOutputLayer(ClassificationOutputLayer):
     def get_pred(self, logit, *args, **kwargs):
         """See `OutputLayerBase.get_pred()`."""
-        preds = torch.max(logit, 1)[1]
+        preds = torch.max(logit, -1)[1]
         scores = F.log_softmax(logit, 1)
         return preds, scores
 

--- a/pytext/models/output_layers/multi_label_classification_layer.py
+++ b/pytext/models/output_layers/multi_label_classification_layer.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import functools
+import operator
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from caffe2.python import core
+from pytext.data.tensorizers import Tensorizer
+from pytext.models.module import create_module
+from pytext.utils.usage import log_class_usage
+from torch import jit
+
+from .doc_classification_output_layer import ClassificationOutputLayer
+from .output_layer_base import OutputLayerBase
+
+
+class MultiLabelClassificationScores(nn.Module):
+    def __init__(self, scores: jit.ScriptModule):
+        super().__init__()
+        self.scores = scores
+        log_class_usage(__class__)
+
+    def forward(
+        self, logits: List[torch.Tensor]
+    ) -> Tuple[List[List[Dict[str, float]]]]:
+
+        results = []
+        for logit_ in logits:
+            results.append(self.scores(logit_))
+        return results
+
+
+class MultiLabelClassificationLayer(OutputLayerBase):
+    """
+    Output layer for multilabel sequence classification models.
+
+    Args:
+        output (List[WordTaggingOutputLayer]): Output for multilabels, here
+            USM + PTSR + EA task.
+
+        label_names (List[str]): Ordered list of labels predicted through the model
+            for which the losses need to be aggregated by the output layer
+
+        label_tensorizer (Dict[str, LabelListTensorizer]): Dict of list of labels
+            that constitute the output from the decoder ordered by label_names
+            sequencing
+
+        optional label_weights (Dict[str, int]): Dict of label_names along with the
+        weight for label
+
+    Attributes:
+        output (type): Output layer for multilabel-multiclass classification task
+        label_names (type): List of labels to be predicted by the model
+        label_tensorizer (type): Dict of key-label names with values-tensorizers
+        used to compute the size of the label vocab
+        optional label_weights (type): Dict of label-weight to compute weighted
+        output layer
+
+    """
+
+    class Config(OutputLayerBase.Config):
+        output: List[ClassificationOutputLayer.Config] = []
+        label_weights: Dict[str, float] = {}
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Config,
+        label_tensorizers: [Dict[str, Tensorizer]],
+        label_names: [List[str]],
+    ):
+        modules = []
+        for label_idx in range(0, len(label_names)):
+            label_ = label_names[label_idx]
+            modules.append(
+                create_module(
+                    config.output[label_idx], labels=label_tensorizers[label_].vocab
+                )
+            )
+        print("Created Modules", len(modules))
+        return cls(modules, label_names, config.label_weights)
+
+    def __init__(
+        self,
+        output: List[ClassificationOutputLayer],
+        label_names: List[str],
+        label_weights: Optional[Dict[str, float]] = None,
+    ) -> None:
+        super().__init__()
+        self.output = output
+        self.label_names = label_names
+        self.label_weights = label_weights
+        log_class_usage(__class__)
+
+    def get_loss(
+        self,
+        logits,
+        targets: List[torch.Tensor],
+        context: Optional[Dict[str, Any]] = None,
+        *args,
+        **kwargs
+    ) -> torch.Tensor:
+        """Compute and return the averaged intent and slot-filling loss.
+
+        Args:
+            logits (List[tuple[torch.Tensor]]): Logits returned by
+                :class:`~pytext.models.decoders.MultiLabelDecoder`. It's list
+                containing logits for all label tasks here pTSR, autoUSM and EA.
+            targets (List[tuple[torch.Tensor]]): Targets as computed by the true labels
+            optional label_weights (Dict[str, float]): Label weights for multi-label
+            ordering of logits corresponding the respective label.
+            targets (Optional[torch.Tensor]): Not applicable. Defaults to None.
+
+        Returns:
+            torch.Tensor: Averaged Loss across all label losses.
+        """
+        loss = 0
+        for label_idx, label_name in enumerate(self.label_names):
+            logit = logits[label_idx]
+            # [batch_size * seq_lens, dim]
+            flattened_logit = logit.view(-1, logit.size()[-1])
+            loss += self.output[label_idx].get_loss(
+                flattened_logit, targets[label_idx].view(-1), None
+            )
+            if self.label_weights:
+                weight = self.label_weights[label_name]
+                loss = torch.mean(torch.mul(loss, weight))
+        loss = loss / (len(self.label_names) * 1.0)
+        return loss
+
+    def get_pred(
+        self,
+        logits: List[torch.Tensor],
+        targets: List[torch.Tensor],
+        context: Optional[Dict[str, Any]] = None,
+        *args,
+        **kwargs
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute and return prediction and scores from the model.
+
+        Prediction is computed using argmax over the document label/target space.
+
+        Scores are sigmoid or softmax scores over the model logits depending on
+        the loss component being used.
+
+        Args:
+            logits (List[torch.Tensor]): Logits returned by
+                :class:`~pytext.models.decoders.MultiLabelDecoder`. It's list
+                containing logits for all label tasks here pTSR, autoUSM and EA.
+            targets (List[tuple[torch.Tensor]]): Targets as computed by the true labels
+            ordering of logits corresponding the respective label.
+            targets (Optional[torch.Tensor]): Not applicable. Defaults to None.
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: Model prediction and scores.
+
+        """
+        # The assumption here is that the logit is a concat of the
+        # label predictions ordered by label list.
+        scores = []
+        preds = []
+        for label_idx, logit in enumerate(logits):
+            pred, score = self.output[label_idx].get_pred(logit)
+            preds.append(pred)
+            scores.append(score)
+        return (preds, scores)
+
+    def export_to_caffe2(
+        self,
+        workspace: core.workspace,
+        init_net: core.Net,
+        predict_net: core.Net,
+        model_out: List[torch.Tensor],
+        out_name: str,
+    ) -> List[core.BlobReference]:
+        """
+        Exports the multilabel output layer to Caffe2.
+        See `OutputLayerBase.export_to_caffe2()` for details.
+        """
+
+        return functools.reduce(
+            operator.add,
+            [
+                self.output[idx].export_to_caffe2(
+                    workspace, init_net, predict_net, model_out[idx], out_name
+                )
+                for idx, single_output in enumerate(model_out)
+            ],
+        )
+
+    def torchscript_predictions(self):
+        scores = self.output.torchscript_predictions()
+        return jit.script(MultiLabelClassificationScores(scores))

--- a/pytext/models/output_layers/word_tagging_output_layer.py
+++ b/pytext/models/output_layers/word_tagging_output_layer.py
@@ -84,6 +84,9 @@ class WordTaggingOutputLayer(OutputLayerBase):
         ] = CrossEntropyLoss.Config()
         label_weights: Dict[str, float] = {}
         ignore_pad_in_loss: Optional[bool] = True
+        # This will be useful for nested output layers
+        # as in the case of multilabel joint models.
+        output: Optional[OutputLayerBase.Config] = OutputLayerBase.Config()
 
     @classmethod
     def from_config(cls, config: Config, labels: Vocabulary):

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -590,7 +590,8 @@ class Trainer(TrainerBase):
 
             if batch_id % self.config.num_samples_to_log_progress == 0:
                 print(
-                    f"Running batch {batch_id} for epoch {state.epoch} in {state.stage} stage",
+                    f"Running batch {batch_id} for epoch {state.epoch} \
+                        in {state.stage} stage",
                     flush=True,
                 )
         # update gradients after len(samples) forward & backward

--- a/pytext/utils/label.py
+++ b/pytext/utils/label.py
@@ -15,7 +15,8 @@ def get_label_weights(vocab_dict: Dict[str, int], label_weights: Dict[str, float
     if len(pruned_label_weights) != len(label_weights):
         filtered_labels = [k for k in label_weights if k not in vocab_dict]
         print(
-            f"Warning: these labels are filtered from original label weights {filtered_labels}"
+            f"Warning: these labels are filtered from original label weights \
+            {filtered_labels}"
         )
     if len(pruned_label_weights) == 0:
         return None


### PR DESCRIPTION
Summary:
We need to support multi-class as well as multi-label prediction for joint models in pytext. This diff implements a

1. Joint Multi Label Decoder
2. MultiLabelClassification Output Layer
3. Loss computation for multi-label-multi-class scenarios
4. Label weights per label and per class
5. Softmax options for output layers
6. Custom Metric Reporter, Metric Class and Output for flow

Reviewed By: seayoung1112

Differential Revision: D20210880

