### PR TITLE
handle resources for both internal and OSS

### DIFF
--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 from fairseq.data.dictionary import Dictionary
 from fairseq.data.legacy.masked_lm_dictionary import BertDictionary
+from pytext import resources
 from pytext.config.component import ComponentType, create_component
 from pytext.data.tensorizers import Tensorizer, TensorizerScriptImpl
 from pytext.data.tokenizers import Tokenizer, WordPieceTokenizer
@@ -379,6 +380,11 @@ class BERTTensorizer(BERTTensorizerBase):
                 replacements=special_token_replacements,
             )
         else:
+            config.vocab_file = (
+                resources.roberta.RESOURCE_MAP[config.vocab_file]
+                if config.vocab_file in resources.roberta.RESOURCE_MAP
+                else config.vocab_file
+            )
             with PathManager.open(config.vocab_file) as file_path:
                 vocab = build_fairseq_vocab(
                     dictionary_class=BertDictionary,

--- a/pytext/data/roberta_tensorizer.py
+++ b/pytext/data/roberta_tensorizer.py
@@ -5,6 +5,7 @@ import itertools
 from typing import Any, Dict, List, Tuple
 
 import torch
+from pytext import resources
 from pytext.config.component import ComponentType, create_component
 from pytext.data.bert_tensorizer import (
     BERTTensorizerBase,
@@ -26,9 +27,8 @@ class RoBERTaTensorizer(BERTTensorizerBase):
     __TENSORIZER_SCRIPT_IMPL__ = RoBERTaTensorizerScriptImpl
 
     class Config(BERTTensorizerBase.Config):
-        vocab_file: str = (
-            "manifold://pytext_training/tree/static/vocabs/bpe/gpt2/dict.txt"
-        )
+        # any unittest should be overriding this with a small local file
+        vocab_file: str = resources.roberta.GPT2_BPE_DICT
         tokenizer: Tokenizer.Config = GPT2BPETokenizer.Config()
         max_seq_len: int = 256
 
@@ -40,6 +40,13 @@ class RoBERTaTensorizer(BERTTensorizerBase):
             base_tokenizer = create_component(
                 ComponentType.TOKENIZER, config.base_tokenizer
             )
+
+        # map to the real vocab_file
+        config.vocab_file = (
+            resources.roberta.RESOURCE_MAP[config.vocab_file]
+            if config.vocab_file in resources.roberta.RESOURCE_MAP
+            else config.vocab_file
+        )
         with PathManager.open(config.vocab_file) as f:
             vocab = build_fairseq_vocab(
                 vocab_file=f,

--- a/pytext/data/squad_for_bert_tensorizer.py
+++ b/pytext/data/squad_for_bert_tensorizer.py
@@ -5,6 +5,7 @@ import itertools
 from typing import List
 
 import torch
+from pytext import resources
 from pytext.config.component import ComponentType, create_component
 from pytext.data.bert_tensorizer import BERTTensorizer, build_fairseq_vocab
 from pytext.data.roberta_tensorizer import RoBERTaTensorizer
@@ -261,6 +262,12 @@ class SquadForRoBERTaTensorizer(SquadForBERTTensorizer, RoBERTaTensorizer):
     @classmethod
     def from_config(cls, config: Config):
         tokenizer = create_component(ComponentType.TOKENIZER, config.tokenizer)
+
+        config.vocab_file = (
+            resources.roberta.RESOURCE_MAP[config.vocab_file]
+            if config.vocab_file in resources.roberta.RESOURCE_MAP
+            else config.vocab_file
+        )
         with PathManager.open(config.vocab_file) as file_path:
             vocab = build_fairseq_vocab(
                 vocab_file=file_path,

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -4,6 +4,7 @@
 from typing import Dict, Optional, Tuple
 
 import torch
+from pytext import resources
 from pytext.common.constants import Stage
 from pytext.config import ConfigBase
 from pytext.data.roberta_tensorizer import (
@@ -63,9 +64,7 @@ class RoBERTaEncoderJit(RoBERTaEncoderBase):
 
     class Config(RoBERTaEncoderBase.Config):
         pretrained_encoder: Module.Config = Module.Config(
-            load_path=(
-                "manifold://pytext_training/tree/static/models/roberta_public.pt1"
-            )
+            load_path=resources.roberta.PUBLIC
         )
 
     def __init__(self, config: Config, output_encoded_layers: bool, **kwarg) -> None:
@@ -99,6 +98,13 @@ class RoBERTaEncoder(RoBERTaEncoderBase):
 
     def __init__(self, config: Config, output_encoded_layers: bool, **kwarg) -> None:
         super().__init__(config, output_encoded_layers=output_encoded_layers)
+
+        # map to the real model_path
+        config.model_path = (
+            resources.roberta.RESOURCE_MAP[config.model_path]
+            if config.model_path in resources.roberta.RESOURCE_MAP
+            else config.model_path
+        )
         # assert config.pretrained_encoder.load_path, "Load path cannot be empty."
         self.encoder = SentenceEncoder(
             transformer=Transformer(

--- a/pytext/resources/__init__.py
+++ b/pytext/resources/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from . import roberta
+
+
+__all__ = ["roberta"]

--- a/pytext/resources/roberta.py
+++ b/pytext/resources/roberta.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+PUBLIC = "public"
+GPT2_BPE_DICT = "gpt2_bpe_dict"
+GPT2_BPE_VOCAB = "gpt2_bpe_vocab"
+GPT2_BPE_ENCODER = "gpt2_bpe_encoder"
+
+# Put public URLs here for OSS
+RESOURCE_MAP = {
+    PUBLIC: "https//dl.fbaipublicfiles.com/pytext/models/roberta/roberta_public.pt1",
+    GPT2_BPE_DICT: "https://dl.fbaipublicfiles.com/pytext/vocabs/gpt2_bpe/dict.txt",
+    GPT2_BPE_VOCAB: "https://dl.fbaipublicfiles.com/pytext/vocabs/gpt2_bpe/vocab.bpe",
+    GPT2_BPE_ENCODER: "https://dl.fbaipublicfiles.com/pytext/vocabs/gpt2_bpe/encoder.json",
+}

--- a/pytext/utils/file_io.py
+++ b/pytext/utils/file_io.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from fvcore.common.file_io import HTTPURLHandler, PathManager
+
+# keep PathManager here for more flexibility until PathManager becomes more mature
+# in case we want some hacks in PathManager, we can do it here without updating
+# the import everywhere in PyText
+from fvcore.common.file_io import HTTPURLHandler, PathManager  # noqa
 
 
 def register_http_url_handler():


### PR DESCRIPTION
Summary:
## Problems:
1. We have hard coded manifold URLs in OSS code, which blocks OSS users from loading pre-trained models and tokenizers.
2. Notebooks can't run in both Bento and OSS, due to different ways to fetch resources. The former doesn't have access to public internet, the latter doesn't have access to Manifold.

## Proposing Approach
Introduce "Resource Id", which has 1 to many relationship to resource URLs. It can be mapped to a corresponding URL in the following scenarios:
1. For OSS, it will be mapped to a public HTTPS URL. We can store the public files in Fair's AWS S3 bucket
2. For internal, it will be mapped to a Manifold URL
3. For tests, it will be mapped to a tiny local file(lives in code repo to make the test faster and less flaky)

e.g. config json including a pre-trained RoBERTa model:
```
"RoBERTaEncoder": {
...
"model_path": "pytext.roberta_public",
...
}
```
**resource_id**: "pytext.roberta_public"
* resource URL for OSS:
"https//dl.fbaipublicfiles.com/pytext/models/roberta/roberta_public.pt1"
* resource URL for internal: "manifold://nlp_technologies/tree/pytext/public/models/roberta/roberta_public.pt1"
* resource URL for tests:
"fbsource/fbcode/pytext/resources/tiny_roberta_public.pt1"

Reviewed By: snisarg, chenyangyu1988

Differential Revision: D21007233

