### PR TITLE
Fix RoBERTa Q&A Training Bug with multiple BoS tokens.

### DIFF
--- a/pytext/data/squad_for_bert_tensorizer.py
+++ b/pytext/data/squad_for_bert_tensorizer.py
@@ -54,6 +54,7 @@ class SquadForBERTTensorizer(BERTTensorizer):
         self.answer_starts_column = answer_starts_column
 
     def _lookup_tokens(self, text: str, seq_len: int = None):
+        # BoS token is added explicitly in numberize()
         return lookup_tokens(
             text,
             tokenizer=self.tokenizer,
@@ -309,11 +310,12 @@ class SquadForRoBERTaTensorizer(SquadForBERTTensorizer, RoBERTaTensorizer):
         self.wrap_special_tokens = False
 
     def _lookup_tokens(self, text: str, seq_len: int = None):
+        # BoS token is added explicitly in numberize()
         return lookup_tokens(
             text,
             tokenizer=self.tokenizer,
             vocab=self.vocab,
-            bos_token=self.vocab.bos_token,
+            bos_token=None,
             eos_token=self.vocab.eos_token,
             max_seq_len=seq_len if seq_len else self.max_seq_len,
         )

--- a/pytext/data/test/tensorizers_test.py
+++ b/pytext/data/test/tensorizers_test.py
@@ -1075,8 +1075,8 @@ class SquadForRobertaTensorizerTest(unittest.TestCase):
         tokens, segments, seq_len, positions, start, end = tensorizer.numberize(row)
         # check against manually verified answer positions in tokenized output
         # there are 4 identical answers
-        self.assertEqual(start, [5])
-        self.assertEqual(end, [5])
+        self.assertEqual(start, [3])
+        self.assertEqual(end, [3])
         self.assertEqual(len(tokens), seq_len)
         self.assertEqual(len(segments), seq_len)
 


### PR DESCRIPTION
Summary:
SquadForRoBERTaTensorizer adds two BoS tokens to the input sequence during training and eval which differs from inference time behavior.
This diff fixes that bug.

Differential Revision: D21287576

