### PR TITLE
Papaya trainers take Config as input

### DIFF
--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -94,19 +94,6 @@ def _union_from_json(subclasses, json_obj):
         ) from e
 
 
-def _any_from_json(cls, json_obj):
-    if _is_dict(json_obj):
-        if len(json_obj) == 1:
-            type_name, value = list(json_obj.keys())[0], list(json_obj.values())[0]
-            assert (
-                type_name == type(value).__name__
-            ), f"type of value mismatches: {type_name} vs. {type(value).__name__} from {value}"
-            return value
-        else:
-            raise TypeError("PyText Config currently don't support this")
-    return json_obj
-
-
 def _is_optional(cls):
     return _get_class_type(cls) == Union and type(None) in cls.__args__
 
@@ -132,7 +119,7 @@ def _value_from_json(cls, value):
     elif hasattr(cls, "_fields"):
         return config_from_json(cls, value)
     elif cls_type == Any:
-        return _any_from_json(cls, value)
+        return value
     elif cls_type == Union:
         return _union_from_json(cls.__args__, value)
     elif issubclass(cls_type, Enum):
@@ -236,11 +223,13 @@ def _value_to_json(cls, value):
     elif _is_optional(cls) and len(cls.__args__) == 2:
         sub_cls = cls.__args__[0] if type(None) != cls.__args__[0] else cls.__args__[1]
         return _value_to_json(sub_cls, value)
-    elif cls_type == Any or cls_type == Union or getattr(cls, "__EXPANSIBLE__", False):
+    elif cls_type == Union or getattr(cls, "__EXPANSIBLE__", False):
         real_cls = type(value)
         if hasattr(real_cls, "_fields"):
             value = config_to_json(real_cls, value)
         return {_canonical_typename(real_cls): value}
+    elif cls_type == Any:
+        return value
     # nested config
     elif hasattr(cls, "_fields"):
         return config_to_json(cls, value)

--- a/pytext/config/test/serialize_test.py
+++ b/pytext/config/test/serialize_test.py
@@ -4,7 +4,7 @@
 import unittest
 from typing import Any, Dict, Union
 
-from pytext.config import serialize
+from pytext.config import ConfigBase, pytext_config_from_json, serialize
 
 
 SAMPLE_INT_JSON = {"int": 6}
@@ -12,11 +12,10 @@ SAMPLE_UNION_CLS = Union[str, int]
 
 SAMPLE_DICT_WITH_ANY_CLS = Dict[str, Any]
 DICT_WITH_ANY: SAMPLE_DICT_WITH_ANY_CLS = {"lr": 0.1, "type": "FedAvg"}
-SAMPLE_DICT_WITH_ANY_JSON = {"lr": {"float": 0.1}, "type": {"str": "FedAvg"}}
 
 SAMPLE_ANY_CLS = Any
 MULTI_TYPE_LIST: Any = [1, "test", 0.01]
-SAMPLE_ANY: Any = {"list": MULTI_TYPE_LIST}
+SAMPLE_ANY: Any = MULTI_TYPE_LIST
 
 
 class SerializeTest(unittest.TestCase):
@@ -32,16 +31,41 @@ class SerializeTest(unittest.TestCase):
 
     def test_value_to_json_for_class_type_any(self):
         json = serialize._value_to_json(Dict[str, Any], DICT_WITH_ANY)
-        self.assertEqual(json, SAMPLE_DICT_WITH_ANY_JSON)
+        self.assertEqual(json, DICT_WITH_ANY)
 
         json = serialize._value_to_json(Any, [1, "test", 0.01])
         self.assertEqual(json, SAMPLE_ANY)
 
     def test_value_from_json_for_class_type_any(self):
-        value = serialize._value_from_json(
-            SAMPLE_DICT_WITH_ANY_CLS, SAMPLE_DICT_WITH_ANY_JSON
-        )
+        value = serialize._value_from_json(SAMPLE_DICT_WITH_ANY_CLS, DICT_WITH_ANY)
         self.assertEqual(DICT_WITH_ANY, value)
 
         value = serialize._value_from_json(SAMPLE_ANY_CLS, SAMPLE_ANY)
         self.assertEqual([1, "test", 0.01], value)
+
+    def test_config_to_json_for_dict(self):
+        """For a config that contains a dict inside it, verify that config
+           can be correctly created from a json/dict, and config can be correctly
+           serialized and de-serialized
+        """
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_dict: Dict[str, Any]
+
+            test_config: TestConfig
+
+        a_dict = {"param2": {"nested_param1": 10, "nested_param2": 2}, "param1": "val1"}
+        a_config_containing_dict = {"test_config": {"a_dict": a_dict}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_dict
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_dict, a_dict)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)


### PR DESCRIPTION
Summary:
There are two parts to this diff (can't be split into 2 because PyText depends on Papaya)

## Changes to Papaya
This diff refactors Papaya trainers (SyncTrainer and AsyncTrainer) to take config as input, instead of individually specified parameters.

Advantages:
- Shared config between Sync and Async trainer moved to base class. Most config parameters are shared
- Error checking and default behavior is specified in one place (inside `SyncTrainerConfig` for example), instead of being spread over the code
- Makes upstream components simpler

## Changes to PyText
The change above simplifies FL trainers in PyText a lot.
Now, adding a new parameter to sync_trainer means no change to PyText!

Eg: FLSyncTrainer before:
{F235369673}

FLSyncTrainer after:

{F235369676}

## How to read this diff
Important changes are in `papaya/simulation/toolkit/trainers/(trainer_base.py| async_trainer.py|sync_trainer.py)`
Other changes are boilerplate.

Reviewed By: jessemin, psuzhanhy

Differential Revision: D21170545

