### PR TITLE
Build PyTextDocumentRegressor to replace TextNNRegressor

### DIFF
--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -115,7 +115,7 @@ class DocumentClassificationTask(NewTask):
 
 class DocumentRegressionTask(NewTask):
     class Config(NewTask.Config):
-        model: DocRegressionModel.Config = DocRegressionModel.Config()
+        model: BaseModel.Config = DocRegressionModel.Config()
         metric_reporter: RegressionMetricReporter.Config = (
             RegressionMetricReporter.Config()
         )


### PR DESCRIPTION
Summary:
1. Build PyTextDocumentRegressor transformer (fblearner/flow/projects/fluent2/definition/transformers/contrib/pytext/transformer.py)
2. Write TorchScript wrapper for DocRegressor model (pytext/models/output_layers/doc_regression_output_layer.py)
3. Write RobertaRegressor model and its torchscript (pytext/models/roberta.py)
4. Write fluent2 TorchScript wrapper (fblearner/flow/projects/fluent2/definition/transformers/contrib/pytext/torchscript.py)
5. Add unit test (fblearner/flow/projects/fluent2/definition/transformers/contrib/pytext/test/transformer_test.py)
6. Add demo domain (fblearner/flow/projects/fluent2/domains/pytext/demo_regression.py)

Differential Revision: D21469699

