### PR TITLE
added arg `dim` explicitly to softmax

### DIFF
--- a/demo/my_tagging/output.py
+++ b/demo/my_tagging/output.py
@@ -23,5 +23,5 @@ class MyTaggingOutputLayer(OutputLayerBase):
 
     def get_pred(self, logit, *args, **kwargs):
         preds = torch.max(logit, 2)[1]
-        scores = F.log_softmax(logit, 2)
+        scores = F.log_softmax(logit, dim=2)
         return preds, scores

--- a/pytext/docs/source/create_new_model.rst
+++ b/pytext/docs/source/create_new_model.rst
@@ -149,7 +149,7 @@ The output layer can be simple enough and demonstrates a few important notions i
 
         def get_pred(self, logit, *args, **kwargs):
             preds = torch.max(logit, 2)[1]
-            scores = F.log_softmax(logit, 2)
+            scores = F.log_softmax(logit, dim=2)
             return preds, scores
 
 6. Metric Reporter

--- a/pytext/exporters/test/new_text_model_exporter_test.py
+++ b/pytext/exporters/test/new_text_model_exporter_test.py
@@ -121,7 +121,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         # Do softmax since we do log softmax before exporting predictor nets
         # We do exp on caffe2 output instead, because log of numbers that are
         # very close to 0 gives different result in pytorch and caffe2
-        py_outs = F.softmax(py_outs, 1)
+        py_outs = F.softmax(py_outs, dim=1)
 
         np.testing.assert_array_almost_equal(
             py_outs.view(-1).detach().numpy(),

--- a/pytext/exporters/test/text_model_exporter_test.py
+++ b/pytext/exporters/test/text_model_exporter_test.py
@@ -367,7 +367,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
                 py_model.eval()
                 py_outs = py_model(*test_inputs)
                 # Do log_softmax since we do that before exporting predictor nets
-                py_outs = F.log_softmax(py_outs, 1)
+                py_outs = F.log_softmax(py_outs, dim=1)
                 np.testing.assert_array_almost_equal(
                     py_outs.view(-1).detach().numpy(), np.array(c2_out).flatten()
                 )

--- a/pytext/loss/loss.py
+++ b/pytext/loss/loss.py
@@ -35,7 +35,7 @@ class CrossEntropyLoss(Loss):
         # There's some wisdom from fairseq folks that it's the preferred way.
         # Needs more testing before we can change to using F.cross_entropy().
         return F.nll_loss(
-            F.log_softmax(logits, 1, dtype=torch.float32),
+            F.log_softmax(logits, dim=1, dtype=torch.float32),
             targets,
             weight=self.weight,
             ignore_index=self.ignore_index,
@@ -407,7 +407,7 @@ class KLDivergenceCELoss(Loss):
         hard_targets, _, soft_targets_logits = targets
         soft_targets = F.softmax(soft_targets_logits.float() / self.t, dim=1)
         soft_targets = soft_targets.clamp(1e-10, 1 - 1e-10)
-        log_probs = F.log_softmax(logits / self.t, 1)
+        log_probs = F.log_softmax(logits / self.t, dim=1)
 
         if self.weight is not None:
             soft_loss = (

--- a/pytext/models/decoders/intent_slot_model_decoder.py
+++ b/pytext/models/decoders/intent_slot_model_decoder.py
@@ -87,7 +87,7 @@ class IntentSlotModelDecoder(DecoderBase):
 
         if self.use_doc_probs_in_word:
             # Get doc probability distribution
-            doc_prob = F.softmax(logit_d, 1)
+            doc_prob = F.softmax(logit_d, dim=1)
             word_input_shape = x_w.size()
             doc_prob = doc_prob.unsqueeze(1).repeat(1, word_input_shape[1], 1)
             x_w = torch.cat((x_w, doc_prob), 2)

--- a/pytext/models/output_layers/doc_classification_output_layer.py
+++ b/pytext/models/output_layers/doc_classification_output_layer.py
@@ -162,7 +162,7 @@ class MulticlassOutputLayer(ClassificationOutputLayer):
     def get_pred(self, logit, *args, **kwargs):
         """See `OutputLayerBase.get_pred()`."""
         preds = torch.max(logit, -1)[1]
-        scores = F.log_softmax(logit, 1)
+        scores = F.log_softmax(logit, dim=1)
         return preds, scores
 
     def torchscript_predictions(self):

--- a/pytext/models/output_layers/squad_output_layer.py
+++ b/pytext/models/output_layers/squad_output_layer.py
@@ -126,16 +126,16 @@ class SquadOutputLayer(OutputLayerBase):
         has_answer_preds = has_answer_logits.float().argmax(-1)
         has_answer_scores = torch.zeros(has_answer_logits.size())
         if not self.ignore_impossible:
-            has_answer_scores = F.softmax(has_answer_logits, 1)
+            has_answer_scores = F.softmax(has_answer_logits, dim=1)
 
         # Compute the logit of the corresponding to start and end positions.
         start_pos_scores = (
-            F.softmax(start_pos_logits, 1)
+            F.softmax(start_pos_logits, dim=1)
             .gather(1, start_pos_preds.view(-1, 1))
             .squeeze(-1)
         )
         end_pos_scores = (
-            F.softmax(end_pos_logits, 1)
+            F.softmax(end_pos_logits, dim=1)
             .gather(1, end_pos_preds.view(-1, 1))
             .squeeze(-1)
         )

--- a/pytext/models/output_layers/word_tagging_output_layer.py
+++ b/pytext/models/output_layers/word_tagging_output_layer.py
@@ -39,7 +39,7 @@ class WordTaggingScores(nn.Module):
     def forward(
         self, logits: torch.Tensor, context: Optional[Dict[str, torch.Tensor]] = None
     ) -> List[List[Dict[str, float]]]:
-        scores: torch.Tensor = F.log_softmax(logits, 2)
+        scores: torch.Tensor = F.log_softmax(logits, dim=2)
         return _get_prediction_from_scores(scores, self.classes)
 
 
@@ -57,7 +57,7 @@ class CRFWordTaggingScores(WordTaggingScores):
         assert "seq_lens" in context
         pred = self.crf.decode(logits, context["seq_lens"])
         logits_rearranged = _rearrange_output(logits, pred)
-        scores: torch.Tensor = F.log_softmax(logits_rearranged, 2)
+        scores: torch.Tensor = F.log_softmax(logits_rearranged, dim=2)
         return _get_prediction_from_scores(scores, self.classes)
 
 
@@ -156,7 +156,7 @@ class WordTaggingOutputLayer(OutputLayerBase):
 
         """
         preds = torch.max(logit, 2)[1]
-        scores = F.log_softmax(logit, 2)
+        scores = F.log_softmax(logit, dim=2)
         return preds, scores
 
     def export_to_caffe2(
@@ -260,7 +260,7 @@ class CRFOutputLayer(OutputLayerBase):
             raise MissingValueError("Expected non-None context but got None.")
         pred = self.crf.decode(logit, context["seq_lens"])
         logit_rearranged = _rearrange_output(logit, pred)
-        scores = F.log_softmax(logit_rearranged, 2)
+        scores = F.log_softmax(logit_rearranged, dim=2)
         return pred, scores
 
     def export_to_caffe2(

--- a/pytext/models/representations/pooling.py
+++ b/pytext/models/representations/pooling.py
@@ -47,7 +47,7 @@ class SelfAttention(Module):
         alphas = torch.onnx.operators.reshape_from_tensor_shape(
             alphas, size[:2]
         )  # (bsz, sent_len)
-        alphas = self.softmax(alphas)  # (bsz, sent_len)
+        alphas = self.softmax(alphas, dim=2)  # (bsz, sent_len)
 
         # (bsz, rep_dim)
         return torch.bmm(alphas.unsqueeze(1), inputs).squeeze(1)

--- a/pytext/models/representations/pooling.py
+++ b/pytext/models/representations/pooling.py
@@ -47,7 +47,7 @@ class SelfAttention(Module):
         alphas = torch.onnx.operators.reshape_from_tensor_shape(
             alphas, size[:2]
         )  # (bsz, sent_len)
-        alphas = self.softmax(alphas, dim=2)  # (bsz, sent_len)
+        alphas = self.softmax(alphas, dim=1)  # (bsz, sent_len)
 
         # (bsz, rep_dim)
         return torch.bmm(alphas.unsqueeze(1), inputs).squeeze(1)


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

This PR adds the argument name `dim` to the functions `torch.nn.functional.softmax` and `torch.nn.functional.log_softmax` wherever it is not already there explicitly. For example, if the function call is of the form `torch.nn.functional.softmax(x, 1)` it will be changed to `torch.nn.functional.softmax(x, dim=1)`.

In line 50 of `pytext/models/representations/pooling.py` I added `dim = 1` in the function call of `torch.nn.functional.softmax`. This change removes the following `UserWarning:

`UserWarning: Implicit dimension choice for softmax has been deprecated. Change the call to include dim=X as an argument.`

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

There is no need for additional testing. My modification has been to only explicitly mention the argument name `dim` in the appropriate cases.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/facebookresearch/pytext/blob/master/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see [**CLA**](https://github.com/facebookresearch/pytext/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla))
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
