### PR TITLE
set onnx==1.6.0 to fix CircleCI build temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fvcore
 hypothesis<4.0
 joblib
 numpy
-onnx>=1.6.0
+onnx==1.6.0
 # pytorch-pretrained-bert requires python-dateutil < 2.8.1
 python-dateutil==2.8.0
 pandas


### PR DESCRIPTION
Summary: ONNX release v1.7.0 on 05/08 broke "new_text_model_exporter_test" in CircleCI

Differential Revision: D21524046

