### PR TITLE
remove move_state_dict_to_gpu, which is causing cuda oom

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -333,9 +333,7 @@ class Trainer(TrainerBase):
         if cuda.CUDA_ENABLED:
             # Move current model to CPU to avoid multiple models in GPU memory
             state.model.cpu()
-            state.model.load_state_dict(
-                self.move_state_dict_to_gpu(state.best_model_state)
-            )
+            state.model.load_state_dict(state.best_model_state)
             # Move model back to GPU
             state.model.cuda()
         else:


### PR DESCRIPTION
Summary: I keep getting cuda oom in this load_best_model stage, move_state_dict_to_gpu and model.cuda() are not both needed. Looks like it will double gpu memory this way.

Differential Revision: D21725316

