### PR TITLE
API support for capturing privacy metrics in metric reporters

### DIFF
--- a/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
+++ b/pytext/metric_reporters/disjoint_multitask_metric_reporter.py
@@ -72,7 +72,14 @@ class DisjointMultitaskMetricReporter(MetricReporter):
             reporter.add_channel(channel)
 
     def report_metric(
-        self, model, stage, epoch, reset=True, print_to_channels=True, optimizer=None
+        self,
+        model,
+        stage,
+        epoch,
+        reset=True,
+        print_to_channels=True,
+        optimizer=None,
+        privacy_engine=None,
     ):
         metrics_dict = {AVRG_LOSS: self.total_loss / self.num_batches}
         for name, reporter in self.reporters.items():

--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -210,7 +210,14 @@ class MetricReporter(Component):
         return {}
 
     def report_metric(
-        self, model, stage, epoch, reset=True, print_to_channels=True, optimizer=None
+        self,
+        model,
+        stage,
+        epoch,
+        reset=True,
+        print_to_channels=True,
+        optimizer=None,
+        privacy_engine=None,  # to be handled by the subclassed metric reporters
     ):
         """
         Calculate metrics and average loss, report all statistic data to channels

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -544,6 +544,7 @@ class Trainer(TrainerBase):
                     optimizer=getattr(
                         state, "optimizer", None
                     ),  # optimizer is not present during test
+                    privacy_engine=getattr(state, "privacy_engine", None),
                 )
         else:
             metric_reporter._reset()


### PR DESCRIPTION
Summary:
sending `privacy_engine` as an argument to `report_metric()` function.
this can be used to obtain the privacy metrics, for eg:
```
epsilon, alpha = privacy_engine.get_privacy_spent()
target_delta = privacy_engine.target_delta
```

Reviewed By: psuzhanhy

Differential Revision: D21388688

