### PR TITLE
Adds an option to skip test run after models have been trained (fixing unlanded D21780336)

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -125,6 +125,8 @@ class PyTextConfig(ConfigBase):
     use_deterministic_cudnn: bool = False
     # Run eval set after model has been trained - for hyperparameter search
     report_eval_results: bool = False
+    # Run test set after model has been trained
+    report_test_results: bool = True
     # include components from custom directories
     include_dirs: Optional[List[str]] = None
     # config version


### PR DESCRIPTION
Summary: In some cases, we have a different testing pipeline (eg MQT), that we are running after training is done. In this case, we don't need to spend time doing pytext testing.

Reviewed By: twwhatever

Differential Revision: D21810507

