### PR TITLE
Consolidate logic for label smoothing (#1376)

### DIFF
--- a/pytext/loss/tests/label_smoothing_loss_test.py
+++ b/pytext/loss/tests/label_smoothing_loss_test.py
@@ -4,12 +4,15 @@
 import caffe2.python.hypothesis_test_util as hu
 import numpy as np
 import torch
-from pytext.loss import LabelSmoothedCrossEntropyLoss
+from pytext.loss.loss import LabelSmoothedCrossEntropyLoss, SourceType
 from scipy.special import logsumexp
 
 
 class LabelSmoothedCrossEntropyLossTest(hu.HypothesisTestCase):
     def test_label_smoothed_cross_entropy_loss_forward(self):
+        torch.manual_seed(1)
+        np.random.seed(1)
+
         for _ in range(50):
             beta = 0.1
             reduce = np.random.choice([True, False])
@@ -48,7 +51,7 @@ class LabelSmoothedCrossEntropyLossTest(hu.HypothesisTestCase):
             self.assertAlmostEqual(error, 0.0, places=4)
 
             loss_log_config = LabelSmoothedCrossEntropyLoss.Config()
-            loss_log_config.from_logits = False
+            loss_log_config.source = SourceType.LOG_PROBS
             loss_log_fn = LabelSmoothedCrossEntropyLoss(
                 config=loss_log_config, ignore_index=-100, weight=weight
             )
@@ -58,6 +61,38 @@ class LabelSmoothedCrossEntropyLossTest(hu.HypothesisTestCase):
             log_diff = np.array(manual_loss) - np.array(label_smoothed_log_loss)
             error = np.linalg.norm(log_diff)
             self.assertAlmostEqual(error, 0.0, places=4)
+
+    def test_label_smoothed_cross_entropy_loss_forward_source_probs(self):
+        torch.manual_seed(1)
+        np.random.seed(1)
+
+        beta = 0.1
+        reduce = False
+        num_classes = 2
+        input_size = 2
+        logits = torch.Tensor([[0.5, 0.5], [0.5, 0.5]])
+        targets = torch.randint(num_classes, (input_size,))
+        padding_indices = 0
+        targets[padding_indices] = -100
+
+        # Only testing for None now because unexpected behavior with nll_loss.
+        # Look at definition of LabelSmoothedCrossEntropyLoss for more
+        # context.
+        weight = None
+
+        manual_loss = self._compute_loss_manual(
+            logits, targets, weight=weight, reduce=reduce, beta=beta, ignore_index=-100
+        )
+        loss_fn = LabelSmoothedCrossEntropyLoss(
+            config=LabelSmoothedCrossEntropyLoss.Config(source=SourceType.PROBS),
+            ignore_index=-100,
+            weight=weight,
+        )
+        label_smoothed_loss = loss_fn(logits, targets, reduce=reduce)
+
+        diff = np.array(manual_loss) - np.array(label_smoothed_loss)
+        error = np.linalg.norm(diff)
+        self.assertAlmostEqual(error, 0.0, places=4)
 
     def _compute_negative_cross_entropy_loss(
         self, logits, targets, weight=None, reduce=True, ignore_index=-100


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/pytext/pull/1376

For task T67950735, in label smoothing loss, changed the parameter "from_logits," which was a boolean, to "source," which is an enum, as follows:

from_logits = true -> SourceType.LOGITS
from_logits = false -> SourceType.LOG_PROBS

Also added SourceType.PROBS

This refactor makes this field less confusing and allows for potential implementation of more sources in the future.

Differential Revision: D21873472

fbshipit-source-id: ad8a25ab36bb10769424f9db4747dac25088fd56

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/facebookresearch/pytext/blob/master/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see [**CLA**](https://github.com/facebookresearch/pytext/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla))
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
