### PR TITLE
Incorporating FairSeq batching to PyText

### DIFF
--- a/pytext/data/__init__.py
+++ b/pytext/data/__init__.py
@@ -14,6 +14,7 @@ from .disjoint_multitask_data import DisjointMultitaskData
 from .disjoint_multitask_data_handler import DisjointMultitaskDataHandler
 from .dynamic_pooling_batcher import DynamicPoolingBatcher
 from .tensorizers import Tensorizer
+from .token_batcher import TokenBatcher
 
 
 __all__ = [
@@ -33,4 +34,5 @@ __all__ = [
     "RandomizedBatchSampler",
     "RoundRobinBatchSampler",
     "Tensorizer",
+    "TokenBatcher",
 ]

--- a/pytext/data/test/token_batcher_test.py
+++ b/pytext/data/test/token_batcher_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+from typing import List
+
+from pytext.data.data import BatchData
+from pytext.data.sources import RawExample
+from pytext.data.token_batcher import TokenBatcher
+from pytext.utils.test import import_tests_module
+
+
+tests_module = import_tests_module()
+
+
+class TokenBatcherTest(unittest.TestCase):
+    @classmethod
+    def _get_dataset(cls, dataset_size: int, num_tokens: int) -> List[RawExample]:
+        return [
+            BatchData(
+                {"source_sequence": ("word " * num_tokens)},
+                {"a": i, "b": 10 + i, "c": 20 + i},
+            )
+            for i in range(dataset_size)
+        ]
+
+    def test_various_token_batcher(self):
+        # test most basic case
+        self.test_token_batcher_helper(
+            dataset_size=100,
+            num_tokens=1,
+            bsz_mult=1,
+            max_tokens=10,
+            output_one_length=10,
+            output_two_length=10,
+        )
+
+        # test running through entire dataset
+        self.test_token_batcher_helper(
+            dataset_size=100,
+            num_tokens=1,
+            bsz_mult=1,
+            max_tokens=55,
+            output_one_length=55,
+            output_two_length=45,
+        )
+
+        # test when max_tokens doesn't exactly divide num_tokens
+        self.test_token_batcher_helper(
+            dataset_size=20,
+            num_tokens=3,
+            bsz_mult=1,
+            max_tokens=20,
+            output_one_length=6,
+            output_two_length=6,
+        )
+
+        # test variation on bsz_mult
+        self.test_token_batcher_helper(
+            dataset_size=20,
+            num_tokens=3,
+            bsz_mult=2,
+            max_tokens=20,
+            output_one_length=6,
+            output_two_length=6,
+        )
+
+    def test_token_batcher_helper(
+        self,
+        dataset_size: int = 100,
+        num_tokens: int = 1,
+        bsz_mult: int = 1,
+        max_tokens: int = 10,
+        output_one_length: int = 10,
+        output_two_length: int = 10,
+    ):
+        data = self._get_dataset(dataset_size, num_tokens)
+
+        batcher_config = TokenBatcher.Config(
+            train_batch_size=1,
+            eval_batch_size=1,
+            test_batch_size=1,
+            pool_num_batches=1,
+            num_shuffled_pools=1,
+            bsz_mult=bsz_mult,
+            max_tokens=max_tokens,
+        )
+
+        batcher = TokenBatcher.from_config(batcher_config)
+
+        # # epoch 1
+        batches = list(batcher.batchify(data))
+        self.assertEqual(len(batches[0][0]), output_one_length)
+
+        # # epoch 2
+        self.assertEqual(len(batches[1][0]), output_two_length)

--- a/pytext/data/token_batcher.py
+++ b/pytext/data/token_batcher.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Iterable
+
+from pytext.common.constants import Stage
+
+from .data import BatchData, PoolingBatcher
+from .sources import RawExample
+
+
+class TokenBatcher(PoolingBatcher):
+    """Batcher that operates on number of tokens rather than number of instances."""
+
+    class Config(PoolingBatcher.Config):
+        bsz_mult: int = 1
+        max_tokens: int = 16
+
+        def num_tokens_fn(self, item):
+            return len(item.split())
+
+    @classmethod
+    def from_config(cls, config: Config):
+        return cls(
+            config.train_batch_size,
+            config.eval_batch_size,
+            config.test_batch_size,
+            config.pool_num_batches,
+            config.num_shuffled_pools,
+            config.bsz_mult,
+            config.max_tokens,
+            config.num_tokens_fn,
+        )
+
+    def __init__(
+        self,
+        train_batch_size=Config.train_batch_size,
+        eval_batch_size=Config.eval_batch_size,
+        test_batch_size=Config.test_batch_size,
+        pool_num_batches=Config.pool_num_batches,
+        num_shuffled_pools=Config.num_shuffled_pools,
+        bsz_mult=Config.bsz_mult,
+        max_tokens=Config.max_tokens,
+        num_tokens_fn=Config.num_tokens_fn,
+    ):
+        super().__init__(
+            train_batch_size,
+            eval_batch_size,
+            test_batch_size,
+            pool_num_batches,
+            num_shuffled_pools,
+        )
+        self.bsz_mult = bsz_mult
+        self.max_tokens = max_tokens
+        self.num_tokens_fn = num_tokens_fn
+
+    def _is_batch_full(self, batch, num_tokens: int, max_tokens: int):
+        if len(batch) == 0:
+            return 0
+        if max_tokens > 0 and num_tokens > max_tokens:
+            return 1
+        return 0
+
+    def batchify(
+        self, iterable: Iterable[RawExample], sort_key=None, stage=Stage.TRAIN
+    ):
+
+        max_tokens = self.max_tokens
+        bsz_mult = self.bsz_mult
+        sample_len = 0
+        sample_lens = []
+        batch = []
+        batches = []
+
+        for item in super().batchify(iterable=iterable, sort_key=sort_key, stage=stage):
+            num_tokens = self.num_tokens_fn(item[0][0]["source_sequence"])
+            sample_lens.append(num_tokens)
+            sample_len = max(sample_len, num_tokens)
+
+            assert max_tokens <= 0 or sample_len <= max_tokens, (
+                "sentence at index {} of size {} exceeds max_tokens "
+                "limit of {}!".format(item, sample_len, max_tokens)
+            )
+            num_tokens = (len(batch) + 1) * sample_len
+            if self._is_batch_full(batch, num_tokens, max_tokens):
+                mod_len = max(
+                    bsz_mult * (len(batch) // bsz_mult), len(batch) % bsz_mult
+                )
+                batches.append(self.combine_batch_data(batch[:mod_len]))
+                batch = batch[mod_len:]
+                sample_lens = sample_lens[mod_len:]
+                sample_len = max(sample_lens) if len(sample_lens) > 0 else 0
+            batch.append(item)
+        if len(batch) > 0:
+            batches.append(self.combine_batch_data(batch))
+        for batch in batches:
+            yield batch
+
+    def combine_batch_data(self, batch) -> BatchData:
+        raw_batch = []
+        numberized_batch = {}
+        for batch_data in batch:
+            raw_batch.extend(batch_data[0])
+            numberized_batch.update(batch_data[1])
+        return BatchData(raw_batch, numberized_batch)


### PR DESCRIPTION
Summary:
In PyText our existing batchers define a number of instances that are in each batch. However in NLP many of our tasks have variable length inputs which means batches can vary significantly in terms of the amount of memory being used. TokenBatcher solves this problem by batching over tokens instead of instances.

The logic is taken from FarSeq, which already implements this: https://fburl.com/diffusion/rvzri31a

Differential Revision: D21911256

