### PR TITLE
Add token/hypothesis confidence for masked nar model

### DIFF
--- a/pytext/torchscript/utils.py
+++ b/pytext/torchscript/utils.py
@@ -4,6 +4,7 @@
 from typing import List, NamedTuple, Optional, Tuple
 
 import torch
+from torch import Tensor
 
 
 class ScriptBatchInput(NamedTuple):
@@ -252,4 +253,12 @@ def squeeze_2d(inputs: Optional[List[List[str]]]) -> Optional[List[List[List[str
         result = torch.jit.annotate(List[List[List[str]]], [])
         for line in inputs:
             result.append([line])
+    return result
+
+
+def float_tensor_list1D(input_tensor: Tensor) -> List[float]:
+    result: List[float] = []
+    assert len(input_tensor.size()) == 1
+    for idx in range(input_tensor.size(0)):
+        result.append(float(input_tensor[idx]))
     return result


### PR DESCRIPTION
Summary:
This diff adds token level and hypothesis scores for different candidates. We follow the same signature as existing production model https://fburl.com/diffusion/npe9kehc

The token level scores are probabilities. These scores will be between 0 and 1
Candidate level score is calculated by a logic inside the non auto regressive generation. There is no guarantee on the bounds of the score. Only assumption should be that higher the score, better the candidate

Differential Revision: D22094127

