### PR TITLE
Adds config to the PandasDataSource object

### DIFF
--- a/pytext/data/sources/pandas.py
+++ b/pytext/data/sources/pandas.py
@@ -26,6 +26,21 @@ class PandasDataSource(RootDataSource):
 
     """
 
+    class Config(RootDataSource.Config):
+        train_df: Optional[DataFrame] = None
+        test_df: Optional[DataFrame] = None
+        eval_df: Optional[DataFrame] = None
+
+    @classmethod
+    def from_config(cls, config: Config, schema: Dict[str, Type]):
+        return cls(
+            train_df=config.train_df,
+            eval_df=config.eval_df,
+            test_df=config.test_df,
+            schema=schema,
+            column_mapping=config.column_mapping,
+        )
+
     def __init__(
         self,
         train_df: Optional[DataFrame] = None,

--- a/pytext/data/test/pandas_data_source_test.py
+++ b/pytext/data/test/pandas_data_source_test.py
@@ -4,10 +4,28 @@
 import unittest
 
 import pandas as pd
+from pytext.config.component import ComponentType, create_component
 from pytext.data.sources import PandasDataSource
 
 
 class PandasDataSourceTest(unittest.TestCase):
+    def test_create_from_config(self):
+        source_config = PandasDataSource.Config(
+            train_df=pd.DataFrame({"c1": [10, 20, 30], "c2": [40, 50, 60]}),
+            eval_df=pd.DataFrame({"c1": [11, 21, 31], "c2": [41, 51, 61]}),
+            test_df=pd.DataFrame({"c1": [12, 22, 32], "c2": [42, 52, 62]}),
+            column_mapping={"c1": "feature1", "c2": "feature2"},
+        )
+        ds = create_component(
+            ComponentType.DATA_SOURCE,
+            source_config,
+            schema={"feature1": float, "feature2": float},
+        )
+        self.assertEqual({"feature1": 10, "feature2": 40}, next(iter(ds.train)))
+        self.assertEqual({"feature1": 11, "feature2": 41}, next(iter(ds.eval)))
+        self.assertEqual({"feature1": 12, "feature2": 42}, next(iter(ds.test)))
+        self.assertEqual(3, len(list(ds.train)))
+
     def test_create_data_source(self):
         ds = PandasDataSource(
             train_df=pd.DataFrame({"c1": [10, 20, 30], "c2": [40, 50, 60]}),


### PR DESCRIPTION
Summary: To be able to specify pandas data source in a task config at runtime.

Differential Revision: D22473596

