### PR TITLE
specify isort version of pytext circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - run:
           name: setup lint
           command: |
-              sudo pip install black isort
+              sudo pip install black isort==4.3.21
       - run:
           name: run black
           command: black pytext --check --diff


### PR DESCRIPTION
Summary: isort was upgraed to 5.x.x which is different than what we have on internal servers. The new version is not compatible with the old one, which breaks oss circleci pylint. specify the version to make it same as internal one.

Differential Revision: D22487881

