### PR TITLE
Fix gradients logging

### DIFF
--- a/pytext/metric_reporters/channel.py
+++ b/pytext/metric_reporters/channel.py
@@ -5,7 +5,9 @@ import sys
 import traceback
 from typing import Tuple
 
+import numpy as np
 import torch
+from numpy import linalg as LA
 from pytext.common.constants import Stage
 from pytext.utils.file_io import PathManager
 from torch.utils.tensorboard import SummaryWriter
@@ -202,6 +204,8 @@ class TensorBoardChannel(Channel):
         meta,
         model,
         optimizer,
+        log_gradient,
+        gradients,
         *args,
     ):
         """
@@ -266,33 +270,32 @@ class TensorBoardChannel(Channel):
                     self.summary_writer.add_scalar(
                         f"optimizer.lr.param_group.{idx}", param_group["lr"], epoch
                     )
+            if log_gradient and gradients:
+                for key in gradients:
+                    if len(gradients[key]):
+                        sum_gradient = sum(gradients[key])
+                        avg_gradient = sum_gradient / len(gradients[key])
+                        grad_norms = np.array([LA.norm(g) for g in gradients[key]])
+                        self.log_vector(key + "_avg_gradients", avg_gradient, epoch)
+                        self.log_vector(key + "_sum_gradients", sum_gradient, epoch)
+                        self.log_vector(key + "_l2norm_gradients", grad_norms, epoch)
+
             for key, val in model.named_parameters():
                 if val is not None and len(val) > 0 and not (val == 0).all():
                     limit = 9.9e19
-                    grad = val.grad
                     val = torch.clamp(val.float(), -limit, limit)
-                    try:
-                        self.summary_writer.add_histogram(key, val, epoch)
-                    except Exception:
-                        print(
-                            f"WARNING: Param {key} cannot be sent to Tensorboard",
-                            file=sys.stderr,
-                        )
-                        traceback.print_exc(file=sys.stderr)
+                    self.log_vector(key, val, epoch)
 
-                    if grad is not None and len(grad) > 0 and not (grad == 0).all():
-                        grad = torch.clamp(grad.float(), -limit, limit)
-                        try:
-                            self.summary_writer.add_histogram(
-                                key + "_gradients", grad, epoch
-                            )
-                        except Exception:
-                            print(
-                                f"WARNING: Grad for param {key} "
-                                "cannot be sent to Tensorboard",
-                                file=sys.stderr,
-                            )
-                            traceback.print_exc(file=sys.stderr)
+    def log_vector(self, key, val, epoch):
+        if len(val) > 0 and not (val == 0).all():
+            try:
+                self.summary_writer.add_histogram(key, val, epoch)
+            except Exception:
+                print(
+                    f"WARNING: Param {key} " "cannot be sent to Tensorboard",
+                    file=sys.stderr,
+                )
+                traceback.print_exc(file=sys.stderr)
 
     def add_texts(self, tag, metrics):
         """

--- a/pytext/metric_reporters/seq2seq_compositional.py
+++ b/pytext/metric_reporters/seq2seq_compositional.py
@@ -67,8 +67,8 @@ class CompositionalSeq2SeqFileChannel(Seq2SeqFileChannel):
 
 
 class Seq2SeqCompositionalMetricReporter(Seq2SeqMetricReporter):
-    def __init__(self, channels, tensorizers, accept_flat_intents_slots):
-        super().__init__(channels, tensorizers)
+    def __init__(self, channels, log_gradient, tensorizers, accept_flat_intents_slots):
+        super().__init__(channels, log_gradient, tensorizers)
         self.accept_flat_intents_slots = accept_flat_intents_slots
 
     class Config(MetricReporter.Config):

--- a/pytext/metric_reporters/seq2seq_metric_reporter.py
+++ b/pytext/metric_reporters/seq2seq_metric_reporter.py
@@ -43,8 +43,8 @@ class Seq2SeqMetricReporter(MetricReporter):
     class Config(MetricReporter.Config):
         pass
 
-    def __init__(self, channels, tensorizers):
-        super().__init__(channels)
+    def __init__(self, channels, log_gradient, tensorizers):
+        super().__init__(channels, log_gradient)
         self.tensorizers = tensorizers
 
     def _reset(self):

--- a/pytext/metric_reporters/tests/tensorboard_test.py
+++ b/pytext/metric_reporters/tests/tensorboard_test.py
@@ -47,6 +47,8 @@ class TensorboardTest(TestCase):
             meta={},
             model=model,
             optimizer=optimizer,
+            log_gradient=False,
+            gradients={},
         )
 
     def test_report_metrics_to_others(self):
@@ -71,4 +73,6 @@ class TensorboardTest(TestCase):
             meta={},
             model=model,
             optimizer=optimizer,
+            log_gradient=False,
+            gradients={},
         )

--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -619,6 +619,9 @@ class Trainer(TrainerBase):
                 )
         # update gradients after len(samples) forward & backward
         self.optimizer_step(state)
+        with timing.time("add gradients"):
+            if report_metric and state.stage == Stage.TRAIN:
+                metric_reporter.add_gradients(state.model)
         self.sparsification_step(state)
 
 
@@ -673,6 +676,9 @@ class TaskTrainer(Trainer):
                     metric_reporter.report_realtime_metric(state.stage)
         # update gradients after #len(samples) forward & backward
         self.optimizer_step(state)
+        with timing.time("add gradients"):
+            if report_metric and state.stage == Stage.TRAIN:
+                metric_reporter.add_gradients(state.model)
         self.sparsification_step(state)
 
     def _prepare_scheduler(self, training_batches, scheduler=None):


### PR DESCRIPTION
Summary:
There was an in issue with the approach that we were using to log gradients. At the end of each epoch, we would look at the model and for each named_parameter we would log tensor.grad to tensorboard. This is incorrect becase after the last step in the epoch, the model parameters will only contain accumulated gradients for the last batch. There is no guarantee that the gradient for the last batch is representative of gradients for the entire dataset.

We fix this by logging the gradients after all optmizer steps into a variable inside the metric reporter. And at the end of each epoch, we aggregate the gradients across different batches and log into tensorboard. It's not entirely clear for me how to aggregate the gradients across different batches. We may want avg gradients over the entire dataset but since at the end of each epoch we are already aggregating over each batch its not trivial to get individual gradient for each sample and avg it later. But I dont think absolute value of gradients matter so much and hence i log the avg as well as sum of gradients. This will help us see relative differences in gradients across different part of the models. I also log the l2 norm of the gradient to make sure that whether gradient clipping was successful / needed or not.

Differential Revision: D22494169

