### PR TITLE
Fix failing metric reporters due to log_gradient attribute

### DIFF
--- a/pytext/metric_reporters/metric_reporter.py
+++ b/pytext/metric_reporters/metric_reporter.py
@@ -52,6 +52,7 @@ class MetricReporter(Component):
         pep_format: bool = False
         #: Useful for KD training, column names that used by student but not teacher.
         student_column_names: List[str] = []
+        log_gradient: bool = False
 
     def __init__(self, channels, log_gradient=False, pep_format=False) -> None:
         self.log_gradient = log_gradient

--- a/pytext/metric_reporters/seq2seq_compositional.py
+++ b/pytext/metric_reporters/seq2seq_compositional.py
@@ -86,6 +86,7 @@ class Seq2SeqCompositionalMetricReporter(Seq2SeqMetricReporter):
                     config.accept_flat_intents_slots,
                 ),
             ],
+            config.log_gradient,
             tensorizers,
             config.accept_flat_intents_slots,
         )

--- a/pytext/metric_reporters/seq2seq_metric_reporter.py
+++ b/pytext/metric_reporters/seq2seq_metric_reporter.py
@@ -59,6 +59,7 @@ class Seq2SeqMetricReporter(MetricReporter):
                 ConsoleChannel(),
                 Seq2SeqFileChannel([Stage.TEST], config.output_path, tensorizers),
             ],
+            config.log_gradient,
             tensorizers,
         )
 


### PR DESCRIPTION
Summary: fix for D22494169 (https://github.com/facebookresearch/PyText/commit/1446b35a8a98042e79ca27cf5709e17745498ab8)

Differential Revision: D22576763

