### PR TITLE
Add support for hypothesis 5.x

### DIFF
--- a/pytext/exporters/test/text_model_exporter_test.py
+++ b/pytext/exporters/test/text_model_exporter_test.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from caffe2.python import workspace
-from hypothesis import given
+from hypothesis import given, settings
 from pytext.builtin_task import (
     DocumentClassificationTask,
     IntentSlotTask,
@@ -443,6 +443,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         test_num_words=st.integers(1, 7),
         num_predictions=st.integers(2, 5),
     )
+    @settings(max_examples=10, deadline=None)
     def test_wordblstm_export_to_caffe2(
         self, export_num_words, num_word_classes, test_num_words, num_predictions
     ):
@@ -536,6 +537,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         test_num_words=st.integers(1, 7),
         num_predictions=st.integers(1, 5),
     )
+    @settings(max_examples=10, deadline=None)
     def test_joint_export_to_caffe2(
         self,
         export_num_words,
@@ -617,6 +619,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         num_predictions=st.integers(1, 5),
         test_num_seq=st.integers(1, 7),
     )
+    @settings(max_examples=10, deadline=None)
     def test_seq_nn_export_to_caffe2(
         self,
         export_num_words,
@@ -671,6 +674,7 @@ class ModelExporterTest(hu.HypothesisTestCase):
         num_predictions=st.integers(1, 5),
         test_num_seq=st.integers(1, 7),
     )
+    @settings(max_examples=10, deadline=None)
     def test_contextual_intent_slot_export_to_caffe2(
         self, test_num_words, num_predictions, test_num_seq
     ):

--- a/pytext/models/test/crf_test.py
+++ b/pytext/models/test/crf_test.py
@@ -5,7 +5,7 @@ import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from hypothesis import given
+from hypothesis import given, settings
 from pytext.common.constants import Padding
 from pytext.models.crf import CRF
 from scipy.special import logsumexp
@@ -18,6 +18,7 @@ class CRFTest(hu.HypothesisTestCase):
             elements=st.integers(min_value=1, max_value=10), min_size=1, max_size=10
         ),
     )
+    @settings(deadline=10000)
     def test_crf_forward(self, num_tags, seq_lens):
 
         crf_model = CRF(
@@ -108,6 +109,7 @@ class CRFTest(hu.HypothesisTestCase):
             elements=st.integers(min_value=1, max_value=10), min_size=1, max_size=10
         ),
     )
+    @settings(deadline=10000)
     def test_crf_decode_torchscript(self, num_tags, seq_lens):
         crf_model = CRF(
             num_tags,

--- a/pytext/models/test/output_layer_test.py
+++ b/pytext/models/test/output_layer_test.py
@@ -8,7 +8,7 @@ import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from hypothesis import given
+from hypothesis import given, settings
 from pytext.common.constants import SpecialTokens
 from pytext.data.tensorizers import LabelTensorizer
 from pytext.data.utils import Vocabulary
@@ -59,6 +59,7 @@ class OutputLayerTest(hu.HypothesisTestCase):
             elements=st.integers(min_value=1, max_value=10), min_size=1, max_size=10
         ),
     )
+    @settings(deadline=10000)
     def test_torchscript_word_tagging_output_layer(self, num_labels, seq_lens):
         batch_size = len(seq_lens)
         vocab = Vocabulary(
@@ -98,6 +99,7 @@ class OutputLayerTest(hu.HypothesisTestCase):
             elements=st.integers(min_value=4, max_value=10), min_size=1, max_size=10
         ),
     )
+    @settings(deadline=10000)
     def test_torchscript_intent_slot_output_layer(
         self, num_doc_labels, num_word_labels, seq_lens
     ):


### PR DESCRIPTION
Update to support `hypothesis 5.x` primarily by overriding the now-enforced default `deadline` of 200ms where appropriate.

Reviewed By: thatch

Differential Revision: D20323893

