### PR TITLE
Add TorchScript export for XLMR Encoder

### DIFF
--- a/pytext/models/model.py
+++ b/pytext/models/model.py
@@ -215,6 +215,9 @@ class BaseModel(nn.Module, Component):
         # default behavior is the same as getting model inputs
         return self.arrange_model_inputs(tensor_dict)
 
+    def trace(self, inputs):
+        return torch.jit.trace(self, inputs)
+
     def caffe2_export(self, tensorizers, tensor_dict, path, export_onnx_path=None):
         pass
 

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -303,7 +303,7 @@ class _NewTask(TaskBase):
         model(*inputs)
         if quantize:
             model.quantize()
-        trace = jit.trace(model, inputs)
+        trace = model.trace(inputs)
         if hasattr(model, "torchscriptify"):
             trace = model.torchscriptify(self.data.tensorizers, trace)
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -186,7 +186,9 @@ def save_and_export(
         )
     if config.export_torchscript_path:
         task.torchscript_export(
-            task.model, config.export_torchscript_path, config.torchscript_quantize
+            model=task.model,
+            export_path=config.export_torchscript_path,
+            quantize=config.torchscript_quantize,
         )
 
 
@@ -344,7 +346,7 @@ def get_logits(
                     )
 
 
-def save_pytext_snapshot(config: PyTextConfig,) -> None:
+def save_pytext_snapshot(config: PyTextConfig) -> None:
     task, training_state = prepare_task(
         config,
         dist_init_url=None,


### PR DESCRIPTION
Summary: This diff adds the ability to torchscript export just the encoder of an XLM-R model in PyText. We need this ability to ship these models in the Ads Ranking Stack.

Reviewed By: chenyangyu1988

Differential Revision: D22638430

