### PR TITLE
Update report metrics API due to a recent change

### DIFF
--- a/pytext/metric_reporters/language_model_metric_reporter.py
+++ b/pytext/metric_reporters/language_model_metric_reporter.py
@@ -65,6 +65,7 @@ class LanguageModelMetricReporter(MetricReporter):
             config.aggregate_metrics,
             config.perplexity_type,
             config.pep_format,
+            config.log_gradient,
         )
 
     def __init__(
@@ -75,8 +76,9 @@ class LanguageModelMetricReporter(MetricReporter):
         aggregate_metrics,
         perplexity_type,
         pep_format,
+        log_gradient=False,
     ):
-        super().__init__(channels, pep_format=pep_format)
+        super().__init__(channels, log_gradient=log_gradient, pep_format=pep_format)
         self.metadata = metadata
         self.tensorizers = tensorizers
         self.aggregate_metrics = aggregate_metrics


### PR DESCRIPTION
Summary:
A recent change D22494169 (https://github.com/facebookresearch/PyText/commit/1446b35a8a98042e79ca27cf5709e17745498ab8) in metrics reporter API that adds log_gradient in the arg for report() causes failure in the smart keyboard MR, in which report() was overridden.

This diff fixes the issue in the smart keyboard MR API.

Reviewed By: FanW123

Differential Revision: D22633523

