### PR TITLE
Ensure lengths are on CPU in pack_padded_sequence

### DIFF
--- a/pytext/models/representations/bilstm.py
+++ b/pytext/models/representations/bilstm.py
@@ -145,7 +145,7 @@ class BiLSTM(RepresentationBase):
                 # using GPU inference
                 rnn_input = pack_padded_sequence(
                     embedded_tokens,
-                    seq_lengths,
+                    seq_lengths.cpu(),
                     batch_first=True,
                     enforce_sorted=True
                     if self.disable_sort_in_jit


### PR DESCRIPTION
Summary:
KNN workflow recently started failing (see https://www.internalfb.com/intern/fblearner/details/207841145/operator/2127765475)

Root cause is that pack_padded_sequence recently started expecting sequence lengths to be on CPU. (from error message: RuntimeError: 'lengths' argument should be a 1D CPU int64 tensor)

Differential Revision: D22787394

