### PR TITLE
allowed embedding initialization without pretrained

### DIFF
--- a/pytext/utils/embeddings.py
+++ b/pytext/utils/embeddings.py
@@ -199,11 +199,11 @@ class PretrainedEmbedding(object):
                 "Unknown embedding initialization strategy '{}'".format(init_strategy)
             )
 
-        assert self.embedding_vectors is not None and self.embed_vocab is not None
-        assert (
-            pretrained_embeds_weight.shape[-1] == self.embedding_vectors.shape[-1]
-        ), f"shape of pretrained_embeds_weight {pretrained_embeds_weight.shape[-1]} \
-        and embedding_vectors {self.embedding_vectors.shape[-1]} doesn't match!"
+        if self.embedding_vectors is not None and self.embed_vocab is not None:
+            assert (
+                pretrained_embeds_weight.shape[-1] == self.embedding_vectors.shape[-1]
+            ), f"shape of pretrained_embeds_weight {pretrained_embeds_weight.shape[-1]} \
+            and embedding_vectors {self.embedding_vectors.shape[-1]} doesn't match!"
         unk_idx = str_to_idx[unk]
         oov_count = 0
         for word, idx in str_to_idx.items():


### PR DESCRIPTION
Summary: changed some assertions. They were set up in a way that did not allow the class to be used unless a pretrained embedding was provided. It should now be able to function with or without a pretrained embedding.

Differential Revision: D22518280

