### PR TITLE
use the latest version of torch and tensorboard

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,3 @@
-https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp37-cp37m-manylinux1_x86_64.whl
 click
 fairseq
 future
@@ -11,6 +10,7 @@ pytorch-pretrained-bert
 requests
 sentencepiece
 torchtext
-tensorboard==1.14
+tensorboard
+torch
 pandas
 pytorch-dp

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ regex==2019.11.1
 requests
 scipy
 sentencepiece
-tensorboard==1.14
-torch==1.5.0
+tensorboard
+torch
 torchtext


### PR DESCRIPTION
Summary:
my diff D21435152 got unrelated import error in CircleCI, due to incompatibility between latest torchtext and torch==1.5.0.

e.g.
OSError: /usr/local/lib/python3.6/site-packages/torchtext/_torchtext.so: undefined symbol:

full log: https://app.circleci.com/pipelines/github/facebookresearch/pytext/5111/workflows/fd4040cd-2580-4e2e-a155-1f52b36a898e/jobs/19183/tests

Differential Revision: D22824001

