### PR TITLE
Added SourceType to loss __init__ file

### DIFF
--- a/pytext/loss/__init__.py
+++ b/pytext/loss/__init__.py
@@ -16,6 +16,7 @@ from .loss import (
     MultiLabelSoftMarginLoss,
     NLLLoss,
     PairwiseRankingLoss,
+    SourceType,
 )
 
 
@@ -34,4 +35,5 @@ __all__ = [
     "PairwiseRankingLoss",
     "LabelSmoothedCrossEntropyLoss",
     "LabelSmoothedCrossEntropyLengthLoss",
+    "SourceType",
 ]


### PR DESCRIPTION
Summary: Enabled SourceType importing by adding it to the pytext/loss/__init__.py file.

Differential Revision: D22978634

