### PR TITLE
pin black version to 19.3b0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - run:
           name: setup lint
           command: |
-              sudo pip install black isort==4.3.21
+              sudo pip install black==19.3b0 isort==4.3.21
       - run:
           name: run black
           command: black pytext --check --diff


### PR DESCRIPTION
Summary: CircleCI is broken due to newly released version of black has different rules as internal version: 19.3b0

Differential Revision: D23403534

