### PR TITLE
Add padding to tensorizer and transition export options into **kwargs

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -122,6 +122,13 @@ class PyTextConfig(ConfigBase):
     # Possible values: texts, multi_texts, tokens (and/or others as
     # supported by inference_interface method).
     inference_interface: Optional[str] = None
+    # Padding boundaries for padded tensor sequence length dimension.
+    # Specified as a list of boundaries to be rounded up to.
+    # Each batch seq length dimension will be rounded to the smallest number
+    # larger than the actual longest sequence in a batch.
+    # The list of padding boundaries must be sorted in asecending order.
+    # The first list element must be 0.  (Will serve as future padding control "version number")
+    padding_control: Optional[List[int]] = None
     # Base directory where modules are saved
     modules_save_dir: str = ""
     # Whether to save intermediate checkpoints for modules if they are best yet

--- a/pytext/data/bert_tensorizer.py
+++ b/pytext/data/bert_tensorizer.py
@@ -159,7 +159,12 @@ class BERTTensorizerBaseScriptImpl(TensorizerScriptImpl):
         """
         Convert instance level vectors into batch level tensors.
         """
-        tokens, pad_mask = pad_2d_mask(tokens_2d, pad_value=self.vocab.pad_idx)
+        tokens, pad_mask = pad_2d_mask(
+            tokens_2d,
+            pad_value=self.vocab.pad_idx,
+            padding_control=self.padding_control,
+            max_pad_len=self.max_seq_len,
+        )
         segment_labels = torch.tensor(
             pad_2d(segment_labels_2d, seq_lens=seq_lens_1d, pad_idx=0), dtype=torch.long
         )

--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -109,13 +109,29 @@ def lookup_tokens(
 
 
 class TensorizerScriptImpl(torch.nn.Module):
+    device: str
+    padding_control: Optional[List[int]]
+
     def __init__(self):
         super().__init__()
         self.device: str = ""
+        # padding_control options:
+        # None - no padding
+        # [0, pad1, pad2, pad3,...] - pads sequence length to smallest padX larger than sequence
+        self.padding_control = torch.jit.annotate(Optional[List[int]], None)
 
     @torch.jit.export
     def set_device(self, device: str):
         self.device = device
+
+    @torch.jit.export
+    def set_padding_control(self, control: Optional[List[int]]):
+        """
+        This functions will be called to set a padding style.
+        None - No padding
+        List: first element 0, round seq length to the smallest list element larger than inputs
+        """
+        self.padding_control = control
 
     def batch_size(self, inputs: ScriptBatchInput) -> int:
         texts: Optional[List[List[str]]] = inputs.texts

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -403,22 +403,13 @@ def export(context, model, output_path, output_onnx_path):
 @click.option("--output-path", help="where to save the exported torchscript model")
 @click.option("--quantize", help="whether to quantize the model")
 @click.pass_context
-def torchscript_export(
-    context,
-    model,
-    output_path=None,
-    quantize=False,
-    inference_interface=None,
-    accelerate=None,
-):
+def torchscript_export(context, model, output_path=None, **options):
     """Convert a pytext model snapshot to a torchscript model."""
     config = context.obj.load_config()
     model = model or config.save_snapshot_path
     output_path = output_path or f"{config.save_snapshot_path}.torchscript"
     print(f"Exporting {model} to torchscript file: {output_path}")
-    export_saved_model_to_torchscript(
-        model, output_path, quantize, inference_interface, accelerate
-    )
+    export_saved_model_to_torchscript(model, output_path, **options)
 
 
 @main.command()

--- a/pytext/task/disjoint_multitask.py
+++ b/pytext/task/disjoint_multitask.py
@@ -238,12 +238,5 @@ class NewDisjointMultitask(_NewTask):
     def export(self, model, export_path, metric_channels=None, export_onnx_path=None):
         pass
 
-    def torchscript_export(
-        self,
-        model,
-        export_path,
-        quantize=False,
-        inference_interface=None,
-        accelerate=None,
-    ):
+    def torchscript_export(self, model, export_path, **options):
         pass

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -284,6 +284,7 @@ class _NewTask(TaskBase):
         # unpack export options
         quantize = options.get("quantize", False)
         accelerate = options.get("accelerate", [])
+        padding_control = options.get("padding_control")
         inference_interface = options.get("inference_interface")
 
         # Make sure to put the model on CPU and disable CUDA before exporting to
@@ -315,6 +316,13 @@ class _NewTask(TaskBase):
             trace._c = torch._C._freeze_module(trace._c)
         if hasattr(model, "torchscriptify"):
             trace = model.torchscriptify(self.data.tensorizers, trace)
+        if padding_control is not None:
+            if hasattr(trace, "set_padding_control"):
+                trace.set_padding_control(padding_control)
+            else:
+                print(
+                    "Padding_control not supported by model. Ignoring padding_control"
+                )
         if inference_interface is not None:
             if hasattr(trace, "inference_interface"):
                 trace.inference_interface(inference_interface)

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -279,15 +279,13 @@ class _NewTask(TaskBase):
         )
 
     def torchscript_export(
-        self,
-        model,
-        export_path=None,
-        quantize=False,
-        sort_input=False,
-        sort_key=1,
-        inference_interface=None,
-        accelerate=None,
+        self, model, export_path=None, sort_input=False, sort_key=1, **options
     ):
+        # unpack export options
+        quantize = options.get("quantize", False)
+        accelerate = options.get("accelerate", [])
+        inference_interface = options.get("inference_interface")
+
         # Make sure to put the model on CPU and disable CUDA before exporting to
         # ONNX to disable any data_parallel pieces
         cuda.CUDA_ENABLED = False
@@ -310,17 +308,20 @@ class _NewTask(TaskBase):
         model(*inputs)
         if quantize:
             model.quantize()
-        if accelerate is not None:
-            if "half" in accelerate:
-                model.half()
-        if inference_interface is not None:
-            model.inference_interface(inference_interface)
-        if accelerate is not None:
-            if "nnpi" in accelerate:
-                trace._c = torch._C._freeze_module(trace._c)
+        if "half" in accelerate:
+            model.half()
         trace = model.trace(inputs)
+        if "nnpi" in accelerate:
+            trace._c = torch._C._freeze_module(trace._c)
         if hasattr(model, "torchscriptify"):
             trace = model.torchscriptify(self.data.tensorizers, trace)
+        if inference_interface is not None:
+            if hasattr(trace, "inference_interface"):
+                trace.inference_interface(inference_interface)
+            else:
+                print(
+                    "inference_interface not supported by model. Ignoring inference_interface"
+                )
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)
         if export_path is not None:
             print(f"Saving torchscript model to: {export_path}")

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -315,10 +315,10 @@ class _NewTask(TaskBase):
                 model.half()
         if inference_interface is not None:
             model.inference_interface(inference_interface)
-        trace = jit.trace(model, inputs)
         if accelerate is not None:
             if "nnpi" in accelerate:
                 trace._c = torch._C._freeze_module(trace._c)
+        trace = model.trace(inputs)
         if hasattr(model, "torchscriptify"):
             trace = model.torchscriptify(self.data.tensorizers, trace)
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -223,6 +223,7 @@ class PairwiseClassificationTask(NewTask):
         # unpack export options
         quantize = options.get("quantize", False)
         accelerate = options.get("accelerate", [])
+        padding_control = options.get("padding_control")
         inference_interface = options.get("inference_interface")
 
         cuda.CUDA_ENABLED = False
@@ -252,6 +253,13 @@ class PairwiseClassificationTask(NewTask):
             trace = model.torchscriptify(
                 self.data.tensorizers, trace, self.trace_both_encoders
             )
+        if padding_control is not None:
+            if hasattr(trace, "set_padding_control"):
+                trace.set_padding_control(padding_control)
+            else:
+                print(
+                    "Padding_control not supported by model. Ignoring padding_control"
+                )
         if inference_interface is not None:
             if hasattr(trace, "inference_interface"):
                 trace.inference_interface(inference_interface)

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -219,14 +219,12 @@ class PairwiseClassificationTask(NewTask):
         super().__init__(data, model, metric_reporter, trainer)
         self.trace_both_encoders = trace_both_encoders
 
-    def torchscript_export(
-        self,
-        model,
-        export_path=None,
-        quantize=False,
-        inference_interface=None,
-        accelerate=None,
-    ):
+    def torchscript_export(self, model, export_path=None, **options):
+        # unpack export options
+        quantize = options.get("quantize", False)
+        accelerate = options.get("accelerate", [])
+        inference_interface = options.get("inference_interface")
+
         cuda.CUDA_ENABLED = False
         model.cpu()
         optimizer = self.trainer.optimizer
@@ -242,22 +240,25 @@ class PairwiseClassificationTask(NewTask):
         model(*inputs)
         if quantize:
             model.quantize()
-        if accelerate is not None:
-            if "half" in accelerate:
-                model.half()
-        if inference_interface is not None:
-            model.inference_interface(inference_interface)
+        if "half" in accelerate:
+            model.half()
         if self.trace_both_encoders:
             trace = jit.trace(model, inputs)
         else:
             trace = jit.trace(model.encoder1, (inputs[0],))
-        if accelerate is not None:
-            if "nnpi" in accelerate:
-                trace._c = torch._C._freeze_module(trace._c)
+        if "nnpi" in accelerate:
+            trace._c = torch._C._freeze_module(trace._c)
         if hasattr(model, "torchscriptify"):
             trace = model.torchscriptify(
                 self.data.tensorizers, trace, self.trace_both_encoders
             )
+        if inference_interface is not None:
+            if hasattr(trace, "inference_interface"):
+                trace.inference_interface(inference_interface)
+            else:
+                print(
+                    "inference_interface not supported by model. Ignoring inference_interface"
+                )
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)
         if export_path is not None:
             print(f"Saving torchscript model to: {export_path}")
@@ -344,14 +345,7 @@ class SequenceLabelingTask(NewTask):
             Seq2SeqCompositionalMetricReporter.Config()
         )
 
-    def torchscript_export(
-        self,
-        model,
-        export_path=None,
-        quantize=False,
-        inference_interface=None,
-        accelerate=None,
-    ):
+    def torchscript_export(self, model, export_path=None, **options):
         model.cpu()
         # Trace needs eval mode, to disable dropout etc
         model.eval()

--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -139,6 +139,7 @@ class ScriptPyTextEmbeddingModule(ScriptModule):
         self.tensorizer = tensorizer
         self.argno = -1
 
+    @torch.jit.script_method
     def inference_interface(self, argument_type: str):
 
         # Argument types and Tuple indices
@@ -224,7 +225,7 @@ class ScriptPyTextEmbeddingModule(ScriptModule):
                     # batch elements (and which ones) were malformed
                     raise RuntimeError("Malformed request.")
 
-            flat_result = self.forward(
+            flat_result: torch.Tensor = self.forward(
                 texts=flat_texts,
                 multi_texts=None,
                 tokens=None,
@@ -242,6 +243,7 @@ class ScriptPyTextEmbeddingModule(ScriptModule):
         start = 0
         for elems in client_batch:
             end = start + elems
+            # res_list.append(flat_result[start:elems])
             res_list.append(flat_result.narrow(0, start, elems))
             start = end
 

--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -155,6 +155,15 @@ class ScriptPyTextEmbeddingModule(ScriptModule):
             raise RuntimeError("Unsupported argument type.")
 
     @torch.jit.script_method
+    def set_padding_control(self, control: Optional[List[int]]):
+        """
+        This functions will be called to set a padding style.
+        None - No padding
+        List: first element 0, round seq length to the smallest list element larger than inputs
+        """
+        self.tensorizer.set_padding_control(control)
+
+    @torch.jit.script_method
     def _forward(self, inputs: ScriptBatchInput):
         input_tensors = self.tensorizer(inputs)
         return self.model(input_tensors).cpu()

--- a/pytext/torchscript/utils.py
+++ b/pytext/torchscript/utils.py
@@ -74,14 +74,30 @@ def long_tensor_2d(shape: Tuple[int, int], fill_value: int = 0) -> torch.Tensor:
 
 @torch.jit.script
 def pad_2d_mask(
-    input: List[List[int]], pad_value: int = 0
+    input: List[List[int]],
+    pad_value: int = 0,
+    padding_control: Optional[List[int]] = None,
+    max_pad_len: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Pad a list to a 2d tensor. Returns a pair of tensors, the padded tensor
     as well as a mask tensor. The mask tensor has the same shape as the padded tensor,
-    with a 1 in the position of non-pad values and a 0 in the position of pads."""
+    with a 1 in the position of non-pad values and a 0 in the position of pads.
+    If padding_control is set, perform padding according to the specified padding style"""
     max_len = 0
     for i in input:
         max_len = max(max_len, len(i))
+    if padding_control is not None:
+        if len(padding_control) < 2:
+            raise NotImplementedError
+        elif padding_control[0] != 0:
+            raise NotImplementedError
+        else:
+            for pad in padding_control:
+                if pad >= max_len:
+                    max_len = pad
+                    break
+        if max_pad_len != -1:
+            max_len = min(max_len, max_pad_len)
     tensor = long_tensor_2d((len(input), max_len), pad_value)
     mask = long_tensor_2d((len(input), max_len), 0)
     for i in range(len(input)):

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -219,14 +219,10 @@ def export_saved_model_to_caffe2(
 
 
 def export_saved_model_to_torchscript(
-    saved_model_path: str,
-    path: str,
-    quantize: bool = False,
-    inference_interface: Optional[str] = None,
-    accelerate: List[str] = [],  # noqa mutable default is read only
+    saved_model_path: str, path: str, **options
 ) -> None:
     task, train_config, _training_state = load(saved_model_path)
-    task.torchscript_export(task.model, path, quantize, inference_interface, accelerate)
+    task.torchscript_export(task.model, path, **options)
 
 
 def test_model(

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -199,6 +199,7 @@ def save_and_export(
             quantize=config.torchscript_quantize,
             inference_interface=config.inference_interface,
             accelerate=config.accelerate,
+            padding_control=config.padding_control,
         )
 
 


### PR DESCRIPTION
Summary:
Add padding to tensorizer:
1 - Added padding logic to tensorizer in pad_2d_mask.
2 - add tensorizer member "padding_control" read by tensorizer padding logic
3 - add support to set_padding_control with function set_padding_control
4 - add config that triggers calling set_padding_control() with a padding control list from the config file.
5 - update derived class interfaces everywhere

Transition growing number of export options into a keyword args list, for readability, maintenance and robustness

Reviewed By: mwu1993

Differential Revision: D23380763

