### PR TITLE
disable dual writing, save models to Manifold

### DIFF
--- a/pytext/exporters/exporter.py
+++ b/pytext/exporters/exporter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import tempfile
 from typing import Callable, Dict, List, Tuple, Union
 
 import torch
@@ -12,6 +13,7 @@ from pytext.config.field_config import FeatureConfig
 from pytext.data import CommonMetadata
 from pytext.fields import FieldMeta
 from pytext.utils import onnx
+from pytext.utils.file_io import PathManager
 from pytext.utils.usage import log_class_usage
 
 
@@ -178,12 +180,17 @@ class ModelExporter(Component):
 
         print(f"Saving caffe2 model to: {export_path}")
 
+        # caffe2/onnx doesn't support internal uri(i.e. manifold)
+        # workaround: save to a temp file and copy to model_path
+        # this will be deprecated soon after caffe2 fully deprecated
+        _, temp_path = tempfile.mkstemp(prefix="pytext")
+
         c2_prepared = onnx.pytorch_to_caffe2(
             model,
             self.dummy_model_input,
             self.input_names,
             self.output_names,
-            export_path,
+            temp_path,
             export_onnx_path,
         )
         c2_prepared, final_input_names = self.prepend_operators(
@@ -208,9 +215,10 @@ class ModelExporter(Component):
             c2_prepared,
             final_input_names,
             final_out_names,
-            export_path,
+            temp_path,
             self.get_extra_params(),
         )
+        PathManager.copy_from_local(temp_path, export_path, overwrite=True)
         return final_out_names
 
     def export_to_metrics(self, model, metric_channels):

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -14,6 +14,7 @@ from pytext.metric_reporters import MetricReporter
 from pytext.models.model import BaseModel
 from pytext.trainers import TaskTrainer, TrainingState
 from pytext.utils import cuda, onnx
+from pytext.utils.file_io import PathManager
 from pytext.utils.usage import log_class_usage
 from torch import jit, sort
 
@@ -333,7 +334,8 @@ class _NewTask(TaskBase):
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)
         if export_path is not None:
             print(f"Saving torchscript model to: {export_path}")
-            trace.save(export_path)
+            with PathManager.open(export_path, "wb") as f:
+                torch.jit.save(trace, f)
         return trace
 
 

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -57,6 +57,7 @@ from pytext.models.word_model import WordTaggingModel
 from pytext.task.new_task import NewTask
 from pytext.trainers import EnsembleTrainer, HogwildTrainer, TaskTrainer
 from pytext.utils import cuda
+from pytext.utils.file_io import PathManager
 from torch import jit
 
 
@@ -270,7 +271,8 @@ class PairwiseClassificationTask(NewTask):
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)
         if export_path is not None:
             print(f"Saving torchscript model to: {export_path}")
-            trace.save(export_path)
+            with PathManager.open(export_path, "wb") as f:
+                torch.jit.save(trace, f)
         return trace
 
 
@@ -359,4 +361,5 @@ class SequenceLabelingTask(NewTask):
         model.eval()
         if hasattr(model, "torchscriptify"):
             jit_module = model.torchscriptify()
-            jit_module.save(export_path)
+            with PathManager.open(export_path, "wb") as f:
+                torch.jit.save(jit_module, f)


### PR DESCRIPTION
Summary:
Currently, we write files dually to Manifold and Gluster because model publishing from manifold is not supported yet.

This diff disables the dual writing and only uses Manifold during model export(jit or caffe2).

Differential Revision: D23152567

