### PR TITLE
Use TorchText SPM in PyText

### DIFF
--- a/pytext/contrib/pytext_lib/resources/__init__.py
+++ b/pytext/contrib/pytext_lib/resources/__init__.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from .url import ROBERTA_BASE_TORCH, ROBERTA_PUBLIC, XLMR_BASE, XLMR_DUMMY
+from .url import ROBERTA_BASE_TORCH, ROBERTA_PUBLIC, SP_MODEL, XLMR_BASE, XLMR_DUMMY
 
 
-__all__ = ["ROBERTA_BASE_TORCH", "ROBERTA_PUBLIC", "XLMR_BASE", "XLMR_DUMMY"]
+__all__ = [
+    "ROBERTA_BASE_TORCH",
+    "ROBERTA_PUBLIC",
+    "XLMR_BASE",
+    "XLMR_DUMMY",
+    "SP_MODEL",
+]

--- a/pytext/contrib/pytext_lib/resources/url.py
+++ b/pytext/contrib/pytext_lib/resources/url.py
@@ -5,10 +5,12 @@ ROBERTA_BASE_TORCH = "roberta_base_torch"
 ROBERTA_PUBLIC = "roberta_public"
 XLMR_BASE = "xlmr_base"
 XLMR_DUMMY = "xlmr_dummy"
+SP_MODEL = "sp_model"
 
 URL = {
     ROBERTA_BASE_TORCH: "https//dl.fbaipublicfiles.com/pytext/models/roberta/roberta_base_torch.pt",  # noqa
     ROBERTA_PUBLIC: "https//dl.fbaipublicfiles.com/pytext/models/roberta/roberta_public.pt1",  # noqa
     XLMR_BASE: "https://dl.fbaipublicfiles.com/pytext/models/xlm_r/checkpoint_base_1500k.pt",  # noqa
     XLMR_DUMMY: "https://dl.fbaipublicfiles.com/pytext/models/xlm_r/xlmr_dummy.pt",  # noqa
+    SP_MODEL: "https://dl.fbaipublicfiles.com/pytext/models/xlm_r/sp_model",  # dummy link  # noqa
 }

--- a/pytext/contrib/pytext_lib/transforms/transforms.py
+++ b/pytext/contrib/pytext_lib/transforms/transforms.py
@@ -4,10 +4,12 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
 import torch.nn as nn
+from pytext.contrib.pytext_lib.resources import url
 from pytext.data.bert_tensorizer import build_fairseq_vocab
 from pytext.data.utils import BOS, EOS, MASK, PAD, UNK
 from pytext.torchscript.vocab import ScriptVocabulary
 from pytext.utils.file_io import PathManager
+from torchtext.data.functional import load_sp_model
 
 
 class IdentityTransform(nn.Module):
@@ -105,3 +107,25 @@ class TruncateTransform(nn.Module):
 
     def forward(self, token_ids: List[List[int]]) -> List[List[int]]:
         return [token_id[: self.max_seq_len] for token_id in token_ids]
+
+
+class SpmTokenizerTransform(nn.Module):
+    """
+    Uses TorchText SPM tokenizer
+    """
+
+    def __init__(self, sp_model_path: Optional[str] = None):
+        super().__init__()
+
+        # This default spm file path is a dummy link as we haven't published
+        # the file yet. Please provide your own spm file path when using
+        # this transform
+        sp_model_path = sp_model_path or url.URL[url.SP_MODEL]
+        local_path = PathManager.get_local_path(sp_model_path)
+        self.sp_model = load_sp_model(local_path)
+
+    def forward(self, texts: List[str]) -> List[List[str]]:
+        tokens: List[List[str]] = []
+        for text in texts:
+            tokens.append(self.sp_model.EncodeAsPieces(text))
+        return tokens


### PR DESCRIPTION
Summary: Create a open-source friendly `SpmTokenizerTransform` that depends on TorchText. Point roberta and xlmr task to the new default tokenizer.

Differential Revision: D23399772

