### PR TITLE
Decode for decoupled tokenizer

### DIFF
--- a/pytext/metric_reporters/seq2seq_compositional.py
+++ b/pytext/metric_reporters/seq2seq_compositional.py
@@ -56,12 +56,12 @@ class CompositionalSeq2SeqFileChannel(Seq2SeqFileChannel):
             yield [
                 context[BatchContext.INDEX][i],
                 context[DatasetFieldName.RAW_SEQUENCE][i],
-                stringify(preds[i][0], target_vocab._vocab).upper(),
+                self.tensorizers["trg_seq_tokens"].stringify(preds[i][0]),
                 self.validated_annotation(
-                    stringify(preds[i][0], target_vocab._vocab).upper()
+                    self.tensorizers["trg_seq_tokens"].stringify(preds[i][0])
                 ),
                 self.validated_annotation(
-                    stringify(targets[i], target_vocab._vocab).upper()
+                    self.tensorizers["trg_seq_tokens"].stringify(targets[i])
                 ),
             ]
 


### PR DESCRIPTION
Summary: This diff adds support for decoding the BPE indexes in the decoupled tokenizer

Reviewed By: arbabu123

Differential Revision: D21580711

