### PR TITLE
PyText's metric reporting

### DIFF
--- a/pytext/contrib/pytext_lib/conf/__init__.py
+++ b/pytext/contrib/pytext_lib/conf/__init__.py
@@ -78,12 +78,20 @@ class TrainerConf:
 
 
 @dataclass
+class ClassificationMetricReporterConf:
+    recall_at_precision_thresholds: List[float] = field(
+        default_factory=lambda: [0.2, 0.4, 0.6, 0.8, 0.9]
+    )
+
+
+@dataclass
 class DocClassificationConfig:
     # MISSING doesn't work with non "str" type in flow
     data: DataConf
     transform: TransformConf
     model: ModelConf
     optim: OptimConf
+    metric_reporter: ClassificationMetricReporterConf = ClassificationMetricReporterConf()
     trainer: TrainerConf = TrainerConf()
     defaults: List[Any] = field(default_factory=lambda: project_defaults)
 

--- a/pytext/contrib/pytext_lib/projects/demo/xlmr_doc_classification.py
+++ b/pytext/contrib/pytext_lib/projects/demo/xlmr_doc_classification.py
@@ -49,6 +49,9 @@ config_json = """
       "weight_decay": 0,
       "amsgrad": false
     },
+    "metric_reporter": {
+      "recall_at_precision_thresholds": [0.2, 0.4, 0.6, 0.8, 0.9]
+    },
     "trainer": {
       "max_epochs": 2,
       "gpus": null,


### PR DESCRIPTION
Summary:
Adding old PyText's metric reporting as is to Lightning.

This includes console printing of tables for now.

Future: make Lightning's metrics support more complex metrics and move everything in PyText onto it.

Reviewed By: hudeven

Differential Revision: D23016786

