### PR TITLE
simplify doc_model with primitive args

### DIFF
--- a/pytext/contrib/pytext_lib/models/__init__.py
+++ b/pytext/contrib/pytext_lib/models/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reservedimport pytext_lib
 
-from .doc_model import doc_model_with_spm_embedding, doc_model_with_xlu_embedding
+from .doc_model import DocClassificationModel
 from .roberta import (
     roberta_base_binary_doc_classifier,
     xlmr_base_binary_doc_classifier,
@@ -10,8 +10,7 @@ from .roberta import (
 
 
 __all__ = [
-    "doc_model_with_spm_embedding",
-    "doc_model_with_xlu_embedding",
+    "DocClassificationModel",
     "roberta_base_binary_doc_classifier",
     "xlmr_base_binary_doc_classifier",
     "xlmr_dummy_binary_doc_classifier",

--- a/pytext/contrib/pytext_lib/models/intent_slot_model.py
+++ b/pytext/contrib/pytext_lib/models/intent_slot_model.py
@@ -217,7 +217,7 @@ def build_intent_joint_model(
     dropout=0.4,
     add_feat_len=0,
 ):
-    embedder = WordEmbedding(pretrain_embed, vocab, embed_dim)
+    embedder = WordEmbedding(pretrain_embed, embed_dim)
     slot_encoder = DocNNEncoder(
         embed_dim, slot_kernel_num, slot_kernel_sizes, dropout=dropout
     )

--- a/pytext/contrib/pytext_lib/models/pytext_model.py
+++ b/pytext/contrib/pytext_lib/models/pytext_model.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import torch.nn as nn
+
+
+class PyTextModel(nn.Module):
+    def forward(self):
+        raise NotImplementedError()
+
+    def get_loss(self):
+        raise NotImplementedError()

--- a/pytext/contrib/pytext_lib/transforms/transforms_deprecated.py
+++ b/pytext/contrib/pytext_lib/transforms/transforms_deprecated.py
@@ -222,10 +222,11 @@ class SlotLabelTransform(Transform):
 
 def build_vocab(vocab_file):
     vocab_builder = VocabBuilder()
-    with PathManager.open(vocab_file) as f:
-        vocab_builder.add_from_file(
-            f, skip_header_line=False, lowercase_tokens=False, size=0
-        )
+    if vocab_file:
+        with PathManager.open(vocab_file) as f:
+            vocab_builder.add_from_file(
+                f, skip_header_line=False, lowercase_tokens=False, size=0
+            )
     return vocab_builder.make_vocab()
 
 


### PR DESCRIPTION
Summary:
1. all trainer-able model should be extended from PyTextModel
2. use primitive args for DocClassificationModel

Reviewed By: snisarg

Differential Revision: D23698964

