### PR TITLE
merge transform and collate_fn

### DIFF
--- a/pytext/contrib/pytext_lib/data/datasets/pytext_dataset.py
+++ b/pytext/contrib/pytext_lib/data/datasets/pytext_dataset.py
@@ -3,7 +3,7 @@
 import itertools
 import logging
 import random
-from typing import Iterable, Optional
+from typing import Callable, Iterable, Optional, Union
 
 import torch.nn as nn
 from pytext.contrib.pytext_lib.data.datasets.batchers import Batcher
@@ -28,9 +28,9 @@ class PyTextDataset(IterableDataset):
         iterable: Iterable,
         batch_size: int = 1,
         is_shuffle: bool = True,
-        transform: Optional[nn.Module] = None,
+        transform: Optional[Union[nn.Module, Callable]] = None,
         custom_batcher: Optional[Batcher] = None,
-        collate_fn=None,
+        collate_fn: Optional[Callable] = None,
         chunk_size: Optional[int] = 1000,
         is_cycle: bool = False,
         length: Optional[int] = None,

--- a/pytext/contrib/pytext_lib/data/datasets/tsv_dataset.py
+++ b/pytext/contrib/pytext_lib/data/datasets/tsv_dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import torch.nn as nn
 from pytext.contrib.pytext_lib.data.datasets.batchers import Batcher
@@ -24,7 +24,7 @@ class TsvDataset(PyTextDataset):
         is_shuffle: bool = True,
         transform: Optional[nn.Module] = None,
         custom_batcher: Optional[Batcher] = None,
-        collate_fn=None,
+        collate_fn: Optional[Callable] = None,
         chunk_size: int = 1000,
         is_cycle: bool = False,
         length: Optional[int] = None,

--- a/pytext/contrib/pytext_lib/transforms/model_transform.py
+++ b/pytext/contrib/pytext_lib/transforms/model_transform.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import torch.nn as nn
+
+
+class ModelTransform(nn.Module):
+    def forward(self):
+        raise NotImplementedError
+
+    def transform(self):
+        raise NotImplementedError
+
+    def collate_fn(self):
+        raise NotImplementedError


### PR DESCRIPTION
Summary:
for regular case, we can use transform.forward(), which performs both transform and collate

for PoolBatcher, it calls transform.transform(), then custom batching, then transform.collate_fn()

Differential Revision: D23761404

