### PR TITLE
Support exporting embedding for two tower document classifier

### DIFF
--- a/pytext/models/two_tower_classification_model.py
+++ b/pytext/models/two_tower_classification_model.py
@@ -7,10 +7,6 @@ import torch
 from pytext.common.constants import Stage
 from pytext.config import ConfigBase
 from pytext.config.component import create_loss
-from pytext.data.dense_retrieval_tensorizer import (  # noqa
-    BERTContextTensorizerForDenseRetrieval,
-    PositiveLabelTensorizerForDenseRetrieval,
-)
 from pytext.data.roberta_tensorizer import RoBERTaTensorizer
 from pytext.data.tensorizers import FloatListTensorizer, LabelTensorizer, Tensorizer
 from pytext.loss import BinaryCrossEntropyLoss, MultiLabelSoftMarginLoss
@@ -24,11 +20,7 @@ from pytext.models.output_layers.doc_classification_output_layer import (
     MultiLabelOutputLayer,
 )
 from pytext.models.roberta import RoBERTaEncoder, RoBERTaEncoderBase
-from pytext.torchscript.module import (
-    ScriptPyTextEmbeddingModuleIndex,
-    ScriptPyTextModule,
-    ScriptPyTextTwoTowerModuleWithDense,
-)
+from pytext.torchscript.module import ScriptPyTextTwoTowerModuleWithDense
 from pytext.utils.label import get_label_weights
 from pytext.utils.usage import log_class_usage
 

--- a/pytext/torchscript/batchutils.py
+++ b/pytext/torchscript/batchutils.py
@@ -54,3 +54,60 @@ class PytextEmbeddingModuleBatchSort:
     ]:
         """return the batch element stored in this wrapper class"""
         return self.batchElement
+
+
+class PytextTwoTowerEmbeddingModuleBatchSort:
+    def __init__(
+        self,
+        batchElement: Tuple[
+            Optional[List[str]],  # right_texts
+            Optional[List[str]],  # left_texts
+            Optional[List[List[str]]],  # right_tokens
+            Optional[List[List[str]]],  # left_tokens
+            Optional[List[str]],  # languages
+            Optional[List[List[float]]],  # right_dense_feat
+            Optional[List[List[float]]],  # left_dense_feat
+            int,
+        ],
+        argno: int = 0,
+    ):
+        self.batchElement = batchElement
+        self.argno = argno
+
+    def __lt__(self, other: "PytextTwoTowerEmbeddingModuleBatchSort") -> bool:
+
+        argno = self.argno
+
+        if argno == 0:
+            this = self.batchElement[0]
+            that = other.batchElement[0]
+
+            if this is None:
+                return True
+            elif that is None:
+                return False
+            else:
+                # TBD: tokenize this and that,
+                # then sort by tokens instead of string length
+                # IGNORE LINTER message:
+                # torch.jit.frontend.UnsupportedNodeError: GeneratorExp aren't supported
+                return max([len(x) for x in this]) < max([len(x) for x in that])  # noqa
+        else:
+            raise NotImplementedError
+
+        return False
+
+    def be(
+        self,
+    ) -> Tuple[
+        Optional[List[str]],  # right_texts
+        Optional[List[str]],  # left_texts
+        Optional[List[List[str]]],  # right_tokens
+        Optional[List[List[str]]],  # left_tokens
+        Optional[List[str]],  # languages
+        Optional[List[List[float]]],  # right_dense_feat
+        Optional[List[List[float]]],  # left_dense_feat
+        int,
+    ]:
+        """return the batch element stored in this wrapper class"""
+        return self.batchElement

--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -3,7 +3,10 @@
 from typing import Dict, List, Optional, Tuple
 
 import torch
-from pytext.torchscript.batchutils import PytextEmbeddingModuleBatchSort
+from pytext.torchscript.batchutils import (
+    PytextEmbeddingModuleBatchSort,
+    PytextTwoTowerEmbeddingModuleBatchSort,
+)
 from pytext.torchscript.tensorizer.normalizer import VectorNormalizer
 from pytext.torchscript.tensorizer.tensorizer import ScriptTensorizer
 from pytext.torchscript.utils import ScriptBatchInput, squeeze_1d, squeeze_2d
@@ -585,3 +588,302 @@ class ScriptPyTextVariableSizeEmbeddingModule(ScriptPyTextEmbeddingModule):
             start = end
 
         return res_list
+
+
+class ScriptPyTextTwoTowerEmbeddingModule(ScriptTwoTowerModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        right_tensorizer: ScriptTensorizer,
+        left_tensorizer: ScriptTensorizer,
+    ):
+        super().__init__()
+        self.model = model
+        self.right_tensorizer = right_tensorizer
+        self.left_tensorizer = left_tensorizer
+        self.argno = -1
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def inference_interface(self, argument_type: str):
+
+        # Argument types and Tuple indices
+        TEXTS = 0
+        # MULTI_TEXTS = 1
+        # TOKENS = 2
+        # LANGUAGES = 3
+        # DENSE_FEAT = 4
+
+        if self.argno != -1:
+            raise RuntimeError("Cannot change argument type.")
+        if argument_type == "texts":
+            self.argno = TEXTS
+        else:
+            raise RuntimeError("Unsupported argument type.")
+
+    @torch.jit.script_method
+    def set_padding_control(self, control: Optional[List[int]]):
+        """
+        This functions will be called to set a padding style.
+        None - No padding
+        List: first element 0, round seq length to the smallest list element larger than inputs
+        """
+        self.right_tensorizer.set_padding_control(control)
+        self.left_tensorizer.set_padding_control(control)
+
+    @torch.jit.script_method
+    def _forward(self, right_inputs: ScriptBatchInput, left_inputs: ScriptBatchInput):
+        right_input_tensors = self.right_tensorizer(right_inputs)
+        left_input_tensors = self.left_tensorizer(left_inputs)
+
+        return self.model(right_input_tensors, left_input_tensors).cpu()
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        right_texts: Optional[List[str]] = None,
+        left_texts: Optional[List[str]] = None,
+        right_tokens: Optional[List[List[str]]] = None,
+        left_tokens: Optional[List[List[str]]] = None,
+        languages: Optional[List[str]] = None,
+    ) -> torch.Tensor:
+        right_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(right_texts),
+            tokens=squeeze_2d(right_tokens),
+            languages=squeeze_1d(languages),
+        )
+        left_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(left_texts),
+            tokens=squeeze_2d(left_tokens),
+            languages=squeeze_1d(languages),
+        )
+        return self._forward(right_inputs, left_inputs)
+
+    @torch.jit.script_method
+    def make_prediction(
+        self,
+        batch: List[
+            Tuple[
+                Optional[List[str]],  # right_texts
+                Optional[List[str]],  # left_texts
+                Optional[List[List[str]]],  # right_tokens
+                Optional[List[List[str]]],  # left_tokens
+                Optional[List[str]],  # languages
+                Optional[List[List[float]]],  # right_dense_feat
+                Optional[List[List[float]]],  # left_dense_feat
+            ]
+        ],
+    ) -> List[torch.Tensor]:
+
+        argno = self.argno
+
+        if argno == -1:
+            raise RuntimeError("Argument number not specified during export.")
+
+        batchsize = len(batch)
+
+        # Argument types and Tuple indices
+        TEXTS = 0
+        # MULTI_TEXTS = 1
+        # TOKENS = 2
+        # LANGUAGES = 3
+        # DENSE_FEAT = 4
+
+        client_batch: List[int] = []
+        res_list: List[torch.Tensor] = []
+
+        if argno == TEXTS:
+            flat_right_texts: List[str] = []
+            flat_left_texts: List[str] = []
+
+            for i in range(batchsize):
+                batch_right_element = batch[i][0]
+                batch_left_element = batch[i][1]
+                if batch_right_element is not None:
+                    flat_right_texts.extend(batch_right_element)
+                    client_batch.append(len(batch_right_element))
+                else:
+                    # At present, we abort the entire batch if
+                    # any batch element is malformed.
+                    #
+                    # Possible refinement:
+                    # we can skip malformed requests,
+                    # and return a list plus an indiction that one or more
+                    # batch elements (and which ones) were malformed
+                    raise RuntimeError("Malformed request.")
+
+                if batch_left_element is not None:
+                    flat_left_texts.extend(batch_left_element)
+                else:
+                    raise RuntimeError("Malformed request.")
+
+            flat_result: torch.Tensor = self.forward(
+                right_texts=flat_right_texts,
+                left_texts=flat_left_texts,
+                right_tokens=None,
+                left_tokens=None,
+                languages=None,
+                right_dense_feat=None,
+                left_dense_feat=None,
+            )
+
+        else:
+            raise RuntimeError("Parameter type unsupported")
+
+        # destructure flat result tensor combining
+        #   cross-request batches and client side
+        #   batches into a cross-request list of
+        #   client-side batch tensors
+        start = 0
+        for elems in client_batch:
+            end = start + elems
+            res_list.append(flat_result.narrow(0, start, elems))
+            start = end
+
+        return res_list
+
+    @torch.jit.script_method
+    def make_batch(
+        self,
+        mega_batch: List[
+            Tuple[
+                Optional[List[str]],  # right_texts
+                Optional[List[str]],  # left_texts
+                Optional[List[List[str]]],  # right_tokens
+                Optional[List[List[str]]],  # left_tokens
+                Optional[List[str]],  # languages
+                Optional[List[List[float]]],  # right_dense_feat
+                Optional[List[List[float]]],  # left_dense_feat
+                int,
+            ]
+        ],
+        goals: Dict[str, str],
+    ) -> List[
+        List[
+            Tuple[
+                Optional[List[str]],  # right_texts
+                Optional[List[str]],  # left_texts
+                Optional[List[List[str]]],  # right_tokens
+                Optional[List[List[str]]],  # left_tokens
+                Optional[List[str]],  # languages
+                Optional[List[List[float]]],  # right_dense_feat
+                Optional[List[List[float]]],  # left_dense_feat
+                int,
+            ]
+        ]
+    ]:
+
+        argno = self.argno
+
+        if argno == -1:
+            raise RuntimeError("Argument number not specified during export.")
+
+        # The next lines performs the following function, which is not supported by TorchScript
+        # sorted_mega_batch = sorted(mega_batch,key=lambda element : len(element[argno]))
+        mega_batch_class_list = [
+            PytextTwoTowerEmbeddingModuleBatchSort(x, argno) for x in mega_batch
+        ]
+        sorted_mega_batch_class_list = sorted(mega_batch_class_list)
+        sorted_mega_batch = [x.be() for x in sorted_mega_batch_class_list]
+
+        # TBD: allow model server to specify batch size in goals dictionary
+        max_bs: int = 10
+        len_mb = len(mega_batch)
+        num_batches = (len_mb + max_bs - 1) // max_bs
+
+        batch_list: List[
+            List[
+                Tuple[
+                    Optional[List[str]],  # right_texts
+                    Optional[List[str]],  # left_texts
+                    Optional[List[List[str]]],  # right_tokens
+                    Optional[List[List[str]]],  # left_tokens
+                    Optional[List[str]],  # languages
+                    Optional[List[List[float]]],  # right_dense_feat
+                    Optional[List[List[float]]],  # left_dense_feat
+                    int,  # position
+                ]
+            ]
+        ] = []
+
+        start = 0
+
+        for _i in range(num_batches):
+            end = min(start + max_bs, len_mb)
+            batch_list.append(sorted_mega_batch[start:end])
+            start = end
+
+        return batch_list
+
+
+class ScriptPyTextTwoTowerEmbeddingModuleWithDense(ScriptPyTextTwoTowerEmbeddingModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        right_tensorizer: ScriptTensorizer,
+        left_tensorizer: ScriptTensorizer,
+        right_normalizer: VectorNormalizer,
+        left_normalizer: VectorNormalizer,
+    ):
+        super().__init__(model, right_tensorizer, left_tensorizer)
+        self.right_normalizer = right_normalizer
+        self.left_normalizer = left_normalizer
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def _forward(
+        self,
+        right_inputs: ScriptBatchInput,
+        left_inputs: ScriptBatchInput,
+        right_dense_tensor: torch.Tensor,
+        left_dense_tensor: torch.Tensor,
+    ):
+        right_input_tensors = self.right_tensorizer(right_inputs)
+        left_input_tensors = self.left_tensorizer(left_inputs)
+
+        if self.right_tensorizer.device != "":
+            right_dense_tensor = right_dense_tensor.to(self.right_tensorizer.device)
+        if self.left_tensorizer.device != "":
+            left_dense_tensor = left_dense_tensor.to(self.left_tensorizer.device)
+
+        return self.model(
+            right_input_tensors,
+            left_input_tensors,
+            right_dense_tensor,
+            left_dense_tensor,
+        ).cpu()
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        right_texts: Optional[List[str]] = None,
+        left_texts: Optional[List[str]] = None,
+        right_tokens: Optional[List[List[str]]] = None,
+        left_tokens: Optional[List[List[str]]] = None,
+        languages: Optional[List[str]] = None,
+        right_dense_feat: Optional[List[List[float]]] = None,
+        left_dense_feat: Optional[List[List[float]]] = None,
+    ) -> torch.Tensor:
+        if right_dense_feat is None or left_dense_feat is None:
+            raise RuntimeError("Expect dense feature.")
+
+        right_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(right_texts),
+            tokens=squeeze_2d(right_tokens),
+            languages=squeeze_1d(languages),
+        )
+        left_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(left_texts),
+            tokens=squeeze_2d(left_tokens),
+            languages=squeeze_1d(languages),
+        )
+
+        right_dense_feat = self.right_normalizer.normalize(right_dense_feat)
+        left_dense_feat = self.left_normalizer.normalize(left_dense_feat)
+        right_dense_tensor = torch.tensor(right_dense_feat, dtype=torch.float)
+        left_dense_tensor = torch.tensor(left_dense_feat, dtype=torch.float)
+
+        sentence_embedding = self._forward(
+            right_inputs, left_inputs, right_dense_tensor, left_dense_tensor
+        )
+        return sentence_embedding


### PR DESCRIPTION
Summary: Support exporting embedding for two tower document classifier. It can export the output of either right-tower mlp or left-tower mlp as embedding separately.

Differential Revision: D23879309

