### PR TITLE
Refactor scores into metric reporter

### DIFF
--- a/pytext/metric_reporters/__init__.py
+++ b/pytext/metric_reporters/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from .calibration_metric_reporter import CalibrationMetricReporter
 from .channel import Channel
 from .classification_metric_reporter import (
     ClassificationMetricReporter,
@@ -25,6 +26,7 @@ from .word_tagging_metric_reporter import (
 __all__ = [
     "Channel",
     "MetricReporter",
+    "CalibrationMetricReporter",
     "ClassificationMetricReporter",
     "MultiLabelClassificationMetricReporter",
     "MultiLabelSequenceTaggingMetricReporter",

--- a/pytext/metric_reporters/calibration_metric_reporter.py
+++ b/pytext/metric_reporters/calibration_metric_reporter.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Any, Dict, List
+
+from pytext.config import PyTextConfig
+from pytext.metric_reporters.channel import Channel, ConsoleChannel
+from pytext.metrics import LabelPrediction
+from pytext.metrics.calibration_metrics import compute_calibration
+from torch import Tensor
+
+from .metric_reporter import MetricReporter
+
+
+class CalibrationMetricReporter(MetricReporter):
+    def __init__(self, channels: List[Channel], pad_index: int = -1) -> None:
+        super().__init__(channels)
+
+        self.pad_index = pad_index
+
+    @classmethod
+    def from_config(cls, config: PyTextConfig, pad_index: int = -1):
+        return cls(channels=[ConsoleChannel()], pad_index=pad_index)
+
+    def aggregate_preds(self, batch_preds: Tensor, batch_context=Dict[str, Any]):
+        self.all_preds.append(batch_preds.flatten().tolist())
+
+    def aggregate_targets(self, batch_targets: Tensor, batch_context=Dict[str, Any]):
+        self.all_targets.append(batch_targets.flatten().tolist())
+
+    def aggregate_scores(self, batch_scores: Tensor):
+        batch_scores = batch_scores.view(-1, batch_scores.size(-1))
+        self.all_scores.append(batch_scores.tolist())
+
+    def calculate_metric(self):
+        scores_list: List[float] = []
+        preds_list: List[int] = []
+        targets_list: List[int] = []
+
+        for (scores, preds, targets) in zip(
+            self.all_scores, self.all_preds, self.all_targets
+        ):
+            non_pad_idxs = [
+                idx for (idx, target) in enumerate(targets) if target != self.pad_index
+            ]
+
+            scores = [scores[idx] for idx in non_pad_idxs]
+            preds = [preds[idx] for idx in non_pad_idxs]
+            targets = [targets[idx] for idx in non_pad_idxs]
+
+            assert len(scores) == len(preds) == len(targets)
+
+            scores_list.extend(scores)
+            preds_list.extend(preds)
+            targets_list.extend(targets)
+
+        label_predictions: List[LabelPrediction] = [
+            LabelPrediction(scores, pred, target)
+            for (scores, pred, target) in zip(scores_list, preds_list, targets_list)
+        ]
+
+        calibration_metrics = compute_calibration(label_predictions)
+
+        return calibration_metrics

--- a/pytext/metrics/calibration_metrics.py
+++ b/pytext/metrics/calibration_metrics.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import math
+from typing import Dict, List, NamedTuple, Tuple
+
+import numpy as np
+from pytext.metrics import LabelPrediction
+
+
+def get_bucket_scores(
+    y_score: List[float], buckets: int = 10
+) -> Tuple[List[List[float]], List[int]]:
+    """
+    Organizes real-valued posterior probabilities into buckets. For example, if
+    we have 10 buckets, the probabilities 0.0, 0.1, 0.2 are placed into buckets
+    0 (0.0 <= p < 0.1), 1 (0.1 <= p < 0.2), and 2 (0.2 <= p < 0.3), respectively.
+    """
+
+    bucket_values = [[] for _ in range(buckets)]
+    bucket_indices = [[] for _ in range(buckets)]
+    for i, score in enumerate(y_score):
+        for j in range(buckets):
+            if score < float((j + 1) / buckets):
+                break
+        bucket_values[j].append(score)
+        bucket_indices[j].append(i)
+    return (bucket_values, bucket_indices)
+
+
+def get_bucket_confidence(bucket_values: List[List[float]]) -> List[float]:
+    """
+    Computes average confidence for each bucket. If a bucket does not have any
+    predictions, uses -1 as a placeholder.
+    """
+
+    return [np.mean(bucket) if len(bucket) > 0 else -1.0 for bucket in bucket_values]
+
+
+def get_bucket_accuracy(
+    bucket_values: List[List[float]], y_true: List[float], y_pred: List[float]
+) -> List[float]:
+    """
+    Computes accuracy for each bucket. If a bucket does not have any predictions,
+    uses -1 as a placeholder.
+    """
+
+    per_bucket_correct = [
+        [int(y_true[i] == y_pred[i]) for i in bucket] for bucket in bucket_values
+    ]
+    return [
+        np.mean(bucket) if len(bucket) > 0 else -1.0 for bucket in per_bucket_correct
+    ]
+
+
+def calculate_error(
+    n_samples: int,
+    bucket_values: List[List[float]],
+    bucket_confidence: List[List[float]],
+    bucket_accuracy: List[List[float]],
+) -> Tuple[float, float, float]:
+    """
+    Computes several metrics used to measure calibration error, including
+    expected calibration error (ECE), maximum calibration error (MCE), and
+    total calibration error (TCE).
+    """
+
+    assert len(bucket_values) == len(bucket_confidence) == len(bucket_accuracy)
+    assert sum(map(len, bucket_values)) == n_samples
+
+    expected_error, max_error, total_error = 0.0, 0.0, 0.0
+    for (bucket, accuracy, confidence) in zip(
+        bucket_values, bucket_accuracy, bucket_confidence
+    ):
+        if len(bucket) > 0:
+            delta = abs(accuracy - confidence)
+            expected_error += (len(bucket) / n_samples) * delta
+            max_error = max(max_error, delta)
+            total_error += delta
+    return (expected_error * 100.0, max_error * 100.0, total_error * 100.0)
+
+
+class CalibrationMetrics(NamedTuple):
+    expected_error: float
+    max_error: float
+    total_error: float
+
+    def print_metrics(self, report_pep=False) -> None:
+        print(f"\tExpected Error: {self.expected_error * 100.:.2f}")
+        print(f"\tMax Error: {self.max_error * 100.:.2f}")
+        print(f"\tTotal Error: {self.total_error * 100.:.2f}")
+
+
+class AllCalibrationMetrics(NamedTuple):
+    calibration_metrics: Dict[str, CalibrationMetrics]
+
+    def print_metrics(self, report_pep=False) -> None:
+        for (name, calibration_metric) in self.calibration_metrics.items():
+            print(f"> {name}")
+            calibration_metric.print_metrics()
+
+
+def compute_calibration(
+    label_predictions: List[LabelPrediction],
+) -> Tuple[float, float, float]:
+    conf_list = [
+        math.exp(prediction.label_scores[prediction.predicted_label])  # exp(log(p))
+        for prediction in label_predictions
+    ]
+    pred_list = [prediction.predicted_label for prediction in label_predictions]
+    true_list = [prediction.expected_label for prediction in label_predictions]
+
+    bucket_values, bucket_indices = get_bucket_scores(conf_list)
+    bucket_confidence = get_bucket_confidence(bucket_values)
+    bucket_accuracy = get_bucket_accuracy(bucket_indices, true_list, pred_list)
+
+    expected_error, max_error, total_error = calculate_error(
+        n_samples=len(conf_list),
+        bucket_values=bucket_values,
+        bucket_confidence=bucket_confidence,
+        bucket_accuracy=bucket_accuracy,
+    )
+
+    return CalibrationMetrics(
+        expected_error=expected_error, max_error=max_error, total_error=total_error
+    )

--- a/pytext/metrics/tests/calibration_metrics_test.py
+++ b/pytext/metrics/tests/calibration_metrics_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+from pytext.metrics.calibration_metrics import (
+    calculate_error,
+    get_bucket_accuracy,
+    get_bucket_confidence,
+    get_bucket_scores,
+)
+
+
+class CalibrationUtilsTest(unittest.TestCase):
+    def test_calibration(self):
+        buckets = 10
+        conf_list = [0.84, 0.98, 0.97, 0.76, 0.59, 0.62, 0.40, 0.33, 0.54, 0.37]
+        true_list = [1, 5, 3, 2, 4, 2, 7, 4, 5, 2]
+        pred_list = [1, 5, 3, 5, 2, 1, 7, 4, 5, 3]
+
+        bucket_values, bucket_indices = get_bucket_scores(conf_list, buckets)
+        bucket_confidence = get_bucket_confidence(bucket_values)
+        bucket_accuracy = get_bucket_accuracy(bucket_indices, true_list, pred_list)
+        expected_error, max_error, total_error = calculate_error(
+            len(conf_list), bucket_values, bucket_confidence, bucket_accuracy
+        )
+
+        self.assertEqual(
+            bucket_values,
+            [
+                [],
+                [],
+                [],
+                [0.33, 0.37],
+                [0.4],
+                [0.59, 0.54],
+                [0.62],
+                [0.76],
+                [0.84],
+                [0.98, 0.97],
+            ],
+        )
+        self.assertEqual(
+            bucket_indices, [[], [], [], [7, 9], [6], [4, 8], [5], [3], [0], [1, 2]]
+        )
+        self.assertEqual(
+            bucket_confidence,
+            [-1.0, -1.0, -1.0, 0.35, 0.4, 0.565, 0.62, 0.76, 0.84, 0.975],
+        )
+        self.assertEqual(
+            bucket_accuracy, [-1.0, -1.0, -1.0, 0.5, 1.0, 0.5, 0.0, 0.0, 1.0, 1.0]
+        )
+        self.assertAlmostEqual(expected_error, 26.2)
+        self.assertAlmostEqual(max_error, 76.0)
+        self.assertAlmostEqual(total_error, 238.0)


### PR DESCRIPTION
Summary: Creates `CalibrationMetricReporter`, which is initialized as a module into existing metric reporters. This new design enables other metric reporters to use calibration metrics for each (logits, targets) pair without overfitting to the current classification design.

Differential Revision: D24130105

