### PR TITLE
Linear-only graph-mode quantization at export for transformer-based models

### DIFF
--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -278,15 +278,14 @@ class RoBERTa(NewBertModel):
                     tensorizer=script_tensorizer,
                 )
 
-    def graph_mode_quantize(self, inputs, data_loader, calibration_num_batches=64):
-        """Quantize the model during export with graph mode quantization for linformer encoder."""
-        if (
-            isinstance(self.encoder, RoBERTaEncoder)
-            and self.encoder.use_linformer_encoder
-        ):
+    def graph_mode_quantize(
+        self, inputs, data_loader, calibration_num_batches=64, qconfig_dict=None
+    ):
+        """Quantize the model during export with graph mode quantization."""
+        if isinstance(self.encoder, RoBERTaEncoder):
             trace = self.trace(inputs)
-            qconfig = get_default_qconfig("fbgemm")
-            qconfig_dict = {"": qconfig}
+            if not qconfig_dict:
+                qconfig_dict = {"": get_default_qconfig("fbgemm")}
             prepare_m = prepare_jit(trace, qconfig_dict, inplace=False)
             prepare_m.eval()
             with torch.no_grad():

--- a/pytext/task/__init__.py
+++ b/pytext/task/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .new_task import NewTask, _NewTask
+from .quantize import quantize_statically
 from .serialize import get_latest_checkpoint_path, load, save
 from .task import Task_Deprecated, TaskBase, create_task
 
@@ -15,4 +16,5 @@ __all__ = [
     "load",
     "create_task",
     "get_latest_checkpoint_path",
+    "quantize_statically",
 ]

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -18,6 +18,7 @@ from pytext.utils.file_io import PathManager
 from pytext.utils.usage import log_class_usage
 from torch import jit, sort
 
+from .quantize import quantize_statically
 from .task import TaskBase
 
 
@@ -313,7 +314,9 @@ class _NewTask(TaskBase):
             model.half()
         if quantize and hasattr(model, "graph_mode_quantize"):
             data_loader = self.data.batches(Stage.TRAIN, load_early=False)
-            trace = model.graph_mode_quantize(inputs, data_loader)
+            print("Quantizing the model ...")
+            quantize_linear_only = "nnpi_quantize" in accelerate
+            trace = quantize_statically(model, data_loader, quantize_linear_only)
         else:
             if quantize:
                 model.quantize()

--- a/pytext/task/quantize.py
+++ b/pytext/task/quantize.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import torch
+from torch.quantization import HistogramObserver, QConfig, default_weight_observer
+
+def quantize_statically(model, data_loader, linear_only=False):
+    if isinstance(model.encoder, RoBERTaEncoder) and linear_only:
+        qconfig = QConfig(
+            activation=HistogramObserver.with_args(reduce_range=False),
+            weight=default_weight_observer,
+        )
+        qconfig_dict = {"": None}
+        for layer_idx in range(len(model.encoder.encoder.transformer.layers)):
+            qconfig_dict[
+                "encoder.encoder.transformer.layers.{}.attention.input_projection".format(
+                    layer_idx
+                )
+            ] = qconfig
+            qconfig_dict[
+                "encoder.encoder.transformer.layers.{}.attention.output_projection".format(
+                    layer_idx
+                )
+            ] = qconfig
+            for mlp_idx, m in enumerate(
+                model.encoder.encoder.transformer.layers[layer_idx].residual_mlp.mlp
+            ):
+                if type(m) == torch.nn.Linear:
+                    qconfig_dict[
+                        "encoder.encoder.transformer.layers.{}.residual_mlp.mlp.{}".format(
+                            layer_idx, mlp_idx
+                        )
+                    ] = qconfig
+        trace = model.graph_mode_quantize(
+            inputs, data_loader, qconfig_dict=qconfig_dict
+        )
+    else:
+        trace = model.graph_mode_quantize(inputs, data_loader)
+
+    return trace


### PR DESCRIPTION
Summary: For NNPI, we want to only quantize Linear layers only.

Reviewed By: mikekgfb

Differential Revision: D24114913

