### PR TITLE
Migrate PathManager from fvcore to ioPath

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,8 +1,8 @@
 click
 fairseq
 future
-fvcore
 hypothesis<4.0
+iopath
 mock
 numpy
 onnx

--- a/pytext/utils/file_io.py
+++ b/pytext/utils/file_io.py
@@ -7,7 +7,8 @@ import os
 # keep PathManager here for more flexibility until PathManager becomes more mature
 # in case we want some hacks in PathManager, we can do it here without updating
 # the import everywhere in PyText
-from fvcore.common.file_io import HTTPURLHandler, PathManagerBase  # noqa
+# TODO: @stevenliu use PathManagerFactory after it's released to PyPI
+from iopath.common.file_io import HTTPURLHandler, PathManager as PathManagerBase
 
 
 PathManager = PathManagerBase()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click
 fairseq
 future
-fvcore
 hypothesis<4.0
+iopath
 joblib
 numpy
 onnx>=1.6.0


### PR DESCRIPTION
Summary:
1. streaming reading support is added to ioPath in T64004265. we are unblocked and can start experiments on pre-training with data in manifold
2. ioPath is open sourced and ready to migrate

Differential Revision: D24312629

