### PR TITLE
Special token replacements for vocabs

### DIFF
--- a/pytext/contrib/pytext_lib/tests/transforms_test.py
+++ b/pytext/contrib/pytext_lib/tests/transforms_test.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reservedimport unittest
 
+import os
 import unittest
 
 import torch
-from pytext.contrib.pytext_lib.transforms import TruncateTransform
+from pytext.common.constants import SpecialTokens
+from pytext.contrib.pytext_lib.transforms import TruncateTransform, VocabTransform
 
 
 class TestTruncateTranform(unittest.TestCase):
 
     DATA = [[0, 1, 2, 3, 4, 5, 6], [0, 1, 2], []]
     MAX_SEQ_LEN = 4
+
+    def setUp(self):
+        self.base_dir = os.path.join(os.path.dirname(__file__), "data")
 
     def test_truncate_transform(self):
         transform = TruncateTransform(max_seq_len=TestTruncateTranform.MAX_SEQ_LEN)
@@ -28,3 +33,20 @@ class TestTruncateTranform(unittest.TestCase):
         for row in res:
             # Truncate lengths above max_seq_len, smaller lens aren't padded.
             self.assertEqual(len(row), min(TestTruncateTranform.MAX_SEQ_LEN, len(row)))
+
+    def test_vocab_transform(self):
+        transform = VocabTransform(os.path.join(self.base_dir, "vocab_dummy"))
+        # <unk> added by fairseq
+        tokens = [["<unk>", ",", "."], ["▁que", "▁и", "i", "e"]]
+        expected = [[3, 4, 5], [41, 35, 14, 13]]
+        self.assertEqual(transform(tokens), expected)
+
+    def test_vocab_transform_replace(self):
+        transform = VocabTransform(
+            os.path.join(self.base_dir, "vocab_dummy"),
+            special_token_replacements={"<unk>": SpecialTokens.UNK},
+        )
+        # Replace <unk> added by fairseq with our token
+        tokens = [["__UNKNOWN__", ",", "."], ["▁que", "▁и", "i", "e"]]
+        expected = [[3, 4, 5], [41, 35, 14, 13]]
+        self.assertEqual(transform(tokens), expected)

--- a/pytext/contrib/pytext_lib/transforms/transforms.py
+++ b/pytext/contrib/pytext_lib/transforms/transforms.py
@@ -52,9 +52,21 @@ class WhitespaceTokenizerTransform(nn.Module):
         return [t.split() for t in text]
 
 
+SPECIAL_TOKEN_REPLACEMENT = {
+    "[UNK]": UNK,
+    "[PAD]": PAD,
+    "[CLS]": BOS,
+    "[MASK]": MASK,
+    "[SEP]": EOS,
+}
+
+
 class VocabTransform(nn.Module):
     def __init__(
-        self, vocab_path: Optional[str] = None, vocab_list: Optional[List[str]] = None
+        self,
+        vocab_path: Optional[str] = None,
+        vocab_list: Optional[List[str]] = None,
+        special_token_replacements=SPECIAL_TOKEN_REPLACEMENT,
     ):
         super().__init__()
         assert vocab_path or vocab_list, "vocab_path or vocab_list is required"
@@ -66,13 +78,6 @@ class VocabTransform(nn.Module):
             self.vocab = ScriptVocabulary(vocab_list)
         else:
             with PathManager.open(vocab_path) as f:
-                special_token_replacements = {
-                    "[UNK]": UNK,
-                    "[PAD]": PAD,
-                    "[CLS]": BOS,
-                    "[MASK]": MASK,
-                    "[SEP]": EOS,
-                }
                 vocab = build_fairseq_vocab(
                     f, special_token_replacements=special_token_replacements
                 )


### PR DESCRIPTION
Summary:
* Adding token replacement optional field in VocabTransform
* RoBERTa replaces FairSeq's special tokens with the ones common in pytext. Reproducing here https://fburl.com/diffusion/v57r2p8c

Reviewed By: hudeven

Differential Revision: D24309466

