### PR TITLE
Upgrade black to 20.8b1 to match internal version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - run:
           name: setup lint
           command: |
-              sudo pip install black==19.3b0 isort==4.3.21
+              sudo pip install black==20.8b1 isort==4.3.21
       - run:
           name: run black
           command: black pytext --check --diff


### PR DESCRIPTION
## Motivation and Context

Facebook internal formatter has been upgraded to black v20.8b1,
and formatting was applied in da1f67642d3796aa615b4ba206af0f0738244e01

This upgrades the version to match so that CI will pass again.

## How Has This Been Tested

🤷

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/facebookresearch/pytext/blob/master/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see [**CLA**](https://github.com/facebookresearch/pytext/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla))
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
