### PR TITLE
Enable Hydra configs in fairseq (#1343) (#1343)

### DIFF
--- a/pytext/metric_reporters/seq2seq_metric_reporter.py
+++ b/pytext/metric_reporters/seq2seq_metric_reporter.py
@@ -82,9 +82,11 @@ class Seq2SeqMetricReporter(MetricReporter):
         total_count = len(self.all_targets)
         trg_vocab = self.tensorizers["trg_seq_tokens"].vocab
         bleu_scorer = bleu.Scorer(
-            trg_vocab.get_pad_index(),
-            trg_vocab.get_eos_index(),
-            trg_vocab.get_unk_index(),
+            bleu.BleuConfig(
+                pad=trg_vocab.get_pad_index(),
+                eos=trg_vocab.get_eos_index(),
+                unk=trg_vocab.get_unk_index(),
+            )
         )
         for beam_pred, target in zip(self.all_preds, self.all_targets):
             pred = beam_pred[0]


### PR DESCRIPTION
Summary:
this is the main pr that switches on hydra functionality in fairseq

we migrate "args" object into omegaconf "DictConfig" at all legacy entry points

in addition this migrates various components from secondary registries (like bpe encoders and tokenizers) to make the migration smoother

i am going through code that references migrated fairseq components and changing it to inherit from "Legacy*" components instead. hopefully tests will catch most of this

Pull Request resolved: https://github.com/fairinternal/fairseq-py/pull/1343

Differential Revision: D23973928

Pulled By: alexeib

