### PR TITLE
MetricReporter config hierarchy + Hydra _target_

### DIFF
--- a/pytext/contrib/pytext_lib/conf/__init__.py
+++ b/pytext/contrib/pytext_lib/conf/__init__.py
@@ -103,7 +103,13 @@ class OptimConf:
 
 
 @dataclass
-class ClassificationMetricReporterConf:
+class MetricReporterConf:
+    pass
+
+
+@dataclass
+class ClassificationMetricReporterConf(MetricReporterConf):
+    _target_: str = "pytext.contrib.pytext_lib.metrics.metric_reporter.classification_metric_reporter_config_expand"
     recall_at_precision_thresholds: List[float] = field(
         default_factory=lambda: [0.2, 0.4, 0.6, 0.8, 0.9]
     )
@@ -152,7 +158,7 @@ class TaskConf:
     datamodule: DataModuleConf = MISSING
     model: ModelConf = MISSING
     optim: OptimConf = MISSING
-    metric: ClassificationMetricReporterConf = ClassificationMetricReporterConf()
+    metric: MetricReporterConf = ClassificationMetricReporterConf()
 
 
 @dataclass
@@ -208,5 +214,17 @@ cs.store(
     name="doc_classification_dummy",
     node=DocClassificationDataModuleConf,
 )
+
+cs.store(
+    group="schema/task/metric",
+    name="classification_metric_reporter",
+    node=ClassificationMetricReporterConf,
+)
+cs.store(
+    group="task/metric",
+    name="classification_metric_reporter",
+    node=ClassificationMetricReporterConf,
+)
+
 cs.store(name="pytext_config", node=PyTextConf)
 cs.store(name="xlmr_classifier_sst2", node=PyTextConf)

--- a/pytext/contrib/pytext_lib/metrics/metric_reporter.py
+++ b/pytext/contrib/pytext_lib/metrics/metric_reporter.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import List
+
+from pytext.metric_reporters import ClassificationMetricReporter
+
+
+def classification_metric_reporter_config_expand(label_names: List[str], **kwargs):
+    classification_metric_reporter_config = ClassificationMetricReporter.Config(
+        **kwargs
+    )
+    return ClassificationMetricReporter.from_config_and_label_names(
+        classification_metric_reporter_config, label_names
+    )

--- a/pytext/contrib/pytext_lib/tests/metrics_test.py
+++ b/pytext/contrib/pytext_lib/tests/metrics_test.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+import hydra
+from pytext.contrib.pytext_lib.conf import ClassificationMetricReporterConf
+from pytext.metric_reporters import ClassificationMetricReporter
+
+
+class TestMetrics(unittest.TestCase):
+    def test_classification_metric_reporter_hydra_init_default(self):
+        default_mr = ClassificationMetricReporterConf()
+        classification_mr = hydra.utils.call(default_mr, label_names=["0", "1"])
+        self.assertIsInstance(classification_mr, ClassificationMetricReporter)


### PR DESCRIPTION
Summary:
Since we have multiple MetricReporters in use, safer to convert this into a hierarchy so we don't change configs again.

MetricsReporter is also not inited via it's constructor, needs a special wrapping for calling the right classmethod.

Differential Revision: D24368800

