### PR TITLE
omegaconf->native objects for torchscript

### DIFF
--- a/pytext/contrib/pytext_lib/tests/hydra_util_test.py
+++ b/pytext/contrib/pytext_lib/tests/hydra_util_test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+from omegaconf import OmegaConf
+from omegaconf.dictconfig import DictConfig
+from omegaconf.listconfig import ListConfig
+from pytext.contrib.pytext_lib.utils.hydra_util import to_container
+
+
+class TestHydraUtil(unittest.TestCase):
+    def test_to_container_list(self):
+        conf = OmegaConf.create([1, 2, 3])
+        self.assertIsInstance(conf, ListConfig)
+        real_obj = to_container(conf)
+        self.assertIsInstance(real_obj, list)
+
+    def test_to_container_dict(self):
+        conf = OmegaConf.create({"a": 1, "b": "c"})
+        self.assertIsInstance(conf, DictConfig)
+        real_obj = to_container(conf)
+        self.assertIsInstance(real_obj, dict)
+
+    def test_to_container_any(self):
+        conf = [1, 2, 3]
+        real_obj = to_container(conf)
+        self.assertIsInstance(real_obj, list)

--- a/pytext/contrib/pytext_lib/utils/hydra_util.py
+++ b/pytext/contrib/pytext_lib/utils/hydra_util.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Any
+
+from omegaconf import OmegaConf
+from omegaconf.base import Container
+
+
+def to_container(obj: Any):
+    """
+    Container types like list and dict converted from OmegaConfs are of
+    types of OmegaConf's Containers. This breaks while intermixing them
+    with code that will be converted to torchscript and breaks. This
+    method will convert these types to native python types.
+    """
+    if isinstance(obj, Container):
+        return OmegaConf.to_container(obj)
+    return obj


### PR DESCRIPTION
Summary:
When you try to script a module that contains a OmegaConf type:

```
Module 'XlmrTransform' has no attribute '_label_names' (This attribute exists on the Python module, but we failed to convert Python type: 'omegaconf.listconfig.ListConfig' to a TorchScript type.):
  File "/data/users/snisarg/fbsource/fbcode/buck-out/dev/gen/pytext/contrib/pytext_lib/test#binary,link-tree/pytext/contrib/pytext_lib/transforms/fb_roberta.py", line 100
    property
    def label_names(self):
        return self._label_names
```

We'll need to use native types if we want to torchscript. Escalating this to omry and maybe to see if we can do this transparently. For now, adding a util method.

This will be consumed as in the next diff that changes signature, so keeping it clean with a separate diff for discussions.

omry, can we upstream this?

Differential Revision: D24382743

