### PR TITLE
Restore previous behavior with respect to static graph mode quantize

### DIFF
--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -279,10 +279,18 @@ class RoBERTa(NewBertModel):
                 )
 
     def graph_mode_quantize(
-        self, inputs, data_loader, calibration_num_batches=64, qconfig_dict=None
+        self,
+        inputs,
+        data_loader,
+        calibration_num_batches=64,
+        qconfig_dict=None,
+        force_quantize=False,
     ):
         """Quantize the model during export with graph mode quantization."""
-        if isinstance(self.encoder, RoBERTaEncoder):
+        if (
+            isinstance(self.encoder, RoBERTaEncoder)
+            and self.encoder.use_linformer_encoder
+        ) or force_quantize:
             trace = self.trace(inputs)
             if not qconfig_dict:
                 qconfig_dict = {"": get_default_qconfig("fbgemm")}

--- a/pytext/task/quantize.py
+++ b/pytext/task/quantize.py
@@ -38,7 +38,7 @@ def quantize_statically(model, inputs, data_loader, linear_only=False):
                         )
                     ] = qconfig
         trace = model.graph_mode_quantize(
-            inputs, data_loader, qconfig_dict=qconfig_dict
+            inputs, data_loader, qconfig_dict=qconfig_dict, force_quantize=True
         )
     else:
         trace = model.graph_mode_quantize(inputs, data_loader)


### PR DESCRIPTION
Summary: In https://www.internalfb.com/diff/D24114913 (https://github.com/facebookresearch/PyText/commit/e828c25e7dd6fbb817af1e72773a42f244868249), static graph mode quantize got  enabled for RoBERTa-based models that were expecting dynamic quantization. This diff restores the previous behavior.

Differential Revision: D24453200

