### PR TITLE
Fix grad clip norm for FP16 use cases

### DIFF
--- a/pytext/optimizer/optimizers.py
+++ b/pytext/optimizer/optimizers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import torch
+from fairseq.utils import clip_grad_norm_
 from pytext.config import ConfigBase
 from pytext.config.component import Component, ComponentType
 
@@ -24,9 +25,9 @@ class Optimizer(Component):
             For those we treat model as max_norm.
             eg. optimizer.clip_grad_norm(max_norm)
             """
-            return torch.nn.utils.clip_grad_norm_(self.params, max_norm)
+            return clip_grad_norm_(self.params, max_norm)
         else:
-            return torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+            return clip_grad_norm_(model.parameters(), max_norm)
 
     def pre_export(self, model):
         pass


### PR DESCRIPTION
Summary:
The Fairseq FP16 optimizers rely on passing in a `max_grad_norm` of 0 and don’t expect the model gradient to update (https://www.fburl.com/diffusion/buqtrdb5)  . However in PyText optimizers we rely on the torch utility for clipping gradient norm which does not do this and ends up setting the gradients of the model to 0, thus stopping learning (https://www.fburl.com/diffusion/eg6v07qa) .

To fix this, Fairseq has its own variant of clip_grad_norm (https://www.fburl.com/diffusion/2q2uwjrf)  and this diff adjusts PyText to rely on that instead of the nn utility.

Differential Revision: D24427025

