### PR TITLE
Fix bug in D24387213

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -190,7 +190,7 @@ class PyTextConfig(ConfigBase):
             export = ExportConfig()
             for k in set(kwargs.keys()):
                 if k in export.__annotations__.keys():
-                    export.k = kwargs.pop(k)
+                    export = export._replace(**{k: kwargs.pop(k)})
             kwargs["export"] = export
         super().__init__(**kwargs)
 


### PR DESCRIPTION
Summary: The exporting configs in prev-version 22 are actually not successfully migrated into ExportConfig. For example: f227341994

Differential Revision: D24525767

