### PR TITLE
R3F/R4F Implementation

### DIFF
--- a/pytext/models/bert_classification_models.py
+++ b/pytext/models/bert_classification_models.py
@@ -126,8 +126,12 @@ class NewBertModel(BaseModel):
         else:
             output_layer_cls = MulticlassOutputLayer
 
+        additional_kwargs = {}
+        if hasattr(config, "r3f_options"):
+            additional_kwargs["r3f_options"] = config.r3f_options
+
         output_layer = output_layer_cls(list(labels), loss)
-        return cls(encoder, decoder, output_layer)
+        return cls(encoder, decoder, output_layer, **additional_kwargs)
 
     def __init__(self, encoder, decoder, output_layer, stage=Stage.TRAIN) -> None:
         super().__init__(stage=stage)

--- a/pytext/models/decoders/mlp_decoder.py
+++ b/pytext/models/decoders/mlp_decoder.py
@@ -48,6 +48,7 @@ class MLPDecoder(DecoderBase):
         bias: bool = True
         activation: Activation = Activation.RELU
         temperature: float = 1.0
+        spectral_normalization: bool = False
 
     def __init__(self, config: Config, in_dim: int, out_dim: int = 0) -> None:
         super().__init__(config)
@@ -66,6 +67,9 @@ class MLPDecoder(DecoderBase):
         if out_dim > 0:
             layers.append(nn.Linear(in_dim, out_dim, config.bias))
 
+        assert len(layers) > 0
+        if config.spectral_normalization:
+            layers[-1] = torch.nn.utils.spectral_norm(layers[-1])
         self.mlp = nn.Sequential(*layers)
         self.out_dim = out_dim if out_dim > 0 else config.hidden_dims[-1]
         self.temperature = config.temperature

--- a/pytext/models/r3f_models.py
+++ b/pytext/models/r3f_models.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from contextlib import AbstractContextManager
+from enum import Enum
+from typing import Dict
+
+import torch
+import torch.nn.functional as F
+from pytext.common.constants import Stage
+from pytext.config import ConfigBase
+from pytext.utils.precision import maybe_float
+
+
+class R3FNoiseType(Enum):
+    UNIFORM = "uniform"
+    NORMAL = "normal"
+
+
+def build_noise_sampler(noise_type: R3FNoiseType, eps: float):
+    """
+    Given a `noise_type` (`R3FNoiseType`): builds a `torch.distribution`
+    capable of generating noise within the passed in `eps` (`float`).
+    """
+    if noise_type == R3FNoiseType.UNIFORM:
+        return torch.distributions.uniform.Uniform(low=-eps, high=eps)
+    elif noise_type == R3FNoiseType.NORMAL:
+        return torch.distributions.normal.Normal(loc=0.0, scale=eps)
+    else:
+        raise Exception(f"Unknown noise type: {noise_type}")
+
+
+def compute_symmetric_kl(noised_logits, input_logits):
+    """
+    Computes symmetric KL loss by taking the KL for both the input logits
+    and the noised logits and comparing the two
+    """
+    return F.kl_div(
+        F.log_softmax(noised_logits, dim=-1, dtype=torch.float32),
+        F.softmax(input_logits, dim=-1, dtype=torch.float32),
+        None,
+        None,
+        "sum",
+    ) + F.kl_div(
+        F.log_softmax(input_logits, dim=-1, dtype=torch.float32),
+        F.softmax(noised_logits, dim=-1, dtype=torch.float32),
+        None,
+        None,
+        "sum",
+    )  # / noised_logits.size(0)
+
+
+class R3FConfigOptions(ConfigBase):
+    """
+    Configuration options for models using R3F
+    """
+
+    # for MTL purposes different lambda per loss
+    r3f_lambda_by_loss: Dict[str, float] = {}
+    r3f_default_lambda: float = 0.5
+    eps: float = 1e-5
+    noise_type: R3FNoiseType = R3FNoiseType.UNIFORM
+
+
+class R3FNoiseContextManager(AbstractContextManager):
+    """
+    Context manager that adds a forward hook to the embedding module,
+    to insert noise into the model and detatch embedding when doing
+    this pass
+    """
+
+    def __init__(self, context):
+        self.encoder_hook = None
+        self.decoder_hook = None
+        self.context = context
+        self.hook = self.context.get_embedding_module().register_forward_hook(
+            self._hook_implementation
+        )
+
+    def __enter__(self):
+        return self.context
+
+    def __exit__(self, type, value, traceback):
+        self.hook.remove()
+        self.hook = None
+
+    def _hook_implementation(self, module, input, output):
+        noise = self.context.noise_sampler.sample(sample_shape=output.shape).to(output)
+        return output.clone().detach() + noise
+
+
+class R3FPyTextMixin(object):
+    """
+    Mixin class for applying the R3F method, to apply R3F with any model
+    inherit the class and implement the abstract functions.
+
+    For more details: https://arxiv.org/abs/2008.03156
+    """
+
+    def __init__(self, config: R3FConfigOptions):
+        self.r3f_lambda_by_loss = config.r3f_lambda_by_loss
+        self.r3f_default_lambda = config.r3f_default_lambda
+        self.r3f_eps = config.eps
+        self.noise_sampler = build_noise_sampler(config.noise_type, self.r3f_eps)
+
+    def get_embedding_module(self, *args, **kwargs):
+        """
+        Given the core model outputs, this returns the embedding module that is used
+        for the R3F loss, in particular noise will be injected to this module.
+        """
+        raise NotImplementedError()
+
+    def forward_with_noise(self, *args, **kwargs):
+        with R3FNoiseContextManager(self):
+            return self.original_forward(*args, **kwargs)
+
+    def original_forward(self, *args, **kwargs):
+        """
+        Runs the traditional forward of this model
+        """
+        raise NotImplementedError()
+
+    def get_sample_size(self, model_inputs, targets):
+        """
+        Gets the sample size of the model that is used as a regularization
+        factor to the model itself
+        """
+        raise NotImplementedError()
+
+    def get_r3f_model_output(self, model_output):
+        """
+        Extracts the output from the model.forward() call that is used for the
+        r3f loss term
+        """
+        return model_output
+
+    def forward(self, *args, use_r3f: bool = False, **kwargs):
+        if use_r3f:
+            # forward with the normal model
+            model_output = self.original_forward(
+                *args,
+                **kwargs,
+            )
+
+            # compute noised model outputs
+            noise_model_outputs = self.forward_with_noise(
+                *args,
+                **kwargs,
+            )
+
+            return model_output, noise_model_outputs
+        else:
+            return self.original_forward(*args, **kwargs)
+
+    def get_r3f_loss_terms(
+        self, model_outputs, noise_model_outputs, sample_size: int
+    ) -> torch.Tensor:
+        """
+        Computes the auxillary loss for R3F, in particular computes a symmetric
+        KL divergence between the result from the input embedding and the noise
+        input embedding.
+        """
+
+        label_symm_kl = compute_symmetric_kl(
+            self.get_r3f_model_output(noise_model_outputs),
+            self.get_r3f_model_output(model_outputs),
+        )
+
+        label_symm_kl = label_symm_kl  # * sample_size
+
+        return (
+            self.r3f_lambda_by_loss.get("label", self.r3f_default_lambda)
+            * label_symm_kl
+        )
+
+    @classmethod
+    def train_batch(cls, model, batch, state=None):
+        """
+        Runs training over a batch with the R3F method, training will use R3F
+        while eval and test do not.
+        """
+
+        # Forward pass through the network.
+        model_inputs = model.arrange_model_inputs(batch)
+        model_context = model.arrange_model_context(batch)
+        targets = model.arrange_targets(batch)
+
+        sample_size = model.get_sample_size(model_inputs=model_inputs, targets=targets)
+
+        # get embedding
+        r3f_loss_term = torch.tensor(0)
+        if state and state.stage == Stage.TRAIN:
+            # during training run R3F forward calls
+            model_outputs, noise_model_outputs = model(*model_inputs, use_r3f=True)
+
+            r3f_loss_term = model.get_r3f_loss_terms(
+                model_outputs, noise_model_outputs, sample_size=sample_size
+            )
+        else:
+            # during eval and test don't run R3F forward
+            model_outputs = model(*model_inputs, use_r3f=False)
+
+        # Add stage to context.
+        if state:
+            if model_context is None:
+                model_context = {"stage": state.stage, "epoch": state.epoch}
+            else:
+                model_context["stage"] = state.stage
+                model_context["epoch"] = state.epoch
+
+        # Compute loss and predictions.
+        loss = maybe_float(model.get_loss(model_outputs, targets, model_context))
+
+        # add R3F loss term
+        loss = loss + r3f_loss_term.to(loss.device)
+
+        predictions, scores = model.get_pred(model_outputs, context=model_context)
+
+        # Pack results and return them.
+        metric_data = (predictions, targets, scores, loss, model_inputs)
+        return loss, metric_data


### PR DESCRIPTION
Summary:
An open source PyText implementation of R3F and R4F (adding spectral normalization to the MLP projection layer)

Paper: https://arxiv.org/abs/2008.03156

Fairseq implementation: https://github.com/pytorch/fairseq/pull/2455

Algorithm

{F341008137}

In this diff we add the option to forward a token embedding through the transformer. In particular, our method optimizes for the symmetric KL between the original embedding x and x + z where z is some noise sampled from a specified distribution. This diff supports both uniform and normal noise.

Differential Revision: D22942118

