### PR TITLE
New pytext hierarchy with only texts input

### DIFF
--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -892,3 +892,725 @@ class ScriptPyTextTwoTowerEmbeddingModuleWithDense(ScriptPyTextTwoTowerEmbedding
             right_inputs, left_inputs, right_dense_tensor, left_dense_tensor
         )
         return sentence_embedding
+
+
+############################################################################
+#
+# New module hierarchy Pytext* mirrors ScriptPytext* while reflecting
+# advances in pytext models:
+#  * Integrated tokenization - sole interface is texts which will be tokenized
+#  * Multi-lingual models - no need to specify languages
+#
+# All new modules provide:
+#  * Cross-request batching support
+#  * Batch optimization support
+#  * Sequence length and batch size padding for accelerators
+#
+
+
+class PyTextModule(ScriptModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        output_layer: torch.jit.ScriptModule,
+        tensorizer: ScriptTensorizer,
+    ):
+        super().__init__()
+        self.model = model
+        self.output_layer = output_layer
+        self.tensorizer = tensorizer
+
+    @torch.jit.script_method
+    def set_padding_control(self, dimension: str, control: Optional[List[int]]):
+        """
+        This functions will be called to set a padding style.
+        None - No padding
+        List: first element 0, round seq length to the smallest list element larger than inputs
+        """
+        self.tensorizer.set_padding_control(dimension, control)
+
+    @torch.jit.script_method
+    def forward(self, texts: List[str] = None):
+        inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(texts, None),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        input_tensors = self.tensorizer(inputs)
+        logits = self.model(input_tensors)
+        return self.output_layer(logits)
+
+
+class PyTextModuleWithDense(PyTextModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        output_layer: torch.jit.ScriptModule,
+        tensorizer: ScriptTensorizer,
+        normalizer: VectorNormalizer,
+    ):
+        super().__init__(model, output_layer, tensorizer)
+        self.normalizer = normalizer
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        texts: List[str],
+        dense_feat: List[List[float]],
+    ):
+        inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(texts, None),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        input_tensors = self.tensorizer(inputs)
+        dense_feat = self.normalizer.normalize(dense_feat)
+
+        dense_tensor = torch.tensor(dense_feat, dtype=torch.float)
+        if self.tensorizer.device != "":
+            dense_tensor = dense_tensor.to(self.tensorizer.device)
+        logits = self.model(input_tensors, dense_tensor)
+        return self.output_layer(logits)
+
+
+class PytextTwoTowerModule(torch.jit.ScriptModule):
+    @torch.jit.script_method
+    def set_device(self, device: str):
+        self.right_tensorizer.set_device(device)
+        self.left_tensorizer.set_device(device)
+
+    @torch.jit.script_method
+    def set_padding_control(self, dimension: str, control: Optional[List[int]]):
+        """
+        This functions will be called to set a padding style.
+        None - No padding
+        List: first element 0, round seq length to the smallest list element larger than inputs
+        """
+        self.right_tensorizer.set_padding_control(dimension, control)
+        self.left_tensorizer.set_padding_control(dimension, control)
+
+
+class PyTextTwoTowerModule(PytextTwoTowerModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        output_layer: torch.jit.ScriptModule,
+        right_tensorizer: ScriptTensorizer,
+        left_tensorizer: ScriptTensorizer,
+    ):
+        super().__init__()
+        self.model = model
+        self.output_layer = output_layer
+        self.right_tensorizer = right_tensorizer
+        self.left_tensorizer = left_tensorizer
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        right_texts: List[str],
+        left_texts: List[str],
+    ):
+        right_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(right_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        right_input_tensors = self.right_tensorizer(right_inputs)
+        left_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(left_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        left_input_tensors = self.left_tensorizer(left_inputs)
+        logits = self.model(right_input_tensors, left_input_tensors)
+        return self.output_layer(logits)
+
+
+class PyTextTwoTowerModuleWithDense(PyTextTwoTowerModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        output_layer: torch.jit.ScriptModule,
+        right_tensorizer: ScriptTensorizer,
+        left_tensorizer: ScriptTensorizer,
+        right_normalizer: VectorNormalizer,
+        left_normalizer: VectorNormalizer,
+    ):
+        super().__init__(model, output_layer, right_tensorizer, left_tensorizer)
+        self.right_normalizer = right_normalizer
+        self.left_normalizer = left_normalizer
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        right_dense_feat: List[List[float]],
+        left_dense_feat: List[List[float]],
+        right_texts: List[str],
+        left_texts: List[str],
+    ):
+        right_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(right_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        right_input_tensors = self.right_tensorizer(right_inputs)
+        left_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(left_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        left_input_tensors = self.left_tensorizer(left_inputs)
+
+        right_dense_feat = self.right_normalizer.normalize(right_dense_feat)
+        left_dense_feat = self.left_normalizer.normalize(left_dense_feat)
+        right_dense_tensor = torch.tensor(right_dense_feat, dtype=torch.float)
+        left_dense_tensor = torch.tensor(left_dense_feat, dtype=torch.float)
+        if self.right_tensorizer.device != "":
+            right_dense_tensor = right_dense_tensor.to(self.right_tensorizer.device)
+        if self.left_tensorizer.device != "":
+            left_dense_tensor = left_dense_tensor.to(self.left_tensorizer.device)
+
+        logits = self.model(
+            right_input_tensors,
+            left_input_tensors,
+            right_dense_tensor,
+            left_dense_tensor,
+        )
+        return self.output_layer(logits)
+
+
+class PyTextEmbeddingModule(ScriptModule):
+    def __init__(self, model: torch.jit.ScriptModule, tensorizer: ScriptTensorizer):
+        super().__init__()
+        self.model = model
+        self.tensorizer = tensorizer
+        self.argno = -1
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def set_padding_control(self, dimension: str, control: Optional[List[int]]):
+        """
+        This functions will be called to set a padding style.
+        None - No padding
+        List: first element 0, round seq length to the smallest list element larger than inputs
+        """
+        self.tensorizer.set_padding_control(dimension, control)
+
+    @torch.jit.script_method
+    def _forward(self, inputs: ScriptBatchInput):
+        input_tensors = self.tensorizer(inputs)
+        return self.model(input_tensors).cpu()
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        texts: List[str],
+        dense_feat: Optional[List[List[float]]] = None,
+    ) -> torch.Tensor:
+        inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(texts, None),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        return self._forward(inputs)
+
+    @torch.jit.script_method
+    def make_prediction(
+        self,
+        batch: List[
+            Tuple[
+                List[str],  # texts
+                Optional[List[List[float]]],  # dense_feat
+            ]
+        ],
+    ) -> List[torch.Tensor]:
+
+        batchsize = len(batch)
+
+        client_batch: List[int] = []
+        res_list: List[torch.Tensor] = []
+
+        flat_texts: List[str] = []
+
+        for i in range(batchsize):
+            batch_element = batch[i][0]
+            flat_texts.extend(batch_element)
+            client_batch.append(len(batch_element))
+
+            if batch[i][1] is not None:
+                # Cross-request batching not yet supported for requests with dense_feat
+                raise RuntimeError("Malformed request.")
+
+        if len(flat_texts) == 0:
+            raise RuntimeError("This is not good. Empty request batch.")
+
+        flat_result: torch.Tensor = self.forward(
+            texts=flat_texts,
+            dense_feat=None,
+        )
+
+        # destructure flat result tensor combining
+        #   cross-request batches and client side
+        #   batches into a cross-request list of
+        #   client-side batch tensors
+        start = 0
+        for elems in client_batch:
+            end = start + elems
+            res_list.append(flat_result.narrow(0, start, elems))
+            start = end
+
+        return res_list
+
+    @torch.jit.script_method
+    def make_batch(
+        self,
+        mega_batch: List[
+            Tuple[
+                List[str],  # texts
+                Optional[List[List[float]]],  # dense_feat
+                int,
+            ]
+        ],
+        goals: Dict[str, str],
+    ) -> List[
+        List[
+            Tuple[
+                List[str],  # texts
+                Optional[List[List[float]]],  # dense_feat
+                int,
+            ]
+        ]
+    ]:
+
+        # The next lines sort all cross-request batch elements by the token length.
+        # Note that cross-request batch element can in turn be a client batch.
+        mega_batch_key_list = [
+            (max_tokens(self.tensorizer.tokenize(x[0], None)), n)
+            for (n, x) in enumerate(mega_batch)
+        ]
+        sorted_mega_batch_key_list = sorted(mega_batch_key_list)
+        sorted_mega_batch = [mega_batch[n] for (key, n) in sorted_mega_batch_key_list]
+
+        # TBD: allow model server to specify batch size in goals dictionary
+        max_bs: int = 10
+        len_mb = len(mega_batch)
+        num_batches = (len_mb + max_bs - 1) // max_bs
+
+        batch_list: List[
+            List[
+                Tuple[
+                    List[str],  # texts
+                    Optional[List[List[float]]],  # dense_feat
+                    int,  # position
+                ]
+            ]
+        ] = []
+
+        start = 0
+
+        for _i in range(num_batches):
+            end = min(start + max_bs, len_mb)
+            batch_list.append(sorted_mega_batch[start:end])
+            start = end
+
+        return batch_list
+
+
+class PyTextEmbeddingModuleIndex(PyTextEmbeddingModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        tensorizer: ScriptTensorizer,
+        index: int = 0,
+    ):
+        super().__init__(model, tensorizer)
+        self.index = torch.jit.Attribute(index, int)
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def _forward(self, inputs: ScriptBatchInput):
+        input_tensors = self.tensorizer(inputs)
+        return self.model(input_tensors)[self.index].cpu()
+
+
+class PyTextEmbeddingModuleWithDense(PyTextEmbeddingModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        tensorizer: ScriptTensorizer,
+        normalizer: VectorNormalizer,
+        concat_dense: bool = False,
+    ):
+        super().__init__(model, tensorizer)
+        self.normalizer = normalizer
+        self.concat_dense = torch.jit.Attribute(concat_dense, bool)
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def _forward(self, inputs: ScriptBatchInput, dense_tensor: torch.Tensor):
+        input_tensors = self.tensorizer(inputs)
+        if self.tensorizer.device != "":
+            dense_tensor = dense_tensor.to(self.tensorizer.device)
+        return self.model(input_tensors, dense_tensor).cpu()
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        texts: List[str],
+        dense_feat: Optional[List[List[float]]] = None,
+    ) -> torch.Tensor:
+        if dense_feat is None:
+            raise RuntimeError("Expect dense feature.")
+
+        inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(texts, None),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        # call model
+        dense_feat = self.normalizer.normalize(dense_feat)
+        dense_tensor = torch.tensor(dense_feat, dtype=torch.float)
+
+        sentence_embedding = self._forward(inputs, dense_tensor)
+        if self.concat_dense:
+            return torch.cat([sentence_embedding, dense_tensor], 1)
+        else:
+            return sentence_embedding
+
+
+class PyTextEmbeddingModuleWithDenseIndex(PyTextEmbeddingModuleWithDense):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        tensorizer: ScriptTensorizer,
+        normalizer: VectorNormalizer,
+        index: int = 0,
+        concat_dense: bool = True,
+    ):
+        super().__init__(model, tensorizer, normalizer, concat_dense)
+        self.index = torch.jit.Attribute(index, int)
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def _forward(self, inputs: ScriptBatchInput, dense_tensor: torch.Tensor):
+        input_tensors = self.tensorizer(inputs)
+        if self.tensorizer.device != "":
+            dense_tensor = dense_tensor.to(self.tensorizer.device)
+        return self.model(input_tensors, dense_tensor)[self.index].cpu()
+
+
+class PyTextVariableSizeEmbeddingModule(PyTextEmbeddingModule):
+    """
+    Assumes model returns a tuple of representations and sequence lengths, then slices
+    each example's representation according to length. Returns a list of tensors. The
+    slicing is easier to do outside a traced model.
+    """
+
+    def __init__(self, model: torch.jit.ScriptModule, tensorizer: ScriptTensorizer):
+        super().__init__(model, tensorizer)
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def _forward(self, inputs: ScriptBatchInput):
+        input_tensors = self.tensorizer(inputs)
+        reps, seq_lens = self.model(input_tensors)
+        reps = reps.cpu()
+        seq_lens = seq_lens.cpu()
+        return [reps[i, : seq_lens[i]] for i in range(len(seq_lens))]
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        texts: List[str],
+        dense_feat: Optional[List[List[float]]] = None,
+    ) -> List[torch.Tensor]:
+        inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(texts, None),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        return self._forward(inputs)
+
+    @torch.jit.script_method
+    def make_prediction(
+        self,
+        batch: List[
+            Tuple[
+                List[str],  # texts
+                Optional[List[List[float]]],  # dense_feat
+            ]
+        ],
+    ) -> List[List[torch.Tensor]]:
+
+        client_batch: List[int] = []
+        res_list: List[List[torch.Tensor]] = []
+
+        flat_texts: List[str] = []
+
+        for be in batch:
+            batch_element = be[0]
+            if batch_element is not None:
+                flat_texts.extend(batch_element)
+                client_batch.append(len(batch_element))
+
+            if be[1] is not None:
+                raise RuntimeError(
+                    "Malformed request: desnse_feat not supported for cross-request batching in VE Module"
+                )
+
+        if len(flat_texts) == 0:
+            raise RuntimeError("This is not good. Empty request batch.")
+
+        flat_result: List[torch.Tensor] = self.forward(
+            texts=flat_texts,
+            multi_texts=None,
+            tokens=None,
+            languages=None,
+            dense_feat=None,
+        )
+
+        # destructure flat result list combining
+        #   cross-request batches and client side
+        #   batches into a cross-request list of
+        #   client-side batch result lists
+        start = 0
+        for elems in client_batch:
+            end = start + elems
+            res_list.append(flat_result[start:end])
+            start = end
+
+        return res_list
+
+
+class PyTextTwoTowerEmbeddingModule(PyTextTwoTowerModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        right_tensorizer: ScriptTensorizer,
+        left_tensorizer: ScriptTensorizer,
+    ):
+        super().__init__()
+        self.model = model
+        self.right_tensorizer = right_tensorizer
+        self.left_tensorizer = left_tensorizer
+        self.argno = -1
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def set_padding_control(self, dimension: str, control: Optional[List[int]]):
+        """
+        This functions will be called to set a padding style.
+        None - No padding
+        List: first element 0, round seq length to the smallest list element larger than inputs
+        """
+        self.right_tensorizer.set_padding_control(dimension, control)
+        self.left_tensorizer.set_padding_control(dimension, control)
+
+    @torch.jit.script_method
+    def _forward(self, right_inputs: ScriptBatchInput, left_inputs: ScriptBatchInput):
+        right_input_tensors = self.right_tensorizer(right_inputs)
+        left_input_tensors = self.left_tensorizer(left_inputs)
+
+        return self.model(right_input_tensors, left_input_tensors).cpu()
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        right_texts: List[str],
+        left_texts: List[str],
+    ) -> torch.Tensor:
+        right_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(right_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        left_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(left_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        return self._forward(right_inputs, left_inputs)
+
+    @torch.jit.script_method
+    def make_prediction(
+        self,
+        batch: List[
+            Tuple[
+                List[str],  # right_texts
+                List[str],  # left_texts
+                Optional[List[List[float]]],  # right_dense_feat
+                Optional[List[List[float]]],  # left_dense_feat
+            ]
+        ],
+    ) -> List[torch.Tensor]:
+
+        batchsize = len(batch)
+
+        client_batch: List[int] = []
+        res_list: List[torch.Tensor] = []
+
+        flat_right_texts: List[str] = []
+        flat_left_texts: List[str] = []
+
+        for i in range(batchsize):
+            batch_right_element = batch[i][0]
+            batch_left_element = batch[i][1]
+
+            flat_right_texts.extend(batch_right_element)
+            flat_left_texts.extend(batch_left_element)
+            client_batch.append(len(batch_right_element))
+
+            if batch[i][2] is not None or batch[i][3] is not None:
+                raise RuntimeError(
+                    "Cross-request batching not supported for desne_feat"
+                )
+
+            flat_result: torch.Tensor = self.forward(
+                right_texts=flat_right_texts,
+                left_texts=flat_left_texts,
+                right_dense_feat=None,
+                left_dense_feat=None,
+            )
+
+        # destructure flat result tensor combining
+        #   cross-request batches and client side
+        #   batches into a cross-request list of
+        #   client-side batch tensors
+        start = 0
+        for elems in client_batch:
+            end = start + elems
+            res_list.append(flat_result.narrow(0, start, elems))
+            start = end
+
+        return res_list
+
+    @torch.jit.script_method
+    def make_batch(
+        self,
+        mega_batch: List[
+            Tuple[
+                List[str],  # right_texts
+                List[str],  # left_texts
+                Optional[List[List[float]]],  # right_dense_feat
+                Optional[List[List[float]]],  # left_dense_feat
+                int,
+            ]
+        ],
+        goals: Dict[str, str],
+    ) -> List[
+        List[
+            Tuple[
+                List[str],  # right_texts
+                List[str],  # left_texts
+                Optional[List[List[float]]],  # right_dense_feat
+                Optional[List[List[float]]],  # left_dense_feat
+                int,
+            ]
+        ]
+    ]:
+
+        # The next lines sort all cross-request batch elements by the token length of right_.
+        # Note that cross-request batch element can in turn be a client batch.
+        mega_batch_key_list = [
+            (max_tokens(self.right_tensorizer.tokenize(x[0], None)), n)
+            for (n, x) in enumerate(mega_batch)
+        ]
+        sorted_mega_batch_key_list = sorted(mega_batch_key_list)
+        sorted_mega_batch = [mega_batch[n] for (key, n) in sorted_mega_batch_key_list]
+
+        # TBD: allow model server to specify batch size in goals dictionary
+        max_bs: int = 10
+        len_mb = len(mega_batch)
+        num_batches = (len_mb + max_bs - 1) // max_bs
+
+        batch_list: List[
+            List[
+                Tuple[
+                    List[str],  # right_texts
+                    List[str],  # left_texts
+                    Optional[List[List[float]]],  # right_dense_feat
+                    Optional[List[List[float]]],  # left_dense_feat
+                    int,  # position
+                ]
+            ]
+        ] = []
+
+        start = 0
+
+        for _i in range(num_batches):
+            end = min(start + max_bs, len_mb)
+            batch_list.append(sorted_mega_batch[start:end])
+            start = end
+
+        return batch_list
+
+
+class PyTextTwoTowerEmbeddingModuleWithDense(PyTextTwoTowerEmbeddingModule):
+    def __init__(
+        self,
+        model: torch.jit.ScriptModule,
+        right_tensorizer: ScriptTensorizer,
+        left_tensorizer: ScriptTensorizer,
+        right_normalizer: VectorNormalizer,
+        left_normalizer: VectorNormalizer,
+    ):
+        super().__init__(model, right_tensorizer, left_tensorizer)
+        self.right_normalizer = right_normalizer
+        self.left_normalizer = left_normalizer
+        log_class_usage(self.__class__)
+
+    @torch.jit.script_method
+    def _forward(
+        self,
+        right_inputs: ScriptBatchInput,
+        left_inputs: ScriptBatchInput,
+        right_dense_tensor: torch.Tensor,
+        left_dense_tensor: torch.Tensor,
+    ):
+        right_input_tensors = self.right_tensorizer(right_inputs)
+        left_input_tensors = self.left_tensorizer(left_inputs)
+
+        if self.right_tensorizer.device != "":
+            right_dense_tensor = right_dense_tensor.to(self.right_tensorizer.device)
+        if self.left_tensorizer.device != "":
+            left_dense_tensor = left_dense_tensor.to(self.left_tensorizer.device)
+
+        return self.model(
+            right_input_tensors,
+            left_input_tensors,
+            right_dense_tensor,
+            left_dense_tensor,
+        ).cpu()
+
+    @torch.jit.script_method
+    def forward(
+        self,
+        right_texts: List[str],
+        left_texts: List[str],
+        right_dense_feat: Optional[List[List[float]]] = None,
+        left_dense_feat: Optional[List[List[float]]] = None,
+    ) -> torch.Tensor:
+        if right_dense_feat is None or left_dense_feat is None:
+            raise RuntimeError("Expect dense feature.")
+
+        right_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(right_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+        left_inputs: ScriptBatchInput = ScriptBatchInput(
+            texts=resolve_texts(left_texts),
+            tokens=squeeze_2d(None),
+            languages=squeeze_1d(None),
+        )
+
+        right_dense_feat = self.right_normalizer.normalize(right_dense_feat)
+        left_dense_feat = self.left_normalizer.normalize(left_dense_feat)
+        right_dense_tensor = torch.tensor(right_dense_feat, dtype=torch.float)
+        left_dense_tensor = torch.tensor(left_dense_feat, dtype=torch.float)
+
+        sentence_embedding = self._forward(
+            right_inputs, left_inputs, right_dense_tensor, left_dense_tensor
+        )
+        return sentence_embedding


### PR DESCRIPTION
Summary:
New pytext hierarchy with only texts input

The current polymorphic forward() interface for pytext models complicates processing for items such as cross-request batching.   The general feeling is that models only use one or the other type of inputs in production, so we're incurring unnecessary overhead  by needing code paths that can support all combinations.

The present diff clones all ScriptPytext* modules with polymorphic inputs into new modules with just texts (or left_ and right_ texts for two tower models).  Future models that offer integrated tokenization are encouraged to use the new, simpler hierarchy.

We'll roll out a transition solution to bring forward legacy models using the texts interface to benefit from the simpler signature once we have demonstrated user acceptance of the new interfaces.

Reviewed By: chenyangyu1988

Differential Revision: D24740759

