### PR TITLE
Make Decoupled Stack FP16 Friendly [6/n]

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -1639,7 +1639,7 @@ class GazetteerTensorizer(Tensorizer):
         feats, weights, lengths = zip(*batch)
         lengths_flattened = [l for l_list in lengths for l in l_list]
         seq_lens = [len(l_list) for l_list in lengths]
-        max_ex_len = max(seq_lens)
+        max_ex_len = precision.pad_length(max(seq_lens))
         max_feat_len = max(lengths_flattened)
         all_lengths, all_feats, all_weights = [], [], []
         for i, seq_len in enumerate(seq_lens):
@@ -1671,7 +1671,7 @@ class GazetteerTensorizer(Tensorizer):
             all_lengths.append(ex_lengths)
         return (
             cuda.tensor(all_feats, torch.long),
-            cuda.tensor(all_weights, torch.float),
+            precision.maybe_half(cuda.tensor(all_weights, torch.float)),
             cuda.tensor(all_lengths, torch.long),
         )
 

--- a/pytext/models/embeddings/dict_embedding.py
+++ b/pytext/models/embeddings/dict_embedding.py
@@ -177,9 +177,9 @@ class DictEmbedding(EmbeddingBase):
         # Temporary workaround till https://github.com/pytorch/pytorch/issues/32840
         # is resolved
         if self.pooling_type == "mean":
-            reduced_embeds = (
-                torch.sum(weighted_embds, dim=2) / lengths.unsqueeze(2).float()
-            )
+            reduced_embeds = torch.sum(weighted_embds, dim=2) / lengths.unsqueeze(
+                2
+            ).type_as(weighted_embds)
         elif self.pooling_type == "max":
             reduced_embeds, _ = torch.max(weighted_embds, dim=2)
         else:


### PR DESCRIPTION
Summary:
This diff goes through the NAR decoupled stack and makes the model FP16 training friendly in particular, the benefits here is that the model training is much faster and capable of leveraging a larger batch size on a single GPU.

The following modules needed to be adjusted for NAR:

* Dict Embedding
* Attention Mechanism
* Decoupled Projection
* Conv Model

There are a few things followed here to make these modules FP16 friendly.

1) Don't use `.float()` as we use different data types for mixed precision, type should always be inferred from prior tensors (e.g. using `type_as`)
2) Softmax operations should be done in 32 bits as well as batch norms, this was advice given from fairseq folks
3) Tensors are expected to be a multiple of 8, this means that anywhere that length is padded as input to the model (e.g. tensorizers) use the pad length of `precision.pad_length(max(seq_len))` rather than `max(seq_len)` for the dimensions of the matrix.

Differential Revision: D24822108

