### PR TITLE
Update param group reset for FP16

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -1639,7 +1639,7 @@ class GazetteerTensorizer(Tensorizer):
         feats, weights, lengths = zip(*batch)
         lengths_flattened = [l for l_list in lengths for l in l_list]
         seq_lens = [len(l_list) for l_list in lengths]
-        max_ex_len = max(seq_lens)
+        max_ex_len = precision.pad_length(max(seq_lens))
         max_feat_len = max(lengths_flattened)
         all_lengths, all_feats, all_weights = [], [], []
         for i, seq_len in enumerate(seq_lens):
@@ -1671,7 +1671,7 @@ class GazetteerTensorizer(Tensorizer):
             all_lengths.append(ex_lengths)
         return (
             cuda.tensor(all_feats, torch.long),
-            cuda.tensor(all_weights, torch.float),
+            precision.maybe_half(cuda.tensor(all_weights, torch.float)),
             cuda.tensor(all_lengths, torch.long),
         )
 

--- a/pytext/models/embeddings/dict_embedding.py
+++ b/pytext/models/embeddings/dict_embedding.py
@@ -177,9 +177,9 @@ class DictEmbedding(EmbeddingBase):
         # Temporary workaround till https://github.com/pytorch/pytorch/issues/32840
         # is resolved
         if self.pooling_type == "mean":
-            reduced_embeds = (
-                torch.sum(weighted_embds, dim=2) / lengths.unsqueeze(2).float()
-            )
+            reduced_embeds = torch.sum(weighted_embds, dim=2) / lengths.unsqueeze(
+                2
+            ).type_as(weighted_embds)
         elif self.pooling_type == "max":
             reduced_embeds, _ = torch.max(weighted_embds, dim=2)
         else:

--- a/pytext/optimizer/fp16_optimizer.py
+++ b/pytext/optimizer/fp16_optimizer.py
@@ -369,7 +369,7 @@ class FP16OptimizerFairseq(Fairseq_FP16OptimizerMixin, FP16Optimizer):
         # reset fp32_optimizer param groups to using master weights
         fp32_param_group = self.fp32_optimizer.param_groups[0]
         fp32_param_group["params"] = [self.fp32_params[torch.cuda.current_device()]]
-        self.fp32_optimizer.param_groups = []
+        self.fp32_optimizer.reset_param_groups()
         self.fp32_optimizer.add_param_group(fp32_param_group)
 
     @classmethod

--- a/pytext/optimizer/optimizers.py
+++ b/pytext/optimizer/optimizers.py
@@ -48,6 +48,9 @@ class Optimizer(Component):
             for p in param_group["params"]:
                 yield p
 
+    def reset_param_groups(self):
+        self.param_groups = []
+
 
 class Adagrad(torch.optim.Adagrad, Optimizer):
     class Config(Optimizer.Config):

--- a/pytext/optimizer/swa.py
+++ b/pytext/optimizer/swa.py
@@ -303,6 +303,10 @@ class StochasticWeightAveraging(Optimizer, PT_Optimizer):
         base_opt = create_optimizer(config.optimizer, model)
         return cls(base_opt, config.start, config.frequency, config.swa_learning_rate)
 
+    def reset_param_groups(self):
+        self.param_groups = []
+        self.optimizer.param_groups = []
+
 
 # BatchNorm utils
 def _check_bn_apply(module, flag):


### PR DESCRIPTION
Summary:
Certain optimizers rely on nested optimizers (such as StochasticWeightAveraging), explicitly reseting the para_group with `param_group = []` won't work in this case because the parameter groups from the nested optimizers need to be removed as well. This diff updates `Optimizer` to have a `reset_param_group` abstraction that allows each optimizer to handle resetting of param groups.

This unblocks weight averaging for FP16 training.

Reviewed By: mwu1993

Differential Revision: D24513502

