### PR TITLE
add py support for textray_details.thrift

### DIFF
--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -3,6 +3,10 @@
 from typing import Dict, List, Optional, Tuple
 
 import torch
+from multiray.textray.textray_details.ttypes import (  # noqa
+    QuantizationSchema,
+    FeatureSchema,
+)
 from pytext.torchscript.batchutils import (
     max_tokens,
     make_prediction_texts,


### PR DESCRIPTION
Summary: add py support for textray_details.thrift, which will be used by PyText module

Reviewed By: mikekgfb

Differential Revision: D24964672

