### PR TITLE
Enhance export/torchscript_export to read parameters from an export configuration JSON

### DIFF
--- a/demo/configs/docnn_wo_export.json
+++ b/demo/configs/docnn_wo_export.json
@@ -1,0 +1,25 @@
+{
+  "version": 8,
+  "task": {
+    "DocumentClassificationTask": {
+      "data": {
+        "source": {
+          "TSVDataSource": {
+            "field_names": ["label", "slots", "text"],
+            "train_filename": "tests/data/train_data_tiny.tsv",
+            "test_filename": "tests/data/test_data_tiny.tsv",
+            "eval_filename": "tests/data/test_data_tiny.tsv"
+          }
+        }
+      },
+      "model": {
+        "DocModel": {
+          "representation": {
+            "DocNNRepresentation": {}
+          }
+        }
+      }
+    }
+  },
+  "save_snapshot_path": "/tmp/model.pt"
+}

--- a/demo/configs/export_options.json
+++ b/demo/configs/export_options.json
@@ -1,0 +1,7 @@
+{
+  "version": 22,
+  "export": {
+    "export_torchscript_path": "/tmp/new_docnn.pt1",
+    "export_caffe2_path": "/tmp/model.caffe2.predictor"
+  }
+}

--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -201,6 +201,12 @@ def config_from_json(cls, json_obj, ignore_fields=()):
             detected in config json: {unknown_fields}"
         )
     for field, f_cls in cls.__annotations__.items():
+        if field in ignore_fields:
+            eprint(
+                f"Info - field: {field} in class: {cls_name} is skipped in",
+                "config_from_json because it's found in the ignore_fields.",
+            )
+            continue
         value = None
         is_optional = _is_optional(f_cls)
 

--- a/pytext/config/test/json_config/v22_export_config.json
+++ b/pytext/config/test/json_config/v22_export_config.json
@@ -1,0 +1,28 @@
+[
+  {
+    "original": {
+      "version": 21,
+      "inference_interface": "texts",
+      "seq_padding_control": [0, 50, 150, 300, 512],
+      "batch_padding_control": [0, 1, 2, 8, 32],
+      "export_torchscript_path": "/tmp/model.pt1",
+      "export_caffe2_path": "/tmp/model_caffe2.pt1",
+      "export_onnx_path": "/tmp/model_onnx.pt1",
+      "torchscript_quantize": false,
+      "task": {"NewTask": {}}
+    },
+    "adapted": {
+      "version": 22,
+      "export": {
+        "seq_padding_control": [0, 50, 150, 300, 512],
+        "batch_padding_control": [0, 1, 2, 8, 32],
+        "inference_interface": "texts",
+        "export_torchscript_path": "/tmp/model.pt1",
+        "export_caffe2_path": "/tmp/model_caffe2.pt1",
+        "export_onnx_path": "/tmp/model_onnx.pt1",
+        "torchscript_quantize": false
+      },
+      "task": {"NewTask": {}}
+    }
+  }
+]

--- a/pytext/docs/source/execute_your_first_model.rst
+++ b/pytext/docs/source/execute_your_first_model.rst
@@ -76,6 +76,7 @@ Exporting a model is pretty simple:
       Convert a pytext model snapshot to a caffe2 model.
 
     Options:
+      --export-json TEXT  the path to the export options in JSON format
       --model TEXT        the pytext snapshot model file to load
       --output-path TEXT  where to save the exported model
       --help              Show this message and exit.
@@ -85,6 +86,14 @@ You can also pass in a configuration to infer some of these options. In this cas
 .. code-block:: console
 
     (pytext) $ pytext export --output-path exported_model.c2 < demo/configs/docnn.json
+    ...[snip]
+    Saving caffe2 model to: exported_model.c2
+
+Alternatively you can use the export-json to pass in a json config with only version and export fields populated.
+
+.. code-block:: console
+
+    (pytext) $ pytext export --output-path exported_model.c2 --export-json demo/configs/export_options.json < demo/configs/docnn.json
     ...[snip]
     Saving caffe2 model to: exported_model.c2
 

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -16,6 +16,7 @@ from pytext.builtin_task import add_include
 from pytext.common.utils import eprint
 from pytext.config import LATEST_VERSION, PyTextConfig
 from pytext.config.component import register_tasks
+from pytext.config.config_adapter import upgrade_to_latest
 from pytext.config.serialize import (
     config_to_json,
     parse_config,
@@ -48,6 +49,26 @@ from torch.multiprocessing.spawn import spawn
 class Attrs:
     def __repr__(self):
         return f"Attrs({', '.join(f'{k}={v}' for k, v in vars(self).items())})"
+
+
+def _is_valid_export_json_config(export_json_config):
+    """Validate if the input export_json_config (PyTextConfig in JSON object) only has
+    export section config and a version number.
+    """
+    return export_json_config.keys() == {"export", "version"}
+
+
+def _load_and_validate_export_json_config(export_json):
+    with PathManager.open(export_json) as fp:
+        export_json_config = json.load(fp)
+        if "config" in export_json_config:
+            export_json_config = export_json_config["config"]
+        export_json_config = upgrade_to_latest(export_json_config)
+        assert _is_valid_export_json_config(export_json_config), (
+            "The export-json config should only contain fields export and version. Got "
+            f"{export_json_config.keys()}"
+        )
+        return export_json_config
 
 
 def train_model_distributed(config, metric_channels: Optional[List[Channel]]):
@@ -381,17 +402,31 @@ def train(context):
 
 
 @main.command()
+@click.option("--export-json", help="the path to the export options in JSON format.")
 @click.option("--model", help="the pytext snapshot model file to load")
 @click.option("--output-path", help="where to save the exported caffe2 model")
 @click.option("--output-onnx-path", help="where to save the exported onnx model")
 @click.pass_context
-def export(context, model, output_path, output_onnx_path):
+def export(context, export_json, model, output_path, output_onnx_path):
     """Convert a pytext model snapshot to a caffe2 model."""
-    if not model:
-        config = context.obj.load_config()
-        model = config.save_snapshot_path
-        output_path = config.export_caffe2_path
-        output_onnx_path = config.export_onnx_path
+    # only populate from export_json if no export option is configured from the command line.
+    if export_json:
+        if not output_path and not output_onnx_path:
+            export_json_config = _load_and_validate_export_json_config(export_json)
+            export_section_config = export_json_config["export"]
+            if "export_caffe2_path" in export_section_config:
+                output_path = export_section_config["export_caffe2_path"]
+            if "export_onnx_path" in export_section_config:
+                output_onnx_path = export_section_config["export_onnx_path"]
+        else:
+            print(
+                "the export-json config is ignored because export options are found the command line"
+            )
+    config = context.obj.load_config()
+    model = model or config.save_snapshot_path
+    output_path = output_path or config.export_caffe2_path
+    output_onnx_path = output_onnx_path or config.export_onnx_path
+
     print(
         f"Exporting {model} to caffe2 file: {output_path} and onnx file: {output_onnx_path}"
     )
@@ -399,12 +434,26 @@ def export(context, model, output_path, output_onnx_path):
 
 
 @main.command()
+@click.option("--export-json", help="the path to the export options in JSON format.")
 @click.option("--model", help="the pytext snapshot model file to load")
 @click.option("--output-path", help="where to save the exported torchscript model")
 @click.option("--quantize", help="whether to quantize the model")
 @click.pass_context
-def torchscript_export(context, model, output_path=None, **kwargs):
+def torchscript_export(context, export_json, model, output_path, quantize):
     """Convert a pytext model snapshot to a torchscript model."""
+    kwargs = {}
+    # only populate from export_json if no export option is configured from the command line.
+    if export_json:
+        if not quantize and not output_path:
+            export_json_config = _load_and_validate_export_json_config(export_json)
+            kwargs = export_json_config["export"]
+            if "export_torchscript_path" in export_json_config["export"]:
+                output_path = export_json_config["export"]["export_torchscript_path"]
+        else:
+            print(
+                "the export-json config is ignored because export options are found the command line"
+            )
+            kwargs = {"torchscript_quantize": quantize}
     config = context.obj.load_config()
     model = model or config.save_snapshot_path
     output_path = output_path or f"{config.save_snapshot_path}.torchscript"

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -284,7 +284,7 @@ class _NewTask(TaskBase):
         self, model, export_path=None, sort_input=False, sort_key=1, **kwargs
     ):
         # unpack export kwargs
-        quantize = kwargs.get("quantize", False)
+        quantize = kwargs.get("torchscript_quantize", False)
         accelerate = kwargs.get("accelerate", [])
         seq_padding_control = kwargs.get("seq_padding_control")
         batch_padding_control = kwargs.get("batch_padding_control")
@@ -363,4 +363,4 @@ class NewTask(_NewTask):
     __EXPANSIBLE__ = True
 
     class Config(_NewTask.Config):
-        model: BaseModel.Config
+        model: Optional[BaseModel.Config]

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -51,3 +51,35 @@ class TestMain(unittest.TestCase):
             input='{"text": "create an alarm for 1:30 pm"}',
         )
         assert "'prediction':" in result.output, result.exception
+
+    def test_docnn_with_export_config(self):
+        # prepare config
+        config_dict = self.find_and_patch_config("docnn_wo_export.json")
+        model_path = config_dict["save_snapshot_path"]
+        config_json = json.dumps(config_dict)
+
+        # train model
+        result = self.runner.invoke(main, args=["--config-json", config_json, "train"])
+        assert not result.exception, result.exception
+
+        # export the trained model
+        result = self.runner.invoke(
+            main,
+            args=[
+                "--config-json",
+                config_json,
+                "export",
+                "--export-json",
+                os.path.join(self.config_base_path, "export_options.json"),
+            ],
+        )
+        print(result.output)
+        assert not result.exception, result.exception
+
+        # predict with PyTorch model
+        result = self.runner.invoke(
+            main,
+            args=["predict-py", "--model-file", model_path],
+            input='{"text": "create an alarm for 1:30 pm"}',
+        )
+        assert "'prediction':" in result.output, result.exception


### PR DESCRIPTION
Summary:
1. The command line arg export-json is added to the torchscript_export and export functions. This export-json points to a PyTextConfig json config where only version and export section are configured and can be used to extend the export options.
2. [fix] implemented the ignore_fields logic in the config_from_json function.
3. Added v22_export_config.json to the config adapter test to cover the new export json config. The task field in PyTextConfig is required and in order to make our export-json valid, a placerholder task value is added to the test config and the model field in the NewTask is set to optional.
4. Updated the usage document and example config in the demo.

Differential Revision: D24955267

