### PR TITLE
move multiray wrapper to pytext/fb

### DIFF
--- a/pytext/torchscript/feature_schema_enum.py
+++ b/pytext/torchscript/feature_schema_enum.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved#!/usr/bin/env python3
-
-from typing import Dict
-
-
-# Keep in sync with QuantizationType enum in textray_contants.thrift
-# We can't directly use the thrift enum because TorchScript doesn't support it
-FEATURE_SCHEMA: Dict[str, int] = {"REPRESENTATION_1D": 1, "REPRESENTATION_2D": 2}

--- a/pytext/torchscript/quantization_schema_enum.py
+++ b/pytext/torchscript/quantization_schema_enum.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved#!/usr/bin/env python3
-
-from typing import Dict
-
-
-# Keep in sync with QuantizationType enum in textray_contants.thrift
-# We can't directly use the thrift enum because TorchScript doesn't support it
-QUANTIZATION_SCHEMA: Dict[str, int] = {"NONE": 1, "INT1_QUANTIZATION": 2}


### PR DESCRIPTION
Summary: move multiray wrapper to pytext/fb, we should not expose this in OSS

Reviewed By: gunchu

Differential Revision: D24998192

