### PR TITLE
Fix defaults in StochasticWeightAveraging

### DIFF
--- a/pytext/optimizer/swa.py
+++ b/pytext/optimizer/swa.py
@@ -94,6 +94,7 @@ class StochasticWeightAveraging(Optimizer, PT_Optimizer):
 
         self.optimizer = optimizer
 
+        self.defaults = self.optimizer.defaults
         self.param_groups = self.optimizer.param_groups
         self.state = defaultdict(dict)
         self.opt_state = self.optimizer.state


### PR DESCRIPTION
Summary: Fixes pickling error in SWA by saving defaults as a class variable -- see L122 of https://github.com/pytorch/contrib/blob/master/torchcontrib/optim/swa.py

Differential Revision: D25198663

