### PR TITLE
Save checkpoints when do_eval = False

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -453,6 +453,8 @@ class Trainer(TrainerBase):
                 self.run_epoch(state, epoch_data, metric_reporter)
 
             if not self.config.do_eval:
+                if train_config.save_all_checkpoints:
+                    self.save_checkpoint(state, train_config)
                 continue
 
             with timing.time("eval epoch"):


### PR DESCRIPTION
Summary: We should save checkpoints if save_all_checkpoints is enabled, even if do_eval = False

Reviewed By: snisarg

Differential Revision: D25231046

