### PR TITLE
Fix FP16 Optimizers

### DIFF
--- a/pytext/models/representations/transformer/sentence_encoder.py
+++ b/pytext/models/representations/transformer/sentence_encoder.py
@@ -168,6 +168,7 @@ def translate_roberta_state_dict(state_dict):
 
     new_state = remove_state_keys(new_state, "^sentence_")
     new_state = remove_state_keys(new_state, "_classification_head.")
+    new_state = remove_state_keys(new_state, r".classification_head[0-9]*.")
     new_state = remove_state_keys(new_state, r"^decoder\.lm_head")
     new_state = remove_state_keys(new_state, r"^encoder\.lm_head")
     new_state = remove_state_keys(new_state, r"segment_embedding")

--- a/pytext/optimizer/adabelief.py
+++ b/pytext/optimizer/adabelief.py
@@ -133,7 +133,7 @@ class AdaBelief(Optimizer, PT_Optimizer):
                         p.data, memory_format=torch.preserve_format
                     )
 
-    def step(self, closure=None):
+    def step(self, closure=None, **kwargs):
         """Performs a single optimization step.
         Arguments:
             closure (callable, optional): A closure that reevaluates the model

--- a/pytext/optimizer/lamb.py
+++ b/pytext/optimizer/lamb.py
@@ -61,7 +61,7 @@ class Lamb(Optimizer, PT_Optimizer):
 
         self.min_trust = min_trust
 
-    def step(self, closure=None):
+    def step(self, closure=None, **kwargs):
         """Performs a single optimization step.
 
         Arguments:

--- a/pytext/optimizer/radam.py
+++ b/pytext/optimizer/radam.py
@@ -30,7 +30,7 @@ class RAdam(Optimizer, PT_Optimizer):
     def __setstate__(self, state):
         super(RAdam, self).__setstate__(state)
 
-    def step(self, closure=None):
+    def step(self, closure=None, **kwargs):
         loss = None
         if closure is not None:
             loss = closure()

--- a/pytext/optimizer/swa.py
+++ b/pytext/optimizer/swa.py
@@ -181,7 +181,7 @@ class StochasticWeightAveraging(Optimizer, PT_Optimizer):
                 buf.copy_(tmp)
         return True
 
-    def step(self, closure=None):
+    def step(self, closure=None, **kwargs):
         r"""Performs a single optimization step.
 
         In automatic mode also updates SWA running averages.


### PR DESCRIPTION
Summary:
There was a recent fairseq diff that changed the arguments for `optimizer.step` (D25152032). This breaks FairseqFP16 Optimizer which breaks the NAR workflows as the rely on FP16 from fairseq.

For some reason Apex FP16 doesn't work with NAR yet, I am yet to figure out why. Also unclear on how we should test this, to prevent future breakage.

Reviewed By: alexeib

Differential Revision: D25432409

