### PR TITLE
Changes to Export from export_list if present in PyTextConfig

### DIFF
--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -175,7 +175,10 @@ def _try_component_config_from_json(cls, value):
 def pytext_config_from_json(json_obj, ignore_fields=(), auto_upgrade=True):
     if auto_upgrade:
         json_obj = upgrade_to_latest(json_obj)
-    return config_from_json(PyTextConfig, json_obj, ignore_fields)
+    pytext_config = config_from_json(PyTextConfig, json_obj, ignore_fields)
+    if len(pytext_config.export_list) == 0:
+        pytext_config.export_list = [pytext_config.export]
+    return pytext_config
 
 
 def config_from_json(cls, json_obj, ignore_fields=()):

--- a/pytext/config/test/serialize_test.py
+++ b/pytext/config/test/serialize_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import unittest
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, List
 
 from pytext.config import ConfigBase, pytext_config_from_json, serialize
 
@@ -62,6 +62,287 @@ class SerializeTest(unittest.TestCase):
         )
         # verify that a_dict was read correctly
         self.assertEqual(pytext_config.test_config.a_dict, a_dict)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_union(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, List[Boo]]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        a_config_containing_union = {
+            "test_config": {"a_union": {"boo": {"aye": a_str}}}
+        }
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_union_with_baa(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class Baa(ConfigBase):
+            oye: int
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, Baa]
+
+            test_config: TestConfig
+
+        an_int = 1
+        a_baa = {"baa": {"oye": an_int}}
+        a_config_containing_union = {"test_config": {"a_union": a_baa}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.oye, an_int)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_union_with_list_a(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class Boolist(ConfigBase):
+            boolistitems: List[Boo]
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, Boolist]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo": {"aye": a_union}}
+        a_boo = {"aye": a_str}
+        a_boo_list = {"boolist": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_union": a_boo_list}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.boolistitems[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def dont_test_config_to_json_for_union_with_list_b(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class Boolist(ConfigBase):
+            boolistitems: List[Boo]
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, Boolist]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        a_boo = {"boo": {"aye": a_str}}
+        # a_boo = {"aye": a_str}
+        a_boo_list = {"boolist": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_union": a_boo_list}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.boolistitems[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def dont_test_config_to_json_for_list_of_boo1(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo1(ConfigBase):
+            aye: str
+
+        class Boolist1(ConfigBase):
+            boolistitems: List[Boo1]
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: Boolist1
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"aye": a_str}
+        a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": a_boo_list}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list.boolistitems[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_list_of_lboo1(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo1(ConfigBase):
+            aye: str
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: List[Boo1]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"aye": a_str}
+        # a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": [a_boo]}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_list_of_lboo2(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo1(ConfigBase):
+            aye: str
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: List[Boo1]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        b_str = "def"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"aye": a_str}
+        b_boo = {"aye": b_str}
+        # a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": [a_boo, b_boo]}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list[0].aye, a_str)
+        self.assertEqual(pytext_config.test_config.a_list[1].aye, b_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_nested_objectsboo2(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo3(ConfigBase):
+            ayeaye: str
+
+        class Boo2(ConfigBase):
+            aye: Boo3
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: List[Boo2]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"ayeaye": a_str}
+        # b_boo = {"aye": {"boo3": a_boo}}
+        b_boo = {"aye": a_boo}
+        # a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": [b_boo]}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list[0].aye.ayeaye, a_str)
         # serialize config to json, and deserialize back to config
         # verify that nothing changed
         jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -25,6 +25,7 @@ from pytext.config.serialize import (
 from pytext.config.utils import find_param, replace_param
 from pytext.data.data_handler import CommonMetadata
 from pytext.metric_reporters.channel import Channel, TensorBoardChannel
+from pytext.PreprocessingMap.ttypes import ModelType
 from pytext.task import load
 from pytext.utils.documentation import (
     ROOT_CONFIG,
@@ -55,14 +56,33 @@ def _validate_export_json_config(export_json_config):
     """Validate if the input export_json_config (PyTextConfig in JSON object) only has
     export section config and a version number.
     """
-    assert export_json_config.keys() == {"export", "version"}, (
-        "The export-json config should only contain fields export and version. Got "
+    assert (export_json_config.keys() == {"export", "version"}) or (
+        export_json_config.keys() == {"export_list", "version"}
+    ), (
+        "The export-json config should only contain fields (export or export_list) and version. Got "
         f"{export_json_config.keys()}"
     )
-    for key in export_json_config["export"]:
-        assert (
-            key in ExportConfig.__annotations__.keys()
-        ), f"Field {key} in the export json is not found in the ExportConfig class."
+    if "export" in export_json_config.keys():
+        for key in export_json_config["export"]:
+            assert (
+                key in ExportConfig.__annotations__.keys()
+            ), f"Field {key} in the export json is not found in the ExportConfig class."
+    else:  # export_list instead of export
+        assert "export_list" in export_json_config.keys()
+        found_model_type = None
+        for export_config in export_json_config["export_list"]:
+            for key in export_config:
+                assert (
+                    key in ExportConfig.__annotations__.keys()
+                ), f"Field {key} in the export json is not found in the ExportConfig class."
+            this_model_type = (
+                ModelType.PYTORCH
+                if "export_pytorch_path" in export_config
+                else ModelType.CAFFE2
+            )
+            assert (found_model_type is None) or (found_model_type == this_model_type)
+            if found_model_type is None:
+                found_model_type = this_model_type
 
 
 def _load_and_validate_export_json_config(export_json):
@@ -427,14 +447,23 @@ def export(context, export_json, model, output_path, output_onnx_path):
                 "the export-json config is ignored because export options are found the command line"
             )
     config = context.obj.load_config()
+    export_list = config.export_list
     model = model or config.save_snapshot_path
-    output_path = output_path or config.export_caffe2_path
-    output_onnx_path = output_onnx_path or config.export_onnx_path
-
-    print(
-        f"Exporting {model} to caffe2 file: {output_path} and onnx file: {output_onnx_path}"
-    )
-    export_saved_model_to_caffe2(model, output_path, output_onnx_path)
+    if len(export_list) == 0:
+        output_path = output_path or config.export_caffe2_path
+        output_onnx_path = output_onnx_path or config.export_onnx_path
+        print(
+            f"Exporting {model} to caffe2 file: {output_path} and onnx file: {output_onnx_path}"
+        )
+        export_saved_model_to_caffe2(model, output_path, output_onnx_path)
+    else:
+        for idx in range(0, len(export_list)):
+            output_path = output_path or config.get_export_caffe2_path(idx)
+            output_onnx_path = output_onnx_path or config.get_export_onnx_path(idx)
+            print(
+                f"Exporting {model} to caffe2 file: {output_path} and onnx file: {output_onnx_path}"
+            )
+            export_saved_model_to_caffe2(model, output_path, output_onnx_path)
 
 
 @main.command()
@@ -450,21 +479,30 @@ def torchscript_export(context, export_json, model, output_path, quantize):
     if export_json:
         if not quantize and not output_path:
             export_json_config = _load_and_validate_export_json_config(export_json)
-            kwargs = export_json_config["export"]
+            if "export_list" not in export_json_config.keys():
+                export_config = export_json_config["export"]
+                kwargs = export_config
+                if "export_torchscript_path" in export_config:
+                    output_path = export_config["export_torchscript_path"]
+                torchscript_export_one(context, model, output_path, kwargs)
+            else:
+                for export_config in export_json_config["export_list"]:
+                    kwargs = export_config
+                    if "export_torchscript_path" in export_config:
+                        output_path = export_config["export_torchscript_path"]
+                    torchscript_export_one(context, model, output_path, kwargs)
         else:
             print(
                 "the export-json config is ignored because export options are found the command line"
             )
-            kwargs = {"quantize": quantize}
+            kwargs = {"torchscript_quantize": quantize}   # while resolving merge conflict got rid of "quantize as key -- watch!"
+            torchscript_export_one(context, model, output_path, kwargs)
 
-        if "export_torchscript_path" in export_json_config["export"]:
-            output_path = export_json_config["export"]["export_torchscript_path"]
 
-    if not model or not output_path:
-        config = context.obj.load_config()
-        model = model or config.save_snapshot_path
-        output_path = output_path or f"{config.save_snapshot_path}.torchscript"
-
+def torchscript_export_one(context, model, output_path, kwargs):
+    config = context.obj.load_config()
+    model = model or config.save_snapshot_path
+    output_path = output_path or f"{config.save_snapshot_path}.torchscript"
     print(f"Exporting {model} to torchscript file: {output_path}")
     export_saved_model_to_torchscript(model, output_path, **kwargs)
 

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -8,7 +8,7 @@ from typing import IO, Any, Dict, Iterator, List, Optional, Tuple, Union, get_ty
 
 import torch
 from pytext.common.constants import Stage
-from pytext.config import PyTextConfig, TestConfig
+from pytext.config import PyTextConfig, TestConfig, ExportConfig
 from pytext.config.component import ComponentType, create_component, create_exporter
 from pytext.data.data import Batcher
 from pytext.data.data_handler import CommonMetadata
@@ -192,7 +192,20 @@ def save_and_export(
     else:
         tensorizers = task.data.tensorizers
     save(config, task.model, meta, tensorizers=tensorizers)
-    export_config = config.export
+    if len(config.export_list) == 0:
+        # this branch should be eliminated to avoid sphaghetti code
+        export_config = config.export
+        save_and_export_exportconfig(export_config, task, metric_channels)
+    else:
+        for export_config in config.export_list:
+            save_and_export_exportconfig(export_config, task, metric_channels)
+
+
+def save_and_export_exportconfig(
+    export_config: ExportConfig,
+    task: Task_Deprecated,
+    metric_channels: Optional[List[Channel]] = None,
+) -> None:
     if export_config.export_caffe2_path:
         task.export(
             task.model,

--- a/tests/task_load_save_test.py
+++ b/tests/task_load_save_test.py
@@ -55,7 +55,9 @@ class TaskLoadSaveTest(unittest.TestCase):
 
             save(config, model, meta=None, tensorizers=task.data.tensorizers)
             task2, config2, training_state_none = load(snapshot_file.name)
-
+            self.assertEqual(config.export, config2.export)
+            self.assertEqual(config.export_list, config2.export_list)
+            self.assertEqual(config.task, config2.task)
             self.assertEqual(config, config2)
             self.assertModulesEqual(model, task2.model)
             self.assertIsNone(training_state_none)


### PR DESCRIPTION
Summary:
Added a field "export_list" to PyTextConfig.   All code was changed to replace f(pytextconfig.export) to the logical equivalent of map(f, pytextconfig.export_list) and a test was added to ensure that model_type is the same across all of the elements in the export list.

*Why not union?*
The combination of Union and List is not handled perfectly by serialize.py. (In trying to understand how serialize interacts with json, I added a few test cases. In serialize_test.py est_config_to_json_for_union_with_list_a succeeds where as est_config_to_json_for_union_with_list_b fails. The difference between the two tests is the absence/presence of wrapper "boo".  Is this the intended behavior?)

Differential Revision: D25257145

