### PR TITLE
Ensure LabelVocab is always sorted on entry

### DIFF
--- a/pytext/contrib/pytext_lib/conf/__init__.py
+++ b/pytext/contrib/pytext_lib/conf/__init__.py
@@ -60,6 +60,7 @@ class PairTransformConf(TransformConf):
     transform_left: TransformConf = MISSING
     # If not specified, uses transform_left
     transform_right: Optional[TransformConf] = None
+    separater_token: Optional[str] = None
 
 
 @dataclass

--- a/pytext/contrib/pytext_lib/transforms/transforms.py
+++ b/pytext/contrib/pytext_lib/transforms/transforms.py
@@ -113,7 +113,7 @@ class LabelTransform(nn.Module):
     def __init__(self, label_names: List[str]):
         super().__init__()
 
-        self.label_vocab = ScriptVocabulary(label_names)
+        self.label_vocab = ScriptVocabulary(sorted(label_names))
 
     def forward(self, labels: List[str]) -> List[int]:
         return self.label_vocab.lookup_indices_1d(labels)


### PR DESCRIPTION
Summary:
Self provided labels by users are generally added interchangeably. We sort these to make sure the order doesn't change the index of the results from the model.

In old pytext, https://fburl.com/diffusion/5p3j6lh5

Reviewed By: jeanm

Differential Revision: D24381569

