### PR TITLE
Optional separator token

### DIFF
--- a/pytext/contrib/pytext_lib/conf/__init__.py
+++ b/pytext/contrib/pytext_lib/conf/__init__.py
@@ -60,6 +60,7 @@ class PairTransformConf(TransformConf):
     transform_left: TransformConf = MISSING
     # If not specified, uses transform_left
     transform_right: Optional[TransformConf] = None
+    separater_token: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Pass an optional separator token.

We extract the index from the vocab and append that while zipping together the inputs.

Reviewed By: jeanm

Differential Revision: D25719066

