### PR TITLE
Vocab should have len()

### DIFF
--- a/pytext/torchscript/tests/test_vocab.py
+++ b/pytext/torchscript/tests/test_vocab.py
@@ -74,3 +74,6 @@ class VocabTest(unittest.TestCase):
             ),
             ["a", "y", "z"],
         )
+
+    def test_len(self):
+        self.assertEqual(len(self.vocab), 5)

--- a/pytext/torchscript/vocab.py
+++ b/pytext/torchscript/vocab.py
@@ -117,3 +117,6 @@ class ScriptVocabulary(torch.jit.ScriptModule):
                 if possible_unk_token is None
                 else possible_unk_token
             )
+
+    def __len__(self):
+        return len(self.vocab)


### PR DESCRIPTION
Summary:
Adding to support len() for the vocab.

Couldn't use     torch.jit.script_method
for the method as it inteferes and len doesn't get called. Using nn.Module for this should fix that in the future.

If I add torch.jit.script_method, the len() function doesn't exist any more.

```
> ======================================================================
> ERROR: test_len (pytext.torchscript.tests.test_vocab.VocabTest)
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>   File "/home/snisarg/fbcode2/fbcode/buck-out/dev/gen/pytext/torchscript/tests/test_vocab#binary,link-tree/pytext/torchscript/tests/test_vocab.py", line 79, in test_len
>     self.assertEqual(len(self.vocab), 5)
> TypeError: object of type 'ScriptVocabulary' has no len()
```

Reviewed By: Darktex

Differential Revision: D25734881

