### PR TITLE
Fix SWA for FP16

### DIFF
--- a/pytext/optimizer/swa.py
+++ b/pytext/optimizer/swa.py
@@ -306,7 +306,7 @@ class StochasticWeightAveraging(Optimizer, PT_Optimizer):
 
     def reset_param_groups(self):
         self.param_groups = []
-        self.optimizer.param_groups = []
+        self.param_groups = self.optimizer.param_groups
 
 
 # BatchNorm utils


### PR DESCRIPTION
Summary: When the parameter groups were reset for SWA, the underlying optimizer and SWA optimizer had differnet param group lists. This occurs in FP16 training causing the optimizer to optimize no parameters.

Differential Revision: D25821246

