### PR TITLE
Using larger ProcessGroup Timeout to prevent Initialization Errors

### DIFF
--- a/pytext/utils/distributed.py
+++ b/pytext/utils/distributed.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from datetime import timedelta
+
 import pytext.utils.cuda as cuda
 import torch
 import torch.distributed as dist_c10d
@@ -26,11 +28,14 @@ def dist_init(
     global _round_robin_process_group
 
     if init_method and world_size > 1 and torch.cuda.is_available():
+        # providing a large process group timeout to prevent errors during
+        # initialization.
         dist_c10d.init_process_group(
             backend=backend,
             init_method=init_method,
             world_size=world_size,
             rank=distributed_rank,
+            timeout=timedelta(minutes=90),
         )
         # calling all_reduce for synchronzing all workers
         dist_tensor = torch.tensor(


### PR DESCRIPTION
Summary:
The time to initialize each process in PyText is very large so there may be a 40-50 minute gap between the first and last processes being initialized (ProcessGroup being constructed). The previous barrier was not subject to timeouts (since it would block on creating NCCL communicators) so the the initialization would take a long time, but still complete successfully. With the new store-based barrier, there is a busy poll that checks whether each rank has incremented a counter in the store, and if all processes have not joined until the timeout, an exception is thrown (which is the error users are seeing).

Increasing the ProcessGroup timeout in PyText will ensure the store-based barrier does not timeout initialization any more.

Reviewed By: mwu1993

Differential Revision: D25792895

