### PR TITLE
Fix the pytext output path missing bug

### DIFF
--- a/pytext/main.py
+++ b/pytext/main.py
@@ -469,6 +469,10 @@ def torchscript_export(context, export_json, model, output_path, quantize):
         export_config.export_torchscript_path = export_section_config.get(
             "export_torchscript_path", None
         )
+        # if config has export_torchscript_path, use export_torchscript_path from config, otherwise keep the default from CLI
+        if export_config.export_torchscript_path is not None:
+            output_path = export_config.export_torchscript_path
+
         export_config.export_lite_path = export_section_config.get(
             "export_lite_path", None
         )

--- a/pytext/task/accelerator_lowering.py
+++ b/pytext/task/accelerator_lowering.py
@@ -47,7 +47,8 @@ def accelerator_transformerLayers_inputs(
 
 
 @accelerator([("NNPI", {"NNPI_IceCores": "12", "NNPINumParallelChunks": "12"})])
-@inputs(accelerator_transformerLayers_inputs)
+# Todo: this decorator dose not return proper module, fixing it later, right now comment out
+# @inputs(accelerator_transformerLayers_inputs)
 class AcceleratorTransformerLayers(nn.Module):
     def __init__(self, layers):
         super().__init__()
@@ -124,7 +125,11 @@ def lower_modules_to_accelerator(model: nn.Module, trace, export_options: Export
         for k, v in compilation_spec_dict.items():
             compilation_group.get_settings().backend_specific_opts_insert(k, v)
 
-        input_sets = inputs.input_process(model, export_options, None, submod_tracepath)
+        # Todod: @input decorator dose not work properly, fixing it later
+        # input_sets = inputs.input_process(model, export_options, None, submod_tracepath)
+        input_sets = accelerator_transformerLayers_inputs(
+            model, export_options, None, submod_tracepath
+        )
         compilation_group.set_input_sets(input_sets)
 
         trace = torch_glow.to_glow_selective(

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -235,7 +235,7 @@ def export_saved_model_to_torchscript(
     saved_model_path: str, path: str, export_config: ExportConfig
 ) -> None:
     task, train_config, _training_state = load(saved_model_path)
-    task.torchscript_export(task.model, path, export_config)
+    task.torchscript_export(task.model, path, False, 1, export_config=export_config)
 
 
 def test_model(


### PR DESCRIPTION
Summary: Fix the pytext output path missing bug. if config has export_torchscript_path, use export_torchscript_path from config, otherwise keep the default from CLI

Reviewed By: mjanderson09

Differential Revision: D26003995

