### PR TITLE
Pass rank and world size information when initializing from snapshot

### DIFF
--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -161,11 +161,17 @@ def prepare_task(
     if config.load_snapshot_path:
         assert PathManager.isfile(config.load_snapshot_path)
         if config.use_config_from_snapshot:
-            task, _, training_state = load(config.load_snapshot_path)
+            task, _, training_state = load(
+                config.load_snapshot_path, rank=rank, world_size=world_size
+            )
         else:
             task, _, training_state = load(
-                config.load_snapshot_path, overwrite_config=config
+                config.load_snapshot_path,
+                overwrite_config=config,
+                rank=rank,
+                world_size=world_size,
             )
+
         if training_state:
             training_state.rank = rank
     else:

--- a/tests/task_load_save_test.py
+++ b/tests/task_load_save_test.py
@@ -10,16 +10,11 @@ from pytext.common.constants import Stage
 from pytext.config import LATEST_VERSION, PyTextConfig
 from pytext.config.component import create_optimizer, create_scheduler
 from pytext.data import Data
-from pytext.data.sources import TSVDataSource
-from pytext.optimizer import Adam, Optimizer
+from pytext.data.sources.tsv import BlockShardedTSVDataSource, TSVDataSource
+from pytext.optimizer import Adam
 from pytext.optimizer.scheduler import Scheduler
 from pytext.task import create_task
-from pytext.task.serialize import (
-    CheckpointManager,
-    get_latest_checkpoint_path,
-    load,
-    save,
-)
+from pytext.task.serialize import get_latest_checkpoint_path, load, save
 from pytext.task.tasks import DocumentClassificationTask
 from pytext.trainers.training_state import TrainingState
 from pytext.utils import test
@@ -154,3 +149,59 @@ class TaskLoadSaveTest(unittest.TestCase):
                 config_restored,
                 training_state_restored,
             )
+
+    def test_load_checkpoint_in_dist_training(self):
+        with tempfile.NamedTemporaryFile() as checkpoint_file:
+            train_data = tests_module.test_file("train_data_tiny.tsv")
+            eval_data = tests_module.test_file("test_data_tiny.tsv")
+            config = PyTextConfig(
+                task=DocumentClassificationTask.Config(
+                    data=Data.Config(
+                        source=BlockShardedTSVDataSource.Config(
+                            train_filename=train_data,
+                            eval_filename=eval_data,
+                            field_names=["label", "slots", "text"],
+                        )
+                    )
+                ),
+                version=LATEST_VERSION,
+                save_snapshot_path=checkpoint_file.name,
+            )
+            task = create_task(config.task)
+            model = task.model
+            # test checkpoint saving and loading
+            optimizer = create_optimizer(Adam.Config(), model)
+            scheduler = create_scheduler(Scheduler.Config(), optimizer)
+            training_state = TrainingState(
+                model=model,
+                optimizer=optimizer,
+                scheduler=scheduler,
+                start_time=0,
+                epoch=0,
+                rank=0,
+                stage=Stage.TRAIN,
+                epochs_since_last_improvement=0,
+                best_model_state=None,
+                best_model_metric=None,
+                tensorizers=task.data.tensorizers,
+            )
+
+            id = "epoch-1"
+            saved_path = save(
+                config, model, None, task.data.tensorizers, training_state, id
+            )
+            new_rank = 2
+            new_world_size = 4
+            task_restored, config_restored, training_state_restored = load(
+                saved_path, rank=new_rank, world_size=new_world_size
+            )
+            self.assertCheckpointEqual(
+                model,
+                config,
+                training_state,
+                task_restored.model,
+                config_restored,
+                training_state_restored,
+            )
+            self.assertEqual(task_restored.data.data_source.rank, new_rank)
+            self.assertEqual(task_restored.data.data_source.world_size, new_world_size)


### PR DESCRIPTION
Summary: This lets us pass in the new rank and world_size information which get propagated to sharded data sources, etc when doing distributed incremental training from snapshot

Differential Revision: D26058665

