### PR TITLE
Changes to Export from export_list if present in PyTextConfig

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -761,6 +761,14 @@ def v22_to_v23(json_config):
     return json_config
 
 
+@register_adapter(from_version=23)
+def v23_to_v24(json_config):
+    """
+    No-op since export_list is optional
+    """
+    return json_config
+
+
 @register_down_grade_adapter(from_version=23)
 def v23_to_v22(json_config):
     """
@@ -768,6 +776,23 @@ def v23_to_v22(json_config):
     """
     if "read_chunk_size" in json_config:
         del json_config["read_chunk_size"]
+    return json_config
+
+
+@register_down_grade_adapter(from_version=24)
+def v24_to_v23(json_config):
+    """
+    Upgrade by removing export_list option
+    """
+    if "export_list" in json_config:
+        if len(json_config["export_list"]) > 1:
+            raise Exception(
+                "Current version does not support multiple exports in export_list"
+            )
+        elif len(json_config["export_list"]) == 0:
+            raise Exception("Current version does not support empty export_list")
+        json_config["export"] = json_config["export_list"][0]
+        del json_config["export_list"]
     return json_config
 
 

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -122,6 +122,13 @@ class ExportConfig(ConfigBase):
     batch_padding_control: Optional[List[int]] = None
 
 
+class InvalidMethodInvocation(Exception):
+    message: str
+
+    def __init__(self, message):
+        self.message = message
+
+
 class PyTextConfig(ConfigBase):
     # the actual task union types will be generated in runtime
     task: Union[PlaceHolder, Any]
@@ -144,6 +151,8 @@ class PyTextConfig(ConfigBase):
     auto_resume_from_snapshot: bool = False
     # Configuration for model export. See ExportConfig for details
     export: ExportConfig = ExportConfig()
+    # Configuration for a list of model exports. If the list is non-empty, export will be ignored.
+    export_list: List[ExportConfig] = []
     # Base directory where modules are saved
     modules_save_dir: str = ""
     # Whether to save intermediate checkpoints for modules if they are best yet
@@ -196,72 +205,151 @@ class PyTextConfig(ConfigBase):
                     if k in kwargs.keys()
                 }
             )
+            kwargs["export_list"] = [kwargs["export"]]
             kwargs["version"] = 22
         super().__init__(**kwargs)
+        if len(self.export_list) == 0:  # Happens if version >= 22:
+            self.export_list = [self.export]
+
+    def export_check(self, method_name):
+        if len(self.export_list) != 1:
+            if len(self.export_list) == 0:
+                # Is there a proper finalizer that can be called instead??
+                # Need help from a python Guru
+                self.export_list = [self.export]
+            else:
+                raise InvalidMethodInvocation(
+                    "export list length is not 1  use the set/get_%s version of method with key"
+                    % (method_name,)
+                )
 
     @property
     def export_caffe2_path(self):
-        return self.export.export_caffe2_path
+        self.export_check("export_caffe2_path")
+        return self.export_list[0].export_caffe2_path
 
     @export_caffe2_path.setter
     def export_caffe2_path(self, p):
-        self.export.export_caffe2_path = p
+        self.export_check("export_caffe2_path")
+        self.export_list[0].export_caffe2_path = p
+
+    def get_export_caffe2_path(self, index):
+        return self.export_list[index].export_caffe2_path
+
+    def set_export_caffe2_path(self, p, index):
+        self.export_list[index].export_caffe2_path = p
 
     @property
     def export_onnx_path(self):
-        return self.export.export_onnx_path
+        self.export_check("export_onnx_path")
+        return self.export_list[0].export_onnx_path
 
     @export_onnx_path.setter
     def export_onnx_path(self, p):
-        self.export.export_onnx_path = p
+        self.export_check("export_onnx_path")
+        self.export_list[0].export_onnx_path = p
+
+    def get_export_onnx_path(self, index):
+        return self.export_list[index].export_onnx_path
+
+    def set_export_onnx_path(self, p, index):
+        self.export_list[index].export_onnx_path = p
 
     @property
     def export_torchscript_path(self):
-        return self.export.export_torchscript_path
+        self.export_check("export_torchscript_path")
+        return self.export_list[0].export_torchscript_path
 
     @export_torchscript_path.setter
     def export_torchscript_path(self, p):
-        self.export.export_torchscript_path = p
+        self.export_check("export_torchscript_path")
+        self.export_list[0].export_torchscript_path = p
+
+    def get_export_torchscript_path(self, index):
+        return self.export_list[index].export_torchscript_path
+
+    def set_export_torchscript_path(self, p, index):
+        self.export_list[index].export_torchscript_path = p
 
     @property
     def torchscript_quantize(self):
-        return self.export.torchscript_quantize
+        self.export_check("torchscript_quantize")
+        return self.export_list[0].torchscript_quantize
 
     @torchscript_quantize.setter
     def torchscript_quantize(self, quantize):
-        self.export.torchscript_quantize = quantize
+        self.export_check("torchscript_quantize")
+        self.export_list[0].torchscript_quantize = quantize
+
+    def get_export_torchscript_quantize(self, index):
+        return self.export_list[index].torchscript_quantize
+
+    def set_export_torchscript_path(self, quantize, index):
+        self.export_list[index].torchscript_quantize = quantize
 
     @property
     def accelerate(self):
-        return self.export.accelerate
+        self.export_check("accelerate")
+        return self.export_list[0].accelerate
 
     @accelerate.setter
     def accelerate(self, acc):
-        self.export.accelerate = acc
+        self.export_check("accelerate")
+        self.export_list[0].accelerate = acc
+
+    def get_export_accelerate(self, index):
+        return self.export_list[index].accelerate
+
+    def set_export_accelerate(self, acc, index):
+        self.export_list[index].accelerate = acc
 
     @property
     def inference_interface(self):
-        return self.export.inference_interface
+        self.export_check("inference_interface")
+        return self.export_list[0].inference_interface
 
     @inference_interface.setter
     def inference_interface(self, inf_inter):
-        self.export.inference_interface = inf_inter
+        self.export_check("inference_interface")
+        self.export_list[0].inference_interface = inf_inter
+
+    def get_export_inference_interface(self, index):
+        return self.export_list[index].inference_interface
+
+    def set_export_inference_interface(self, inference_interface, index):
+        self.export_list[index].inference_interface = inference_interface
 
     @property
     def seq_padding_control(self):
-        return self.export.seq_padding_control
+        self.export_check("seq_padding_control")
+        return self.export_list[0].seq_padding_control
 
     @seq_padding_control.setter
     def seq_padding_control(self, spc):
-        self.export.seq_padding_control = spc
+        self.export_check("seq_padding_control")
+        self.export_list[0].seq_padding_control = spc
+
+    def get_export_seq_padding_control(self, index):
+        return self.export_list[index].seq_padding_control
+
+    def set_export_inference_interface(self, seq_padding_control, index):
+        self.export_list[index].seq_padding_control = seq_padding_control
 
     @property
     def batch_padding_control(self):
-        return self.export.batch_padding_control
+        self.export_check("batch_padding_control")
+        return self.export_list[0].batch_padding_control
 
     @batch_padding_control.setter
     def batch_padding_control(self, bpc):
-        self.export.batch_padding_control = bpc
+        self.export_check("batch_padding_control")
+        self.export_list[0].batch_padding_control = bpc
+
+    def get_export_batch_padding_control(self, index):
+        return self.export_list[index].batchpadding_control
+
+    def set_export_batch_padding_control(self, batch_padding_control, index):
+        self.export_list[index].batch_padding_control = batch_padding_control
 
 
 class TestConfig(ConfigBase):

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -301,4 +301,4 @@ class LogitsConfig(TestConfig):
 
 
 # update sitevar PYTEXT_CONFIG_LATEST_VERSION when new PytextConfig pushed in pytext config
-LATEST_VERSION = 23
+LATEST_VERSION = 24

--- a/pytext/config/serialize.py
+++ b/pytext/config/serialize.py
@@ -175,7 +175,10 @@ def _try_component_config_from_json(cls, value):
 def pytext_config_from_json(json_obj, ignore_fields=(), auto_upgrade=True):
     if auto_upgrade:
         json_obj = upgrade_to_latest(json_obj)
-    return config_from_json(PyTextConfig, json_obj, ignore_fields)
+    pytext_config = config_from_json(PyTextConfig, json_obj, ignore_fields)
+    if len(pytext_config.export_list) == 0:
+        pytext_config.export_list = [pytext_config.export]
+    return pytext_config
 
 
 def config_from_json(cls, json_obj, ignore_fields=()):

--- a/pytext/config/test/serialize_test.py
+++ b/pytext/config/test/serialize_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import unittest
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, List
 
 from pytext.config import ConfigBase, pytext_config_from_json, serialize
 
@@ -62,6 +62,287 @@ class SerializeTest(unittest.TestCase):
         )
         # verify that a_dict was read correctly
         self.assertEqual(pytext_config.test_config.a_dict, a_dict)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_union(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, List[Boo]]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        a_config_containing_union = {
+            "test_config": {"a_union": {"boo": {"aye": a_str}}}
+        }
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_union_with_baa(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class Baa(ConfigBase):
+            oye: int
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, Baa]
+
+            test_config: TestConfig
+
+        an_int = 1
+        a_baa = {"baa": {"oye": an_int}}
+        a_config_containing_union = {"test_config": {"a_union": a_baa}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.oye, an_int)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_union_with_list_a(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class Boolist(ConfigBase):
+            boolistitems: List[Boo]
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, Boolist]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo": {"aye": a_union}}
+        a_boo = {"aye": a_str}
+        a_boo_list = {"boolist": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_union": a_boo_list}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.boolistitems[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def dont_test_config_to_json_for_union_with_list_b(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo(ConfigBase):
+            aye: str
+
+        class Boolist(ConfigBase):
+            boolistitems: List[Boo]
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_union: Union[Boo, Boolist]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        a_boo = {"boo": {"aye": a_str}}
+        # a_boo = {"aye": a_str}
+        a_boo_list = {"boolist": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_union": a_boo_list}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_union.boolistitems[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def dont_test_config_to_json_for_list_of_boo1(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo1(ConfigBase):
+            aye: str
+
+        class Boolist1(ConfigBase):
+            boolistitems: List[Boo1]
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: Boolist1
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"aye": a_str}
+        a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": a_boo_list}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list.boolistitems[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_list_of_lboo1(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo1(ConfigBase):
+            aye: str
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: List[Boo1]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"aye": a_str}
+        # a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": [a_boo]}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list[0].aye, a_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_list_of_lboo2(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo1(ConfigBase):
+            aye: str
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: List[Boo1]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        b_str = "def"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"aye": a_str}
+        b_boo = {"aye": b_str}
+        # a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": [a_boo, b_boo]}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list[0].aye, a_str)
+        self.assertEqual(pytext_config.test_config.a_list[1].aye, b_str)
+        # serialize config to json, and deserialize back to config
+        # verify that nothing changed
+        jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)
+        pytext_config_deserialized = serialize.config_from_json(
+            TestConfigContainer, jsonified_config
+        )
+        self.assertEqual(pytext_config, pytext_config_deserialized)
+
+    def test_config_to_json_for_nested_objectsboo2(self):
+        """For a config that contains a dict inside it, verify that config
+        can be correctly created from a json/dict, and config can be correctly
+        serialized and de-serialized
+        """
+
+        class Boo3(ConfigBase):
+            ayeaye: str
+
+        class Boo2(ConfigBase):
+            aye: Boo3
+
+        class TestConfigContainer(ConfigBase):
+            class TestConfig(ConfigBase):
+                a_list: List[Boo2]
+
+            test_config: TestConfig
+
+        a_str = "abc"
+        # a_boo = {"boo1": {"aye": a_str}}
+        a_boo = {"ayeaye": a_str}
+        # b_boo = {"aye": {"boo3": a_boo}}
+        b_boo = {"aye": a_boo}
+        # a_boo_list = {"boolist1": {"boolistitems": [a_boo]}}
+        a_config_containing_union = {"test_config": {"a_list": [b_boo]}}
+        pytext_config = serialize.config_from_json(
+            TestConfigContainer, a_config_containing_union
+        )
+        # verify that a_dict was read correctly
+        self.assertEqual(pytext_config.test_config.a_list[0].aye.ayeaye, a_str)
         # serialize config to json, and deserialize back to config
         # verify that nothing changed
         jsonified_config = serialize.config_to_json(TestConfigContainer, pytext_config)

--- a/pytext/main.py
+++ b/pytext/main.py
@@ -25,6 +25,7 @@ from pytext.config.serialize import (
 from pytext.config.utils import find_param, replace_param
 from pytext.data.data_handler import CommonMetadata
 from pytext.metric_reporters.channel import Channel, TensorBoardChannel
+from pytext.PreprocessingMap.ttypes import ModelType
 from pytext.task import load
 from pytext.utils.documentation import (
     ROOT_CONFIG,
@@ -55,14 +56,33 @@ def _validate_export_json_config(export_json_config):
     """Validate if the input export_json_config (PyTextConfig in JSON object) only has
     export section config and a version number.
     """
-    assert export_json_config.keys() == {"export", "version"}, (
-        "The export-json config should only contain fields export and version. Got "
+    assert (export_json_config.keys() == {"export", "version"}) or (
+        export_json_config.keys() == {"export_list", "version"}
+    ), (
+        "The export-json config should only contain fields (export or export_list) and version. Got "
         f"{export_json_config.keys()}"
     )
-    for key in export_json_config["export"]:
-        assert (
-            key in ExportConfig.__annotations__.keys()
-        ), f"Field {key} in the export json is not found in the ExportConfig class."
+    if "export" in export_json_config.keys():
+        for key in export_json_config["export"]:
+            assert (
+                key in ExportConfig.__annotations__.keys()
+            ), f"Field {key} in the export json is not found in the ExportConfig class."
+    else:  # export_list instead of export
+        assert "export_list" in export_json_config.keys()
+        found_model_type = None
+        for export_config in export_json_config["export_list"]:
+            for key in export_config:
+                assert (
+                    key in ExportConfig.__annotations__.keys()
+                ), f"Field {key} in the export json is not found in the ExportConfig class."
+            this_model_type = (
+                ModelType.PYTORCH
+                if "export_pytorch_path" in export_config
+                else ModelType.CAFFE2
+            )
+            assert (found_model_type is None) or (found_model_type == this_model_type)
+            if found_model_type is None:
+                found_model_type = this_model_type
 
 
 def _load_and_validate_export_json_config(export_json):
@@ -427,14 +447,23 @@ def export(context, export_json, model, output_path, output_onnx_path):
                 "the export-json config is ignored because export options are found the command line"
             )
     config = context.obj.load_config()
+    export_list = config.export_list
     model = model or config.save_snapshot_path
-    output_path = output_path or config.export_caffe2_path
-    output_onnx_path = output_onnx_path or config.export_onnx_path
-
-    print(
-        f"Exporting {model} to caffe2 file: {output_path} and onnx file: {output_onnx_path}"
-    )
-    export_saved_model_to_caffe2(model, output_path, output_onnx_path)
+    if len(export_list) == 0:
+        output_path = output_path or config.export_caffe2_path
+        output_onnx_path = output_onnx_path or config.export_onnx_path
+        print(
+            f"Exporting {model} to caffe2 file: {output_path} and onnx file: {output_onnx_path}"
+        )
+        export_saved_model_to_caffe2(model, output_path, output_onnx_path)
+    else:
+        for idx in range(0, len(export_list)):
+            output_path = output_path or config.get_export_caffe2_path(idx)
+            output_onnx_path = output_onnx_path or config.get_export_onnx_path(idx)
+            print(
+                f"Exporting {model} to caffe2 file: {output_path} and onnx file: {output_onnx_path}"
+            )
+            export_saved_model_to_caffe2(model, output_path, output_onnx_path)
 
 
 @main.command()
@@ -449,51 +478,56 @@ def torchscript_export(context, export_json, model, output_path, quantize):
     # only populate from export_json if no export option is configured from the command line.
     if export_json:
         export_json_config = _load_and_validate_export_json_config(export_json)
-        export_section_config = export_json_config["export"]
-        if not quantize and not output_path:
-            export_config.export_caffe2_path = export_section_config.get(
-                "export_caffe2_path", None
-            )
-            export_config.export_onnx_path = export_section_config.get(
-                "export_onnx_path", "/tmp/model.onnx"
-            )
-            export_config.torchscript_quantize = export_section_config.get(
-                "torchscript_quantize", False
-            )
+
+        if "export_list" not in export_json_config.keys():
+            export_section_config_list = [export_json_config["export"]]
         else:
-            print(
-                "the export-json config is ignored because export options are found the command line"
+            export_section_config_list = export_json_config["export_list"]
+        for export_section_config in export_section_config_list:
+            if not quantize and not output_path:
+                export_config.export_caffe2_path = export_section_config.get(
+                    "export_caffe2_path", None
+                )
+                export_config.export_onnx_path = export_section_config.get(
+                    "export_onnx_path", "/tmp/model.onnx"
+                )
+                export_config.torchscript_quantize = export_section_config.get(
+                    "torchscript_quantize", False
+                )
+
+            else:
+                print(
+                    "the export-json config is ignored because export options are found the command line"
+                )
+                export_config.torchscript_quantize = quantize
+
+            export_config.export_torchscript_path = export_section_config.get(
+                "export_torchscript_path", None
             )
-            export_config.torchscript_quantize = quantize
+            # if config has export_torchscript_path, use export_torchscript_path from config, otherwise keep the default from CLI
+            if export_config.export_torchscript_path is not None:
+                output_path = export_config.export_torchscript_path
 
-        export_config.export_torchscript_path = export_section_config.get(
-            "export_torchscript_path", None
-        )
-        # if config has export_torchscript_path, use export_torchscript_path from config, otherwise keep the default from CLI
-        if export_config.export_torchscript_path is not None:
-            output_path = export_config.export_torchscript_path
+            export_config.export_lite_path = export_section_config.get(
+                "export_lite_path", None
+            )
+            export_config.inference_interface = export_section_config.get(
+                "inference_interface", None
+            )
+            export_config.accelerate = export_section_config.get("accelerate", [])
+            export_config.seq_padding_control = export_section_config.get(
+                "seq_padding_control", None
+            )
+            export_config.batch_padding_control = export_section_config.get(
+                "batch_padding_control", None
+            )
+            if not model or not output_path:
+                config = context.obj.load_config()
+                model = model or config.save_snapshot_path
+                output_path = output_path or f"{config.save_snapshot_path}.torchscript"
 
-        export_config.export_lite_path = export_section_config.get(
-            "export_lite_path", None
-        )
-        export_config.inference_interface = export_section_config.get(
-            "inference_interface", None
-        )
-        export_config.accelerate = export_section_config.get("accelerate", [])
-        export_config.seq_padding_control = export_section_config.get(
-            "seq_padding_control", None
-        )
-        export_config.batch_padding_control = export_section_config.get(
-            "batch_padding_control", None
-        )
-
-    if not model or not output_path:
-        config = context.obj.load_config()
-        model = model or config.save_snapshot_path
-        output_path = output_path or f"{config.save_snapshot_path}.torchscript"
-
-    print(f"Exporting {model} to torchscript file: {output_path}")
-    export_saved_model_to_torchscript(model, output_path, export_config)
+            print(f"Exporting {model} to torchscript file: {output_path}")
+            export_saved_model_to_torchscript(model, output_path, export_config)
 
 
 @main.command()

--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -198,27 +198,32 @@ def save_and_export(
     else:
         tensorizers = task.data.tensorizers
     save(config, task.model, meta, tensorizers=tensorizers)
-    export_config = config.export
-    if export_config is not None:
-        if export_config.export_caffe2_path:
-            task.export(
-                task.model,
-                export_config.export_caffe2_path,
-                metric_channels,
-                export_config.export_onnx_path,
-            )
-        if export_config.export_torchscript_path:
-            task.torchscript_export(
-                model=task.model,
-                export_path=export_config.export_torchscript_path,
-                export_config=export_config,
-            )
-        if export_config.export_lite_path:
-            task.lite_export(
-                model=task.model,
-                export_path=export_config.export_lite_path,
-                export_config=export_config,
-            )
+    if len(config.export_list) == 0:
+        export_configs = [config.export]
+    else:
+        export_configs = config.export_list
+
+    for export_config in export_configs:
+        if export_config is not None:
+            if export_config.export_caffe2_path:
+                task.export(
+                    task.model,
+                    export_config.export_caffe2_path,
+                    metric_channels,
+                    export_config.export_onnx_path,
+                )
+            if export_config.export_torchscript_path:
+                task.torchscript_export(
+                    model=task.model,
+                    export_path=export_config.export_torchscript_path,
+                    export_config=export_config,
+                )
+            if export_config.export_lite_path:
+                task.lite_export(
+                    model=task.model,
+                    export_path=export_config.export_lite_path,
+                    export_config=export_config,
+                )
 
 
 def export_saved_model_to_caffe2(

--- a/tests/task_load_save_test.py
+++ b/tests/task_load_save_test.py
@@ -50,7 +50,9 @@ class TaskLoadSaveTest(unittest.TestCase):
 
             save(config, model, meta=None, tensorizers=task.data.tensorizers)
             task2, config2, training_state_none = load(snapshot_file.name)
-
+            self.assertEqual(config.export, config2.export)
+            self.assertEqual(config.export_list, config2.export_list)
+            self.assertEqual(config.task, config2.task)
             self.assertEqual(config, config2)
             self.assertModulesEqual(model, task2.model)
             self.assertIsNone(training_state_none)


### PR DESCRIPTION
Summary:
Modified from D25257145 (https://github.com/facebookresearch/PyText/commit/04ac4bf713a031cd9ef68e692b76f8e0b78e9097) which added a field "export_list" to PyTextConfig.   All code was changed to replace f(pytextconfig.export) to the logical equivalent of map(f, pytextconfig.export_list) and a test was added to ensure that model_type is the same across all of the elements in the export list. The original diff was reverted due to interface mismatch between PyTextConfig and current pytext pkg. See more detail about the original task from D25257145 (https://github.com/facebookresearch/PyText/commit/04ac4bf713a031cd9ef68e692b76f8e0b78e9097) and T7965600.

I commandeered this diff from the original author to rebase it onto master and adapt it to the new implementation in version 23. The version mismatch problem should be resolved in D26116558.

Reviewed By: mikekgfb

Differential Revision: D25682460

