### PR TITLE
Create a downgrade adapter for export_list

### DIFF
--- a/pytext/config/config_adapter.py
+++ b/pytext/config/config_adapter.py
@@ -761,6 +761,14 @@ def v22_to_v23(json_config):
     return json_config
 
 
+@register_adapter(from_version=23)
+def v23_to_v24(json_config):
+    """
+    No-op since export_list is optional
+    """
+    return json_config
+
+
 @register_down_grade_adapter(from_version=23)
 def v23_to_v22(json_config):
     """
@@ -768,6 +776,23 @@ def v23_to_v22(json_config):
     """
     if "read_chunk_size" in json_config:
         del json_config["read_chunk_size"]
+    return json_config
+
+
+@register_down_grade_adapter(from_version=24)
+def v24_to_v23(json_config):
+    """
+    Upgrade by removing export_list option
+    """
+    if "export_list" in json_config:
+        if len(json_config["export_list"]) > 1:
+            raise Exception(
+                "Current version does not support multiple exports in export_list"
+            )
+        elif len(json_config["export_list"]) == 0:
+            raise Exception("Current version does not support empty export_list")
+        json_config["export"] = json_config["export_list"][0]
+        del json_config["export_list"]
     return json_config
 
 

--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -301,4 +301,4 @@ class LogitsConfig(TestConfig):
 
 
 # update sitevar PYTEXT_CONFIG_LATEST_VERSION when new PytextConfig pushed in pytext config
-LATEST_VERSION = 23
+LATEST_VERSION = 24


### PR DESCRIPTION
Summary:
The original diff was reverted due to interface mismatch between PyTextConfig and current pytext pkg. See more detail about the original task from D25257145 (https://github.com/facebookresearch/PyText/commit/04ac4bf713a031cd9ef68e692b76f8e0b78e9097) and T7965600.

I added a a downgrade adaptor to PyText adaptors and increase version number to 24.

Reviewed By: mikekgfb

Differential Revision: D26116558

