### PR TITLE
Fix torchtext.legacy import error

### DIFF
--- a/pytext/data/data_handler.py
+++ b/pytext/data/data_handler.py
@@ -31,7 +31,11 @@ from pytext.utils.data import parse_json_array
 from pytext.utils.file_io import PathManager
 from pytext.utils.path import get_absolute_path
 from pytext.utils.usage import log_class_usage
-from torchtext.legacy import data as textdata
+
+try:
+    from torchtext.legacy import data as textdata
+except ImportError:
+    from torchtext import data as textdata
 
 from .utils import align_target_labels
 

--- a/pytext/fields/char_field.py
+++ b/pytext/fields/char_field.py
@@ -8,7 +8,11 @@ import torch
 from pytext.common.constants import VocabMeta
 from pytext.utils.data import no_tokenize
 from torchtext import vocab
-from torchtext.legacy import data as textdata
+
+try:
+    from torchtext.legacy import data as textdata
+except ImportError:
+    from torchtext import data as textdata
 
 from .field import VocabUsingField
 

--- a/pytext/fields/dict_field.py
+++ b/pytext/fields/dict_field.py
@@ -7,7 +7,11 @@ import torch
 from pytext.common.constants import VocabMeta
 from pytext.utils.data import no_tokenize
 from torchtext import vocab
-from torchtext.legacy import data as textdata
+
+try:
+    from torchtext.legacy import data as textdata
+except ImportError:
+    from torchtext import data as textdata
 
 from .field import VocabUsingField
 

--- a/pytext/fields/field.py
+++ b/pytext/fields/field.py
@@ -2,14 +2,18 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import re
-from typing import Any, Dict, Mapping, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import torch
 from pytext.common.constants import Padding, VocabMeta
 from pytext.config.field_config import EmbedInitStrategy
 from pytext.utils import data as data_utils, precision
-from pytext.utils.label import get_label_weights
-from torchtext.legacy import data as textdata
+
+try:
+    from torchtext.legacy import data as textdata
+except ImportError:
+    from torchtext import data as textdata
+
 from torchtext.vocab import Vocab
 
 

--- a/pytext/fields/text_field_with_special_unk.py
+++ b/pytext/fields/text_field_with_special_unk.py
@@ -10,7 +10,11 @@ import torch
 from pytext.common.constants import VocabMeta
 from pytext.fields import TextFeatureField
 from pytext.utils.data import is_number, unkify
-from torchtext.legacy.data import Dataset
+
+try:
+    from torchtext.legacy.data import Dataset
+except ImportError:
+    from torchtext.data import Dataset
 
 
 class TextFeatureFieldWithSpecialUnk(TextFeatureField):

--- a/pytext/trainers/hogwild_trainer.py
+++ b/pytext/trainers/hogwild_trainer.py
@@ -10,7 +10,11 @@ from pytext.config.pytext_config import ConfigBase
 from pytext.metric_reporters import MetricReporter
 from pytext.trainers.trainer import TaskTrainer, Trainer, TrainingState
 from pytext.utils import cuda
-from torchtext.legacy.data import Iterator
+
+try:
+    from torchtext.legacy.data import Iterator
+except ImportError:
+    from torchtext.data import Iterator
 
 
 class HogwildTrainer_Deprecated(Trainer):


### PR DESCRIPTION
Summary:
CircleCI is failing due to an import error at this point. Sample error:
```
collection failure
ImportError while importing test module '/home/circleci/project/tests/accelerator_lowering_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/accelerator_lowering_test.py:8: in <module>
    from pytext.task.accelerator_lowering import accelerator_transformerLayers_inputs
pytext/__init__.py:13: in <module>
    from pytext.task import load
pytext/task/__init__.py:4: in <module>
    from .new_task import NewTask, _NewTask
pytext/task/new_task.py:14: in <module>
    from pytext.metric_reporters import MetricReporter
pytext/metric_reporters/__init__.py:6: in <module>
    from .classification_metric_reporter import (
pytext/metric_reporters/classification_metric_reporter.py:10: in <module>
    from pytext.data import CommonMetadata
pytext/data/__init__.py:13: in <module>
    from .data_handler import BatchIterator, CommonMetadata, DataHandler
pytext/data/data_handler.py:28: in <module>
    from pytext.fields import Field, FieldMeta, RawField, VocabUsingField
pytext/fields/__init__.py:4: in <module>
    from .char_field import CharFeatureField
pytext/fields/char_field.py:11: in <module>
    from torchtext.legacy import data as textdata
E   ModuleNotFoundError: No module named 'torchtext.legacy'
```
Temporary fix until new torchtext is released:
```
try:
  from torchtext import data as textdata
except ImportError:
  from torchtext.legacy import data as textdata
```
Reference: https://fb.workplace.com/groups/1941258842562334

Differential Revision: D26627274

