### PR TITLE
Fix Compositional Metric Reporter

### DIFF
--- a/pytext/data/data_structures/node.py
+++ b/pytext/data/data_structures/node.py
@@ -50,6 +50,7 @@ class Node:
             self.label == other.label  # noqa
             and self.span == other.span  # noqa
             and self.children == other.children  # noqa
+            and self.text == other.text  # noqa
         )
 
     def get_depth(self) -> int:

--- a/pytext/metric_reporters/compositional_metric_reporter.py
+++ b/pytext/metric_reporters/compositional_metric_reporter.py
@@ -193,10 +193,12 @@ class CompositionalMetricReporter(MetricReporter):
         """
         res_children: Set[Node] = set()
         idx = start
+        node_text_tokens: List[str] = []
         if node.children:
             for child in node.children:
                 if type(child) == Token:
                     idx += len(child.label) + 1
+                    node_text_tokens.append(child.label)
                 elif type(child) == Intent or type(child) == Slot:
                     res_child = CompositionalMetricReporter.node_to_metrics_node(
                         child, idx
@@ -205,5 +207,12 @@ class CompositionalMetricReporter(MetricReporter):
                     idx = res_child.span.end + 1
                 else:
                     raise ValueError("Child must be Token, Intent or Slot!")
-        node = Node(label=node.label, span=Span(start, idx - 1), children=res_children)
+        node_text = " ".join(node_text_tokens)
+        print(node_text)
+        node = Node(
+            label=node.label,
+            span=Span(start, idx - 1),
+            children=res_children,
+            text=node_text,
+        )
         return node


### PR DESCRIPTION
Summary:
In our compositional metric reporter when checking for equality during FA computation, we compare two parse trees, but don’t compare slot text content but instead end up comparing the length of the slot text. I assume this was a valid comparison during RNNG/Seqlogical time, but became problematic once we switched to decoupled. Consider the following

```
utterance: Don’t call John, call Jane
prediction: [in:create_call [sl:contact John ] ]
target: [in:create_call [sl:contact Jane ] ]
```

This will be marked as a correct prediction because len(“John”) == len(“Jane”).
�Source of bug: https://fburl.com/diffusion/l40ns7rd
Notebook to repro: N495220

Reviewed By: shreydesai, AdithyaSagar007

Differential Revision: D26783893

