### PR TITLE
Deprecate inference interface export configuration option; raise runtime error when accelerator support requested in old-style task.py

### DIFF
--- a/pytext/config/pytext_config.py
+++ b/pytext/config/pytext_config.py
@@ -101,10 +101,7 @@ class ExportConfig(ConfigBase):
     # "nnpi" - freeze model for use with Glow on NNPI accelerator
     accelerate: List[str] = []
     # Inference Interface.
-    # Specifies which of the 3 optional list parameters a model takes,
-    # when the model implements the inference_ionterface() method.:
-    # Possible values: texts, multi_texts, tokens (and/or others as
-    # supported by inference_interface method).
+    # *** DEPRECATED *** DO NOT USE ***
     inference_interface: Optional[str] = None
     # Padding boundaries for padded tensor sequence length dimension.
     # Specified as a list of boundaries to be rounded up to.

--- a/pytext/config/test/json_config/v22.json
+++ b/pytext/config/test/json_config/v22.json
@@ -2,7 +2,6 @@
   {
     "original": {
       "version": 21,
-      "inference_interface": "texts",
       "seq_padding_control": [0, 50, 150, 300, 512],
       "batch_padding_control": [0, 1, 2, 8, 32],
       "export_torchscript_path": "/tmp/model.pt1",
@@ -164,7 +163,6 @@
       "export": {
         "seq_padding_control": [0, 50, 150, 300, 512],
         "batch_padding_control": [0, 1, 2, 8, 32],
-        "inference_interface": "texts",
         "export_torchscript_path": "/tmp/model.pt1",
         "torchscript_quantize": false
       },

--- a/pytext/config/test/json_config/v22_export_config.json
+++ b/pytext/config/test/json_config/v22_export_config.json
@@ -2,7 +2,6 @@
   {
     "original": {
       "version": 21,
-      "inference_interface": "texts",
       "seq_padding_control": [0, 50, 150, 300, 512],
       "batch_padding_control": [0, 1, 2, 8, 32],
       "export_torchscript_path": "/tmp/model.pt1",
@@ -16,7 +15,6 @@
       "export": {
         "seq_padding_control": [0, 50, 150, 300, 512],
         "batch_padding_control": [0, 1, 2, 8, 32],
-        "inference_interface": "texts",
         "export_torchscript_path": "/tmp/model.pt1",
         "export_caffe2_path": "/tmp/model_caffe2.pt1",
         "export_onnx_path": "/tmp/model_onnx.pt1",

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -313,7 +313,6 @@ class _NewTask(TaskBase):
         accelerate = export_config.accelerate
         seq_padding_control = export_config.seq_padding_control
         batch_padding_control = export_config.batch_padding_control
-        inference_interface = export_config.inference_interface
 
         # introduce a single nnpi:quantize that obviates need for torchscript quantize on NNPI
         use_nnpi = ("nnpi" in accelerate) or ("nnpi:quantize" in accelerate)
@@ -393,13 +392,6 @@ class _NewTask(TaskBase):
             else:
                 print(
                     "Padding_control not supported by model. Ignoring batch_padding_control"
-                )
-        if inference_interface is not None:
-            if hasattr(trace, "inference_interface"):
-                trace.inference_interface(inference_interface)
-            else:
-                print(
-                    "inference_interface not supported by model. Ignoring inference_interface"
                 )
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)
         if "nnpi" in accelerate:

--- a/pytext/task/tasks.py
+++ b/pytext/task/tasks.py
@@ -232,7 +232,11 @@ class PairwiseClassificationTask(NewTask):
         accelerate = export_config.accelerate
         seq_padding_control = export_config.seq_padding_control
         batch_padding_control = export_config.batch_padding_control
-        inference_interface = export_config.inference_interface
+
+        if accelerate is not None:
+            raise RuntimeError(
+                "old-style task.py does not support export for NNPI accelerators"
+            )
 
         cuda.CUDA_ENABLED = False
         model.cpu()
@@ -249,8 +253,6 @@ class PairwiseClassificationTask(NewTask):
         model(*inputs)
         if quantize:
             model.quantize()
-        if accelerate is not None and "half" in accelerate:
-            model.half()
         if self.trace_both_encoders:
             trace = jit.trace(model, inputs)
         else:
@@ -273,19 +275,7 @@ class PairwiseClassificationTask(NewTask):
                 print(
                     "Padding_control not supported by model. Ignoring padding_control"
                 )
-        if inference_interface is not None:
-            if hasattr(trace, "inference_interface"):
-                trace.inference_interface(inference_interface)
-            else:
-                print(
-                    "inference_interface not supported by model. Ignoring inference_interface"
-                )
         trace.apply(lambda s: s._pack() if s._c._has_method("_pack") else None)
-        if accelerate is not None and "nnpi" in accelerate:
-            trace._c = torch._C._freeze_module(
-                trace._c,
-                preservedAttrs=["make_prediction", "make_batch", "set_padding_control"],
-            )
         if export_path is not None:
             print(f"Saving torchscript model to: {export_path}")
             with PathManager.open(export_path, "wb") as f:

--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -41,9 +41,15 @@ def resolve_texts(
 
 
 def deprecation_warning(export_conf: ExportConfig):
-    if (
-        (export_conf.inference_interface is not None)
-        or (export_conf.accelerate is not None)
+    if export_conf.inference_interface is not None:
+        print(
+            "***************  DEPRECATION ERROR  **************"
+            "inference_interface config option is not available"
+            "**************************************************"
+        )
+        raise RuntimeError("export configuration not supported")
+    elif (
+        (export_conf.accelerate is not None)
         or (export_conf.seq_padding_control is not None)
         or (export_conf.batch_padding_control is not None)
     ):
@@ -67,7 +73,6 @@ class ScriptPyTextEmbeddingModule(torch.jit.ScriptModule):
         super().__init__()
         self.model = model
         self.tensorizer = tensorizer
-        self.argno = -1
         log_class_usage(self.__class__)
 
     def validate(self, export_conf: ExportConfig):
@@ -777,8 +782,6 @@ class ScriptPyTextTwoTowerEmbeddingModule(ScriptTwoTowerModule):
         self.model = model
         self.right_tensorizer = right_tensorizer
         self.left_tensorizer = left_tensorizer
-        # We only support texts input for TwoTower until further updates
-        self.argno = 0
         log_class_usage(self.__class__)
 
     @torch.jit.script_method
@@ -825,7 +828,7 @@ class ScriptPyTextTwoTowerEmbeddingModule(ScriptTwoTowerModule):
         ],
     ) -> List[torch.Tensor]:
 
-        argno = self.argno
+        argno = -1
 
         if argno == -1:
             raise RuntimeError("Argument number not specified during export.")
@@ -917,7 +920,7 @@ class ScriptPyTextTwoTowerEmbeddingModule(ScriptTwoTowerModule):
         ]
     ]:
 
-        argno = self.argno
+        argno = -1
 
         if argno == -1:
             raise RuntimeError("Argument number not specified during export.")


### PR DESCRIPTION
Summary:
Deprecate inference interface export configuration option
raise runtime error when accelerator support requested in old-style task.py

Differential Revision: D26877097

