### PR TITLE
Add conditional import in accelerator_lowering.py to avoid ImportError

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -21,7 +21,7 @@ from pytext.utils.usage import (
     log_feature_usage,
     log_accelerator_feature_usage,
 )
-from torch import jit, sort
+from torch import sort
 
 from .accelerator_lowering import (
     lower_modules_to_accelerator,

--- a/pytext/task/nop_decorator.py
+++ b/pytext/task/nop_decorator.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reservedimport functools
+
+import functools
+
+# module decorator for specifying acceleration
+# The purpose is to avoid ImportError when glow_decorator is not available
+class accelerator:
+    def __init__(self, specs, inputs_function=None):
+        pass
+
+    def __call__(self, module):
+        @functools.wraps(module)
+        def wrapper(*args, **kwargs):
+            return module(*args, **kwargs)
+
+        return wrapper
+
+    @classmethod
+    def _dfs_modules(cls, node, backend, results, submod_path=""):
+        pass
+
+    @classmethod
+    def get_modules(cls, model, backend):
+        pass
+
+    @classmethod
+    def get_module_from_path(cls, model, prefixes):
+        pass
+
+    @classmethod
+    def get_embedding_module_from_path(cls, model, submod_path):
+        pass


### PR DESCRIPTION
Summary:
Alternative approach to https://github.com/facebookresearch/pytext/pull/1631. Handling ImportError of accelerator in accelerator_lowering.py instead of new_task.py.
accelerator function is both used as a declarator on class AcceleratorTransformerLayers and called directly in lower_modules_to_accelerator. In addition to adding the try block for importing accelerator, accelerator_lowering_supported is used in lower_modules_to_accelerator to avoid ImportError.

Differential Revision: D26885302

