### PR TITLE
Try/except block for multi-export of tochscript models in PyText TrainWorkflow

### DIFF
--- a/pytext/workflow.py
+++ b/pytext/workflow.py
@@ -216,11 +216,18 @@ def save_and_export(
                 export_config.export_onnx_path,
             )
         elif export_config.export_torchscript_path:
-            task.torchscript_export(
-                model=task.model,
-                export_path=export_config.export_torchscript_path,
-                export_config=export_config,
-            )
+            try:
+                task.torchscript_export(
+                    model=task.model,
+                    export_path=export_config.export_torchscript_path,
+                    export_config=export_config,
+                )
+            except (RuntimeError, TypeError) as e:
+                print("Ran into error: {}".format(", ".join(e.args)))
+                print(
+                    f"The torchscript model at {export_config.export_torchscript_path} could not be saved, skipping for now."
+                )
+
         elif export_config.export_lite_path:
             task.lite_export(
                 model=task.model,


### PR DESCRIPTION
Summary: wrap torchscript export in try/except block so processes can continue running even if one model fails

Reviewed By: mikekgfb

Differential Revision: D26831840

