### PR TITLE
Fp16 gradients for pytext

### DIFF
--- a/pytext/trainers/trainer.py
+++ b/pytext/trainers/trainer.py
@@ -29,6 +29,7 @@ from pytext.optimizer.sparsifiers.sparsifier import Sparsifier
 from pytext.task.serialize import save
 from pytext.trainers.training_state import TrainingState
 from pytext.utils import cuda, distributed, precision, timing
+from torch.distributed.algorithms.ddp_comm_hooks.default_hooks import fp16_compress_hook
 
 
 class TrainerBase(Component):
@@ -120,6 +121,7 @@ class Trainer(TrainerBase):
         #: backward and master weight will be maintained on original optimizer.
         #: https://arxiv.org/abs/1710.03740
         fp16_args: FP16Optimizer.Config = FP16OptimizerFairseq.Config()
+        fp16_grad_compression: bool = False
         # PrivacyEngine related args
         privacy_engine: Optional[PrivacyEngine.Config] = None
         use_tensorboard: bool = False
@@ -184,6 +186,10 @@ class Trainer(TrainerBase):
                 find_unused_parameters=state.model.find_unused_parameters,
                 process_group=distributed._round_robin_process_group,
             )
+            if self.config.fp16_grad_compression:
+                state.model.register_comm_hook(
+                    distributed._round_robin_process_group, fp16_compress_hook
+                )
         state.start_time = time.time()
 
         if self.config.num_batches_per_epoch:

--- a/pytext/utils/distributed.py
+++ b/pytext/utils/distributed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import os
 from datetime import timedelta
 
 import pytext.utils.cuda as cuda
@@ -30,6 +31,9 @@ def dist_init(
     if init_method and world_size > 1 and torch.cuda.is_available():
         # providing a large process group timeout to prevent errors during
         # initialization.
+
+        os.environ["NCCL_NSOCKS_PERTHREAD"] = "4"
+        os.environ["NCCL_SOCKET_NTHREADS"] = "2"
         dist_c10d.init_process_group(
             backend=backend,
             init_method=init_method,


### PR DESCRIPTION
Summary:
Akshat mentioned fblearner is network bottle necked for multi node training. This leads to NLU having to use grad accumulation and slowing down training by 2x

I saw something similar in multi node DPR training and using fp16 gradient compression a new feature added in pytorch 1.8 helped me get around a ~33% increases in iteration speed of the model. (1.8s/it->1.2s/it)

This tests out the same for the NLU model and adds changes to the experimental nightly

Differential Revision: D27178926

