### PR TITLE
Add lowering capability for internal CNN LM

### DIFF
--- a/pytext/task/accelerator_lowering.py
+++ b/pytext/task/accelerator_lowering.py
@@ -267,9 +267,17 @@ def lower_modules_to_accelerator(
     import torch_glow
 
     log_accelerator_feature_usage("build.NNPI")
-    if (hasattr(model, "encoder") and isinstance(model.encoder, RoBERTaEncoder)) or (
-        hasattr(model, "representation")
-        and isinstance(model.representation, AcceleratorBiLSTM)
+    if (
+        (hasattr(model, "encoder") and isinstance(model.encoder, RoBERTaEncoder))
+        or (
+            hasattr(model, "representation")
+            and isinstance(model.representation, AcceleratorBiLSTM)
+        )
+        or (
+            hasattr(model, "lower_module")
+            # Internal CNN LM module to add accelerator support.
+            and type(model.lower_module).__qualname__ == "CNNLowerModule"
+        )
     ):
         backend = "NNPI"
         (


### PR DESCRIPTION
Summary:
Check class field and name instead of import to avoid circular dependency.
We pad to fix shape before lowering, remove pad after lowering.
Passed param order is after traced, different from definition.
This CNN LM has incremental inference support, it assumes all sequence lengths are same or batch size=1 during **inference**, else returned output and state will be incorrect.

 Lowering module to accelerator will be enabled by:
  ```
  "accelerate": ["nnpi"],
  "seq_padding_control": [0, 3, 5, 10, 12, 20, 50],
  "batch_padding_control": [0, 1, 2, 3, 5, 8, 32],
  ```

Reviewed By: gardenia22

Differential Revision: D27207694

