### PR TITLE
Training time optimizations for nlu models + fp16 grad compression

### DIFF
--- a/pytext/trainers/__init__.py
+++ b/pytext/trainers/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from .ensemble_trainer import EnsembleTrainer
 from .hogwild_trainer import HogwildTrainer, HogwildTrainer_Deprecated
-from .trainer import TaskTrainer, Trainer
+from .trainer import TaskTrainer, Trainer, FP16GradsTrainer
 from .training_state import TrainingState
 
 
@@ -13,4 +13,5 @@ __all__ = [
     "HogwildTrainer",
     "HogwildTrainer_Deprecated",
     "TaskTrainer",
+    "FP16GradsTrainer",
 ]


### PR DESCRIPTION
Summary:
1) Adds fp16 gradient compression option to PyText trainer. Config adapters were causing too many test failures which were hard to debug so i just add a new trainer
2) Tunes various paramters of the experimental nightly to improve training speed
3) This uses 12 more gpus but reduction in training time brings down overall gpu hours close to before

Differential Revision: D27435035

