### PR TITLE
add logging for all Components to track usage

### DIFF
--- a/pytext/config/component.py
+++ b/pytext/config/component.py
@@ -5,6 +5,7 @@ import enum
 from typing import Any, Dict, List, Tuple, Type, Union
 
 import torch
+from pytext.utils.usage import log_class_usage
 
 from .pytext_config import ConfigBase, PyTextConfig
 
@@ -185,6 +186,7 @@ class Component(metaclass=ComponentMeta):
 
     def __init__(self, config=None, *args, **kwargs):
         self.config = config
+        log_class_usage(self.__class__)
 
 
 def register_tasks(task_cls: Union[Type, List[Type]]):

--- a/pytext/models/module.py
+++ b/pytext/models/module.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import zipfile
 from typing import Dict
 
 import torch
@@ -10,7 +9,6 @@ import torch.nn as nn
 from pytext.config.component import Component, ComponentType, create_component
 from pytext.config.module_config import ModuleConfig
 from pytext.utils.file_io import PathManager
-from pytext.utils.usage import log_class_usage
 
 
 SHARED_MODULE_REGISTRY: Dict[str, torch.nn.Module] = {}
@@ -92,7 +90,6 @@ class Module(nn.Module, Component):
     def __init__(self, config=None) -> None:
         nn.Module.__init__(self)
         Component.__init__(self, config)
-        log_class_usage(__class__)
 
     def freeze(self) -> None:
         for param in self.parameters():

--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -271,7 +271,7 @@ class _NewTask(TaskBase):
             self.Config.metric_reporter, model
         )
         self.trainer = trainer or TaskTrainer()
-        log_class_usage
+        log_class_usage(self.__class__)
 
     def train(
         self,


### PR DESCRIPTION
Summary:
Currently, no all components are logged during `__init__`

To track the usage of all components for migration or deprecation decision, this diff added log to the base Component and fixed a logging bug in Task

Differential Revision: D27631525

