### PR TITLE
port the q-scaling fix to FasterTransformer 4.0

### DIFF
--- a/pytext/task/cuda_lowering.py
+++ b/pytext/task/cuda_lowering.py
@@ -13,7 +13,7 @@ from pytext.models.representations.transformer import (
 from pytext.models.roberta import RoBERTaEncoder
 from torch import nn, Tensor
 
-torch.ops.load_library("//pytorch/FasterTransformers3.1:faster_transformers")
+torch.ops.load_library("//pytorch/FasterTransformers4.0:faster_transformers")
 
 
 @torch.jit.script


### PR DESCRIPTION
Summary: A redo of D27376839 for FasterTransformer 4.0. Note that this is probably not needed as FT4.0 seem to be using trt fused kernels which triggers a different code path. But the test plan before is exercised on whatever path that is being triggered.

Differential Revision: D27702734

