### PR TITLE
Fix blocking scheme of add_QKV_bias_generalized

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -487,7 +487,9 @@ class _NewTask(TaskBase):
                     iter(self.data.batches(Stage.TRAIN, load_early=True))
                 )
                 inputs = model.onnx_trace_input(batch)
-                assert trace(*inputs)
+                results = trace(*inputs)
+                assert results
+                print(results)
             else:
                 trace = model.trace(inputs)
                 print("traced!")

--- a/tests/cuda_lowering_test.py
+++ b/tests/cuda_lowering_test.py
@@ -31,6 +31,38 @@ class TestCUDALowering(unittest.TestCase):
                 for rref, ffast in zip(ref, fast):
                     torch.testing.assert_allclose(rref, ffast, atol=2e-2, rtol=2e-2)
 
+    def testLoweringBaseTransformerToNVFastTransformerUnfusedXL(self):
+        """
+        No padding (full sequence lengths), unfused path (no trt)
+        XL model (D > 1024, D/2 <= 1024), this will exercise
+        add_QKV_bias_generalized but not block-strided add_bias_input_layernorm.
+        """
+        V = 1000
+        L = 12
+        D = 1280
+        H = 32
+        layers = [
+            TransformerLayer(
+                embedding_dim=D,
+                attention=MultiheadSelfAttention(embed_dim=D, num_heads=H, scaling=1.0/np.sqrt(D / H)),
+            )
+            for _ in range(L)
+        ]
+        transformer = Transformer(vocab_size=V, embedding_dim=D, layers=layers).cuda().eval().half()
+        faster_transformer = NVFasterTransformerEncoder(transformer)
+
+        for B in range(1, 32):
+            for T in [0, 1, 7, 8, 16]:
+                tokens = (
+                    torch.randint(transformer.padding_idx + 1, V - 1, size=(B, T))
+                    .cuda()
+                    .long()
+                )
+                ref = transformer(tokens)
+                fast = faster_transformer(tokens)
+                for rref, ffast in zip(ref, fast):
+                    torch.testing.assert_allclose(rref, ffast, atol=3e-2, rtol=2e-2)
+
     def testLoweringBaseTransformerToNVFastTransformerUnfused(self):
         """
         No padding (full sequence lengths), unfused path (no trt)


### PR DESCRIPTION
Summary: If `m * k / block.x` cannot be divided by `word_per_block`, we are rounding down which will miss some of the blocks. Setting `word_per_block` to `1` to ensure this doesn't happen for now.

Differential Revision: D27782731

