### PR TITLE
Fix add_bias_input_layernorm

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -487,7 +487,9 @@ class _NewTask(TaskBase):
                     iter(self.data.batches(Stage.TRAIN, load_early=True))
                 )
                 inputs = model.onnx_trace_input(batch)
-                assert trace(*inputs)
+                results = trace(*inputs)
+                assert results
+                print(results)
             else:
                 trace = model.trace(inputs)
                 print("traced!")

--- a/tests/cuda_lowering_test.py
+++ b/tests/cuda_lowering_test.py
@@ -44,11 +44,18 @@ class TestCUDALowering(unittest.TestCase):
         layers = [
             TransformerLayer(
                 embedding_dim=D,
-                attention=MultiheadSelfAttention(embed_dim=D, num_heads=H, scaling=1.0/np.sqrt(D / H)),
+                attention=MultiheadSelfAttention(
+                    embed_dim=D, num_heads=H, scaling=1.0 / np.sqrt(D / H)
+                ),
             )
             for _ in range(L)
         ]
-        transformer = Transformer(vocab_size=V, embedding_dim=D, layers=layers).cuda().eval().half()
+        transformer = (
+            Transformer(vocab_size=V, embedding_dim=D, layers=layers)
+            .cuda()
+            .eval()
+            .half()
+        )
         faster_transformer = NVFasterTransformerEncoder(transformer)
 
         for B in range(1, 32):
@@ -99,6 +106,94 @@ class TestCUDALowering(unittest.TestCase):
                 fast = faster_transformer(tokens)
                 for rref, ffast in zip(ref, fast):
                     torch.testing.assert_allclose(rref, ffast, atol=3e-2, rtol=2e-2)
+
+    def testLoweringBaseTransformerToNVFastTransformerPaddedUnfused(self):
+        """
+        With padding, unfused path (no trt)
+        """
+        V = 1000
+        L = 24
+        D = 960
+        H = 16
+        layers = [
+            TransformerLayer(
+                embedding_dim=D,
+                attention=MultiheadSelfAttention(
+                    embed_dim=D, num_heads=H, scaling=1.0 / np.sqrt(D / H)
+                ),
+            )
+            for _ in range(L)
+        ]
+        transformer = (
+            Transformer(vocab_size=V, embedding_dim=D, layers=layers)
+            .cuda()
+            .eval()
+            .half()
+        )
+        faster_transformer = NVFasterTransformerEncoder(transformer)
+
+        for B in range(1, 32):
+            for max_T in [0, 1, 2, 6, 40, 127]:
+                lengths = np.random.randint(low=0, high=max_T + 1, size=(B,))
+                tokens = torch.zeros(B, max_T).cuda().long()
+                for b in range(B):
+                    length = lengths[b]
+                    tokens[b, :length] = (
+                        torch.randint(
+                            transformer.padding_idx + 1, V - 1, size=(1, length)
+                        )
+                        .cuda()
+                        .long()
+                    )
+                    tokens[b, length:] = transformer.padding_idx
+
+                ref = transformer(tokens)
+                fast = faster_transformer(tokens)
+                for rref, ffast in zip(ref, fast):
+                    for b in range(B):
+                        length = lengths[b]
+                        torch.testing.assert_allclose(
+                            rref[:length, b], ffast[:length, b], atol=4e-2, rtol=2e-2
+                        )
+
+    def testLoweringBaseTransformerToNVFastTransformerUnfusedXXL(self):
+        """
+        No padding (full sequence lengths), unfused path (no trt)
+        XXL model (D > 1024 and D/2 > 1024). This will exercise both
+        add_QKV_bias_generalized and block-strided add_bias_input_layernorm.
+        """
+        V = 1000
+        L = 12
+        D = 2560
+        H = 32
+        layers = [
+            TransformerLayer(
+                embedding_dim=D,
+                attention=MultiheadSelfAttention(
+                    embed_dim=D, num_heads=H, scaling=1.0 / np.sqrt(D / H)
+                ),
+            )
+            for _ in range(L)
+        ]
+        transformer = (
+            Transformer(vocab_size=V, embedding_dim=D, layers=layers)
+            .cuda()
+            .eval()
+            .half()
+        )
+        faster_transformer = NVFasterTransformerEncoder(transformer)
+
+        for B in range(1, 32):
+            for T in [0, 1, 7, 8, 16]:
+                tokens = (
+                    torch.randint(transformer.padding_idx + 1, V - 1, size=(B, T))
+                    .cuda()
+                    .long()
+                )
+                ref = transformer(tokens)
+                fast = faster_transformer(tokens)
+                for rref, ffast in zip(ref, fast):
+                    torch.testing.assert_allclose(rref, ffast, atol=4e-2, rtol=2e-2)
 
     def testLoweringBaseTransformerToNVFastTransformerPadded(self):
         V = 1000

--- a/tests/cuda_lowering_test.py
+++ b/tests/cuda_lowering_test.py
@@ -31,6 +31,38 @@ class TestCUDALowering(unittest.TestCase):
                 for rref, ffast in zip(ref, fast):
                     torch.testing.assert_allclose(rref, ffast, atol=2e-2, rtol=2e-2)
 
+    def testLoweringBaseTransformerToNVFastTransformerUnfusedXL(self):
+        """
+        No padding (full sequence lengths), unfused path (no trt)
+        XL model (D > 1024, D/2 <= 1024), this will exercise
+        add_QKV_bias_generalized but not block-strided add_bias_input_layernorm.
+        """
+        V = 1000
+        L = 12
+        D = 1280
+        H = 32
+        layers = [
+            TransformerLayer(
+                embedding_dim=D,
+                attention=MultiheadSelfAttention(embed_dim=D, num_heads=H, scaling=1.0/np.sqrt(D / H)),
+            )
+            for _ in range(L)
+        ]
+        transformer = Transformer(vocab_size=V, embedding_dim=D, layers=layers).cuda().eval().half()
+        faster_transformer = NVFasterTransformerEncoder(transformer)
+
+        for B in range(1, 32):
+            for T in [0, 1, 7, 8, 16]:
+                tokens = (
+                    torch.randint(transformer.padding_idx + 1, V - 1, size=(B, T))
+                    .cuda()
+                    .long()
+                )
+                ref = transformer(tokens)
+                fast = faster_transformer(tokens)
+                for rref, ffast in zip(ref, fast):
+                    torch.testing.assert_allclose(rref, ffast, atol=3e-2, rtol=2e-2)
+
     def testLoweringBaseTransformerToNVFastTransformerUnfused(self):
         """
         No padding (full sequence lengths), unfused path (no trt)


### PR DESCRIPTION
Summary: For layernorm, since we need to do two reductions in the middle, we need to do 3 block-strided loops. But previously, we only record the aggregated value of `local_out`, which was incorrect. Instead, we should record the `local_out` at each loop iteration. This diff reuses the out array to save such local_out, since in the end, out will be overwritten by the finally result anyway.

Differential Revision: D27789994

