### PR TITLE
Change defaults for PyText CUDA export.

### DIFF
--- a/pytext/task/new_task.py
+++ b/pytext/task/new_task.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
@@ -414,7 +415,7 @@ class _NewTask(TaskBase):
             if quantize:
                 log_feature_usage("quantize.dynamically.CPU")
                 model.quantize()
-            if accel.use_cuda_half_ft:
+            if accel.use_cuda and accel.use_cuda_half_ft:
                 log_accelerator_feature_usage("build.CUDA.half.faster_transformers")
                 # We need a separate path for GPU-only tracing, as we can't just trace a CPU model
                 # and invoke .cuda().half(),
@@ -442,7 +443,7 @@ class _NewTask(TaskBase):
             else:
                 trace = model.trace(inputs)
                 print("Traced!")
-                if accel.use_cuda_half:
+                if accel.use_cuda and accel.use_cuda_half:
                     log_accelerator_feature_usage("build.CUDA.half")
                     # convert trace to half precision
                     trace.cuda().half()


### PR DESCRIPTION
Summary:
Change defaults for PyText CUDA export to
make preferred operating modes the default.
Make cuda:half and cuda:half:ft are the default.

disable cuda:half with cuda:fp32 (or should we make it cuda:float?)
and FT with cuda:fp32 or cuda:fp16:noft

Reviewed By: mleshen

Differential Revision: D28784222

