### PR TITLE
Support Separate length evaluation

### DIFF
--- a/pytext/models/seq_models/mask_generator.py
+++ b/pytext/models/seq_models/mask_generator.py
@@ -190,6 +190,7 @@ class MaskedSequenceGenerator(Module):
         embed_quantize,
     ):
         super().__init__()
+        length_prediction_model = length_prediction_model.create_eval_module()
         if quantize:
             self.model = torch.quantization.quantize_dynamic(
                 model,

--- a/pytext/models/seq_models/nar_length.py
+++ b/pytext/models/seq_models/nar_length.py
@@ -95,6 +95,9 @@ class ConvLengthPredictionModule(Module):
         predicted_lengths = F.log_softmax(predicted_lengths_logits, dim=-1)
         return predicted_lengths, predicted_lengths_logits
 
+    def create_eval_module(self):
+        return self
+
     @classmethod
     def from_config(cls, config: Config, embed_dim: int):
         conv_layers = []
@@ -156,6 +159,9 @@ class MaskedLengthPredictionModule(Module):
             predicted_lengths_logits.dtype
         )
         return predicted_lengths, predicted_lengths_logits
+
+    def create_eval_module(self):
+        return self
 
     @classmethod
     def from_config(cls, config: Config, embed_dim: int):


### PR DESCRIPTION
Summary: Supports creating a separate evaluation module for length predictors, this way we can support differnet logic for training / inference

Reviewed By: anchit

Differential Revision: D28854126

