### PR TITLE
Add embedding module for Int Single Category features and Int weighted category features

### DIFF
--- a/pytext/data/sources/data_source.py
+++ b/pytext/data/sources/data_source.py
@@ -334,13 +334,27 @@ JSONString = TypeVar("JSONString", str, bytes)
 
 @RootDataSource.register_type(Gazetteer)
 @RootDataSource.register_type(Dict[int, int])
+@RootDataSource.register_type(Dict[int, Dict[int, float]])
 @RootDataSource.register_type(List[str])
 @RootDataSource.register_type(List[int])
 def load_json(s):
     if isinstance(s, List) and all(isinstance(x, (str, int)) for x in s):
         return s
+
     if isinstance(s, Dict) and all(
-        isinstance(x[0], int) and isinstance(x[1], int) for x in s.items()
+        isinstance(x[0], int)
+        and (
+            # Dict[int, int]
+            isinstance(x[1], int)
+            or (  # Dict[int, Dict[int, float]]
+                isinstance(x[1], Dict)
+                and all(
+                    isinstance(y[0], int) and isinstance(y[1], float)
+                    for y in x[1].items()
+                )
+            )
+        )
+        for x in s.items()
     ):
         return s
     return json.loads(s)

--- a/pytext/models/embeddings/__init__.py
+++ b/pytext/models/embeddings/__init__.py
@@ -5,10 +5,11 @@ from .contextual_token_embedding import ContextualTokenEmbedding
 from .dict_embedding import DictEmbedding
 from .embedding_base import EmbeddingBase
 from .embedding_list import EmbeddingList
+from .int_single_category_embedding import IntSingleCategoryEmbedding
+from .int_weighted_multi_category_embedding import IntWeightedMultiCategoryEmbedding
 from .mlp_embedding import MLPEmbedding
 from .word_embedding import WordEmbedding
 from .word_seq_embedding import WordSeqEmbedding
-
 
 __all__ = [
     "EmbeddingBase",
@@ -19,4 +20,6 @@ __all__ = [
     "ContextualTokenEmbedding",
     "WordSeqEmbedding",
     "MLPEmbedding",
+    "IntSingleCategoryEmbedding",
+    "IntWeightedMultiCategoryEmbedding",
 ]

--- a/pytext/models/embeddings/int_single_category_embedding.py
+++ b/pytext/models/embeddings/int_single_category_embedding.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+import torch.onnx.operators
+from pytext.config.module_config import ModuleConfig
+from pytext.utils.usage import log_class_usage
+
+from .embedding_base import EmbeddingBase
+
+
+class IntSingleCategoryEmbedding(EmbeddingBase):
+    """Embed Dict of feature_id -> feature value to list of tensors (1 tensor per feature ID) after looking up feature value embedding,
+    then apply optional pooling and MLP to final tensor.
+    Passed in feature dict keys need to be in fixed order in forward.
+    """
+
+    class Config(ModuleConfig):
+        embedding_dim: int = 32
+        # mean / max / none (concat)
+        pooling_type: str = "none"
+        mlp_layer_dims: List[int] = []
+        # Per feature buckets. emb bucket = mod(feature_value, feature_buckets[feature_id]).
+        # When pooling_type is none, the concat order is based on the key order.
+        feature_buckets: Dict[int, int] = {}
+
+    @classmethod
+    def from_config(cls, config: Config):
+        """Factory method to construct an instance of DictEmbedding from
+        the module's config object and the field's metadata object.
+
+        Args:
+            config (DictFeatConfig): Configuration object specifying all the
+            parameters of DictEmbedding.
+            metadata (FieldMeta): Object containing this field's metadata.
+
+        Returns:
+            type: An instance of DictEmbedding.
+
+        """
+        return cls(
+            embedding_dim=config.embedding_dim,
+            pooling_type=config.pooling_type,
+            mlp_layer_dims=config.mlp_layer_dims,
+            feature_buckets=config.feature_buckets,
+        )
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        pooling_type: str,
+        mlp_layer_dims: List[int],
+        feature_buckets: Dict[int, int],
+    ) -> None:
+        super().__init__(embedding_dim)
+        self.pooling_type = pooling_type
+        self.mlp_layer_dims = mlp_layer_dims
+        self.num_intput_features = len(feature_buckets)
+        input_dim = (
+            self.num_intput_features * embedding_dim
+            if self.pooling_type == "none"
+            else embedding_dim
+        )
+        self.mlp = nn.Sequential(
+            *(
+                nn.Sequential(nn.Linear(m, n), nn.ReLU())
+                for m, n in zip(
+                    [input_dim] + list(mlp_layer_dims),
+                    mlp_layer_dims,
+                )
+            )
+        )
+
+        self.feature_buckets = {int(k): v for k, v in feature_buckets.items()}
+        self.feature_embeddings = nn.ModuleDict(
+            {str(k): nn.Embedding(v, embedding_dim) for k, v in feature_buckets.items()}
+        )
+        log_class_usage(__class__)
+
+    def get_output_dim(self):
+        if self.mlp_layer_dims:
+            return self.mlp_layer_dims[-1]
+
+        if self.pooling_type == "none":
+            return self.num_intput_features * self.embedding_dim
+        elif self.pooling_type == "mean":
+            return self.embedding_dim
+        elif self.pooling_type == "max":
+            return self.embedding_dim
+        else:
+            raise RuntimeError(f"Pooling type {self.pooling_type} is unsupported.")
+
+    def forward(self, feats: Dict[int, torch.Tensor]) -> torch.Tensor:
+        embeddings: List[torch.Tensor] = []
+        for k, buckets in self.feature_buckets.items():
+            feat = feats[k]
+            feats_remap = torch.remainder(feat, buckets)
+            feat_emb: nn.Embedding = self.feature_embeddings[str(k)]
+            embeddings.append(feat_emb(feats_remap))
+
+        if self.pooling_type == "none":
+            reduced_embeds = torch.cat(embeddings, dim=1)
+        elif self.pooling_type == "mean":
+            reduced_embeds = torch.sum(torch.stack(embeddings, dim=1), dim=1)
+        elif self.pooling_type == "max":
+            reduced_embeds, _ = torch.max(torch.stack(embeddings, dim=1), dim=1)
+        else:
+            raise RuntimeError(f"Pooling type {self.pooling_type} is unsupported.")
+
+        return self.mlp(reduced_embeds)

--- a/pytext/models/embeddings/int_weighted_multi_category_embedding.py
+++ b/pytext/models/embeddings/int_weighted_multi_category_embedding.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.onnx.operators
+from pytext.config.module_config import ModuleConfig
+from pytext.utils.usage import log_class_usage
+
+from .embedding_base import EmbeddingBase
+
+
+class IntWeightedMultiCategoryEmbedding(EmbeddingBase):
+    """Embed Dict of feature_id -> (feature values, offsets, weights) to list of tensors (1 tensor per feature ID) with EmbeddingBag,
+    then apply optional pooling and MLP to final tensor.
+    Passed in feature dict keys need to be in fixed order in forward.
+    """
+
+    class Config(ModuleConfig):
+        embedding_dim: int = 32
+        weight_scale: float = 1.0
+        embedding_bag_mode: str = "sum"
+        # when it's false, mode has to be 'sum'
+        ignore_weight: bool = False
+        # mean / max / none (concat)
+        pooling_type: str = "none"
+        # Apply MLP layers after pooling.
+        mlp_layer_dims: List[int] = []
+        # Per feature buckets, emb bucket = mod(feature_value, feature_buckets[feature_id]).
+        # When pooling_type is none, the concat order is based on the key order.
+        feature_buckets: Dict[int, int] = {}
+
+    @classmethod
+    def from_config(cls, config: Config):
+        """Factory method to construct an instance of IntWeightedMultiCategoryEmbedding
+        from the module's config object and the field's metadata object.
+
+        Args:
+            config (Config): Configuration object specifying all the
+            parameters of IntWeightedMultiCategoryEmbedding.
+            num_intput_features: Number of input features in forward.
+
+        Returns:
+            type: An instance of IntWeightedMultiCategoryEmbedding.
+
+        """
+        return cls(
+            embedding_dim=config.embedding_dim,
+            weight_scale=config.weight_scale,
+            embedding_bag_mode=config.embedding_bag_mode,
+            ignore_weight=config.ignore_weight,
+            pooling_type=config.pooling_type,
+            mlp_layer_dims=config.mlp_layer_dims,
+            feature_buckets=config.feature_buckets,
+        )
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        weight_scale: float,
+        embedding_bag_mode: str,
+        ignore_weight: bool,
+        pooling_type: str,
+        mlp_layer_dims: List[int],
+        feature_buckets: Dict[int, int],
+    ) -> None:
+        super().__init__(embedding_dim)
+
+        self.weight_scale = weight_scale
+        self.ignore_weight = ignore_weight
+        if not ignore_weight:
+            assert embedding_bag_mode == "sum"  # EmbeddingBag required.
+        self.pooling_type = pooling_type
+        self.mlp_layer_dims = mlp_layer_dims
+
+        self.feature_buckets = {int(k): v for k, v in feature_buckets.items()}
+        self.feature_embeddings = nn.ModuleDict(
+            {
+                str(k): nn.EmbeddingBag(v, embedding_dim, mode=embedding_bag_mode)
+                for k, v in feature_buckets.items()
+            }
+        )
+
+        self.num_intput_features = len(feature_buckets)
+        input_dim = (
+            self.num_intput_features * embedding_dim
+            if self.pooling_type == "none"
+            else embedding_dim
+        )
+        self.mlp = nn.Sequential(
+            *(
+                nn.Sequential(nn.Linear(m, n), nn.ReLU())
+                for m, n in zip(
+                    [input_dim] + list(mlp_layer_dims),
+                    mlp_layer_dims,
+                )
+            )
+        )
+        log_class_usage(__class__)
+
+    def get_output_dim(self):
+        if self.mlp_layer_dims:
+            return self.mlp_layer_dims[-1]
+
+        if self.pooling_type == "none":
+            return self.num_intput_features * self.embedding_dim
+        elif self.pooling_type == "mean":
+            return self.embedding_dim
+        elif self.pooling_type == "max":
+            return self.embedding_dim
+        else:
+            raise RuntimeError(f"Pooling type {self.pooling_type} is unsupported.")
+
+    def forward(
+        self, feats: Dict[int, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]
+    ) -> torch.Tensor:
+        embeddings: List[torch.Tensor] = []
+        for k, buckets in self.feature_buckets.items():
+            # it will throw if no key found in feats
+            (feat, offsets, weights) = feats[k]
+            feats_remap = torch.remainder(feat, buckets)
+            feat_emb: nn.EmbeddingBag = self.feature_embeddings[str(k)]
+            embeddings.append(
+                feat_emb(
+                    feats_remap,
+                    offsets=offsets,
+                    per_sample_weights=(weights if not self.ignore_weight else None),
+                )
+                * self.weight_scale
+            )
+
+        if self.pooling_type == "none":  # None
+            reduced_embeds = torch.cat(embeddings, dim=1)
+        elif self.pooling_type == "mean":
+            reduced_embeds = torch.sum(torch.stack(embeddings, dim=1), dim=1)
+        elif self.pooling_type == "max":
+            reduced_embeds, _ = torch.max(torch.stack(embeddings, dim=1), dim=1)
+        else:
+            raise RuntimeError(f"Pooling type {self.pooling_type} is unsupported.")
+
+        return self.mlp(reduced_embeds)

--- a/pytext/models/test/int_single_category_embedding_test.py
+++ b/pytext/models/test/int_single_category_embedding_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import unittest
+
+import torch
+from pytext.models.embeddings.int_single_category_embedding import (
+    IntSingleCategoryEmbedding,
+)
+
+
+class IntSingleCategoryEmbeddingTest(unittest.TestCase):
+    def test_basic(self):
+        # Setup embedding
+        config = IntSingleCategoryEmbedding.Config(feature_buckets={1: 10, 2: 20})
+        embedding_module = IntSingleCategoryEmbedding.from_config(config)
+
+        self.assertEqual(embedding_module.feature_embeddings["1"].weight.size(0), 10)
+        self.assertEqual(
+            embedding_module.feature_embeddings["1"].weight.size(1),
+            config.embedding_dim,
+        )
+        self.assertEqual(embedding_module.feature_embeddings["2"].weight.size(0), 20)
+        self.assertEqual(
+            embedding_module.feature_embeddings["2"].weight.size(1),
+            config.embedding_dim,
+        )
+
+        output = embedding_module(
+            {
+                1: torch.tensor([11, 12, 13], dtype=torch.int),
+                2: torch.tensor([21, 22, 23], dtype=torch.int),
+                3: torch.tensor([31, 32, 33], dtype=torch.int),
+            }
+        )
+
+        self.assertEqual(list(output.size()), [3, 64])
+        self.assertEqual(embedding_module.get_output_dim(), 64)
+
+    def test_pooling(self):
+        # Setup embedding
+        config = IntSingleCategoryEmbedding.Config(
+            pooling_type="max", feature_buckets={1: 10, 2: 20}
+        )
+        embedding_module = IntSingleCategoryEmbedding.from_config(config)
+
+        output = embedding_module(
+            {
+                1: torch.tensor([11, 12, 13], dtype=torch.int),
+                2: torch.tensor([21, 22, 23], dtype=torch.int),
+            }
+        )
+
+        self.assertEqual(list(output.size()), [3, 32])
+        self.assertEqual(embedding_module.get_output_dim(), 32)
+
+    def test_pooling_mlp(self):
+        # Setup embedding
+        config = IntSingleCategoryEmbedding.Config(
+            pooling_type="max", feature_buckets={1: 10, 2: 20}, mlp_layer_dims=[40]
+        )
+        embedding_module = IntSingleCategoryEmbedding.from_config(config)
+
+        output = embedding_module(
+            {
+                1: torch.tensor([11, 12, 13], dtype=torch.int),
+                2: torch.tensor([21, 22, 23], dtype=torch.int),
+            }
+        )
+
+        self.assertEqual(list(output.size()), [3, 40])
+        self.assertEqual(embedding_module.get_output_dim(), 40)

--- a/pytext/models/test/int_weighted_multi_category_embedding_test.py
+++ b/pytext/models/test/int_weighted_multi_category_embedding_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import unittest
+
+import torch
+from pytext.models.embeddings.int_weighted_multi_category_embedding import (
+    IntWeightedMultiCategoryEmbedding,
+)
+
+
+class IntWeightedMultiCategoryEmbeddingTest(unittest.TestCase):
+    def test_basic(self):
+        # Setup embedding
+        config = IntWeightedMultiCategoryEmbedding.Config(
+            feature_buckets={1: 100, 2: 200}
+        )
+        embedding_module = IntWeightedMultiCategoryEmbedding.from_config(config)
+
+        self.assertEqual(embedding_module.feature_embeddings["1"].weight.size(0), 100)
+        self.assertEqual(
+            embedding_module.feature_embeddings["1"].weight.size(1),
+            config.embedding_dim,
+        )
+        self.assertEqual(embedding_module.feature_embeddings["2"].weight.size(0), 200)
+        self.assertEqual(
+            embedding_module.feature_embeddings["2"].weight.size(1),
+            config.embedding_dim,
+        )
+
+        output = embedding_module(
+            # feat ID -> (feat value - categories, offsets, weights)
+            {
+                1: (
+                    torch.tensor([11, 12, 13], dtype=torch.int),
+                    torch.tensor([0, 1], dtype=torch.int),
+                    torch.tensor([0.0, 0.0, 0.0]),
+                ),
+                2: (
+                    torch.tensor([], dtype=torch.int),
+                    torch.tensor([0, 0], dtype=torch.int),
+                    torch.tensor([]),
+                ),
+            }
+        )
+
+        self.assertEqual(list(output.size()), [2, 64])
+        # First feature is embed to zeros as weight is zero. Second feature is embed to zero as it's empty.
+        self.assertTrue(torch.all(output == torch.zeros([2, 64])))
+        self.assertEqual(embedding_module.get_output_dim(), 64)
+
+    def test_pooling(self):
+        # Setup embedding
+        config = IntWeightedMultiCategoryEmbedding.Config(
+            pooling_type="max", feature_buckets={1: 100, 2: 200}
+        )
+        embedding_module = IntWeightedMultiCategoryEmbedding.from_config(config)
+
+        output = embedding_module(
+            {
+                1: (
+                    torch.tensor([11, 12, 13], dtype=torch.int),
+                    torch.tensor([0, 1], dtype=torch.int),
+                    torch.tensor([0.0, 0.0, 0.0]),
+                ),
+                2: (
+                    torch.tensor([1], dtype=torch.int),
+                    torch.tensor([0, 0], dtype=torch.int),
+                    torch.tensor([1.0]),
+                ),
+            }
+        )
+
+        self.assertEqual(list(output.size()), [2, 32])
+        self.assertEqual(embedding_module.get_output_dim(), 32)
+
+    def test_pooling_mlp(self):
+        # Setup embedding
+        config = IntWeightedMultiCategoryEmbedding.Config(
+            pooling_type="max",
+            feature_buckets={1: 100, 2: 200},
+            mlp_layer_dims=[40],
+            ignore_weight=True,
+            embedding_bag_mode="mean",
+        )
+        embedding_module = IntWeightedMultiCategoryEmbedding.from_config(config)
+
+        self.assertEqual(embedding_module.get_output_dim(), 40)
+
+        output = embedding_module(
+            {
+                1: (
+                    torch.tensor([11, 12, 13], dtype=torch.int),
+                    torch.tensor([0, 1], dtype=torch.int),
+                    torch.tensor([0.0, 0.0, 0.0]),
+                ),
+                2: (
+                    torch.tensor([1], dtype=torch.int),
+                    torch.tensor([0, 0], dtype=torch.int),
+                    torch.tensor([1.0]),
+                ),
+            }
+        )
+
+        self.assertEqual(list(output.size()), [2, 40])
+        self.assertEqual(embedding_module.get_output_dim(), 40)


### PR DESCRIPTION
Summary:
1. Int Single category features: Map Dict[int, Tensor] to Tensor
2. Int weighted category features Map Dict[int, (Feat value Tensor, Offset Tensor, Feat weight Tensor)] to Tensor.

We apply hash to map feature values to embedding index (bucket), then apply optional pooling + MLP to get final Tensor.

Differential Revision: D28248603

