### PR TITLE
Remove torch.onnx from two modules

### DIFF
--- a/pytext/models/embeddings/int_single_category_embedding.py
+++ b/pytext/models/embeddings/int_single_category_embedding.py
@@ -4,7 +4,6 @@ from typing import Dict, List
 
 import torch
 import torch.nn as nn
-import torch.onnx.operators
 from pytext.config.module_config import ModuleConfig
 from pytext.utils.usage import log_class_usage
 

--- a/pytext/models/embeddings/int_weighted_multi_category_embedding.py
+++ b/pytext/models/embeddings/int_weighted_multi_category_embedding.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Tuple
 
 import torch
 import torch.nn as nn
-import torch.onnx.operators
 from pytext.config.module_config import ModuleConfig
 from pytext.utils.usage import log_class_usage
 


### PR DESCRIPTION
Summary: torch.onnx is not used in these two files.

Differential Revision: D30582695

