### PR TITLE
pytext: torch.quantization -> torch.ao.quantization

### DIFF
--- a/pytext/common/constants.py
+++ b/pytext/common/constants.py
@@ -2,6 +2,18 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from enum import Enum
+from typing import Tuple
+
+import torch
+
+
+TORCH_VERSION: Tuple[int, ...] = tuple(
+    # Versions could be in the following formats:
+    # - 1.9, 1.10 etc.
+    # - torch.deploy-1.9, torch.deploy-1.10, etc.
+    int(x)
+    for x in torch.__version__.split("-")[-1].split(".")[:2]
+)
 
 
 class Token(str):

--- a/pytext/models/roberta.py
+++ b/pytext/models/roberta.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple
 import torch
 from pytext import resources
 from pytext.common.constants import Stage
+from pytext.common.constants import TORCH_VERSION
 from pytext.config import ConfigBase
 from pytext.data.roberta_tensorizer import (
     RoBERTaTensorizer,
@@ -55,11 +56,14 @@ from pytorch.text.fb.nn.modules.transformer import (
     TransformerLayer,
 )
 from torch import nn
-from torch.quantization import convert_jit, get_default_qconfig, prepare_jit
 from torch.serialization import default_restore_location
 
 from .r3f_models import R3FConfigOptions, R3FPyTextMixin
 
+if TORCH_VERSION >= (1, 11):
+    from torch.ao.quantization import convert_jit, get_default_qconfig, prepare_jit
+else:
+    from torch.quantization import convert_jit, get_default_qconfig, prepare_jit
 
 logger = logging.getLogger(name=__name__)
 

--- a/pytext/models/tri_tower_classification_model.py
+++ b/pytext/models/tri_tower_classification_model.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 from pytext.common.constants import Stage
+from pytext.common.constants import TORCH_VERSION
 from pytext.config import ConfigBase
 from pytext.config.component import create_loss
 from pytext.data.roberta_tensorizer import RoBERTaTensorizer
@@ -24,7 +25,11 @@ from pytext.models.roberta import RoBERTaEncoder, RoBERTaEncoderBase
 from pytext.torchscript.module import ScriptPyTextTriTowerModuleWithDense
 from pytext.utils.label import get_label_weights
 from pytext.utils.usage import log_class_usage
-from torch.quantization import convert_jit, get_default_qconfig, prepare_jit
+
+if TORCH_VERSION >= (1, 11):
+    from torch.ao.quantization import convert_jit, get_default_qconfig, prepare_jit
+else:
+    from torch.quantization import convert_jit, get_default_qconfig, prepare_jit
 
 
 class TriTowerClassificationModel(BaseModel):

--- a/pytext/models/two_tower_classification_model.py
+++ b/pytext/models/two_tower_classification_model.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 from pytext.common.constants import Stage
+from pytext.common.constants import TORCH_VERSION
 from pytext.config import ConfigBase
 from pytext.config.component import create_loss
 from pytext.data.roberta_tensorizer import RoBERTaTensorizer
@@ -23,7 +24,11 @@ from pytext.models.roberta import RoBERTaEncoder, RoBERTaEncoderBase
 from pytext.torchscript.module import ScriptPyTextTwoTowerModuleWithDense
 from pytext.utils.label import get_label_weights
 from pytext.utils.usage import log_class_usage
-from torch.quantization import convert_jit, get_default_qconfig, prepare_jit
+
+if TORCH_VERSION >= (1, 11):
+    from torch.ao.quantization import convert_jit, get_default_qconfig, prepare_jit
+else:
+    from torch.quantization import convert_jit, get_default_qconfig, prepare_jit
 
 
 class TwoTowerClassificationModel(BaseModel):


### PR DESCRIPTION
Summary:
This changes the imports in the `caffe2/torch/ao/nn` to include the new import locations.

```
codemod -d pytext --extensions py 'torch.quantization' 'torch.ao.quantization'
```

Differential Revision: D31302214

