### PR TITLE
Remove fixed pad_shape from FloatListSeqTensorizer

### DIFF
--- a/pytext/data/tensorizers.py
+++ b/pytext/data/tensorizers.py
@@ -2372,12 +2372,13 @@ class FloatListSeqTensorizer(Tensorizer):
         ):
             # infer batch size
             pad_shape = [len(lens), self.pad_shape[1], self.pad_shape[2]]
-            self.pad_shape = pad_shape
+        else:
+            pad_shape = self.pad_shape
 
         padded_and_tensorized_float_lists = pad_and_tensorize(
             float_lists,
             pad_token=self.pad_token,
-            pad_shape=self.pad_shape,
+            pad_shape=pad_shape,
             dtype=torch.float,
         )
         return (padded_and_tensorized_float_lists, pad_and_tensorize(lens))


### PR DESCRIPTION
Summary:
Current FloatListSeqTensorizer fixes pad_shape to initial batch. This raises problem in the last batch where number of samples is not sufficient to fill the full pad size. This problem is hidden when BiLSTM representation is used, because of the sorting operation (even with disable_sorting, the index selection part of the method still kicks in and removes the blank slices). When other representation, e.g. CNN is used, this problem shows up.
See run f338219453 for example inputs for BiLSTM representation and run f338248738 for CNN representation.

Differential Revision: D35598633

