### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pytext/models/embeddings/int_weighted_multi_category_embedding.py
+++ b/pytext/models/embeddings/int_weighted_multi_category_embedding.py
@@ -43,7 +43,7 @@ class IntWeightedMultiCategoryEmbedding(EmbeddingBase):
         Args:
             config (Config): Configuration object specifying all the
             parameters of IntWeightedMultiCategoryEmbedding.
-            num_intput_features: Number of input features in forward.
+            num_input_features: Number of input features in forward.
 
         Returns:
             type: An instance of IntWeightedMultiCategoryEmbedding.
@@ -106,9 +106,9 @@ class IntWeightedMultiCategoryEmbedding(EmbeddingBase):
             }
         )
 
-        self.num_intput_features = len(feature_buckets)
+        self.num_input_features = len(feature_buckets)
         input_dim = (
-            self.num_intput_features * embedding_dim
+            self.num_input_features * embedding_dim
             if self.pooling_type == "none"
             else embedding_dim
         )
@@ -128,7 +128,7 @@ class IntWeightedMultiCategoryEmbedding(EmbeddingBase):
             return self.mlp_layer_dims[-1]
 
         if self.pooling_type == "none":
-            return self.num_intput_features * self.embedding_dim
+            return self.num_input_features * self.embedding_dim
         elif self.pooling_type == "mean":
             return self.embedding_dim
         elif self.pooling_type == "max":

--- a/pytext/torchscript/batchutils.py
+++ b/pytext/torchscript/batchutils.py
@@ -370,7 +370,7 @@ def make_batch_texts(
 
     # TBD: allow model server to specify batch size in goals dictionary
     # the right batchsize depends on the target architecture and should
-    # be passed via the goals config doctionary
+    # be passed via the goals config dictionary
     max_bs = int(goals.get("batchsize", "4"))
     len_mb = len(mega_batch)
     num_batches = (len_mb + max_bs - 1) // max_bs
@@ -462,7 +462,7 @@ def make_batch_texts_dense(
 
     # TBD: allow model server to specify batch size in goals dictionary
     # the right batchsize depends on the target architecture and should
-    # be passed via the goals config doctionary
+    # be passed via the goals config dictionary
     max_bs = int(goals.get("batchsize", "4"))
     len_mb = len(mega_batch)
     num_batches = (len_mb + max_bs - 1) // max_bs

--- a/pytext/torchscript/module.py
+++ b/pytext/torchscript/module.py
@@ -427,7 +427,7 @@ class ScriptPyTextEmbeddingModule(torch.jit.ScriptModule):
 
         # TBD: allow model server to specify batch size in goals dictionary
         # the right batchsize depends on the target architecture and should
-        # be passed via the goals config doctionary
+        # be passed via the goals config dictionary
         max_bs = int(goals.get("batchsize", "4"))
         len_mb = len(mega_batch)
         num_batches = (len_mb + max_bs - 1) // max_bs
@@ -1053,7 +1053,7 @@ class ScriptPyTextTwoTowerEmbeddingModule(ScriptTwoTowerModule):
 
         # TBD: allow model server to specify batch size in goals dictionary
         # the right batchsize depends on the target architecture and should
-        # be passed via the goals config doctionary
+        # be passed via the goals config dictionary
         max_bs = int(goals.get("batchsize", "4"))
         len_mb = len(mega_batch)
         num_batches = (len_mb + max_bs - 1) // max_bs
@@ -1521,7 +1521,7 @@ class PyTextEmbeddingModule(torch.jit.ScriptModule):
 
         # TBD: allow model server to specify batch size in goals dictionary
         # the right batchsize depends on the target architecture and should
-        # be passed via the goals config doctionary
+        # be passed via the goals config dictionary
         max_bs = int(goals.get("batchsize", "4"))
         len_mb = len(mega_batch)
         num_batches = (len_mb + max_bs - 1) // max_bs
@@ -1933,7 +1933,7 @@ class PyTextTwoTowerEmbeddingModule(torch.jit.ScriptModule):
 
         # TBD: allow model server to specify batch size in goals dictionary
         # the right batchsize depends on the target architecture and should
-        # be passed via the goals config doctionary
+        # be passed via the goals config dictionary
         max_bs = int(goals.get("batchsize", "4"))
         len_mb = len(mega_batch)
         num_batches = (len_mb + max_bs - 1) // max_bs
@@ -2175,7 +2175,7 @@ class PyTextTwoTowerLayerModuleWithDense(PyTextTwoTowerLayerModule):
 
         # TBD: allow model server to specify batch size in goals dictionary
         # the right batchsize depends on the target architecture and should
-        # be passed via the goals config doctionary
+        # be passed via the goals config dictionary
         max_bs = int(goals.get("batchsize", "4"))
         len_mb = len(mega_batch)
         num_batches = (len_mb + max_bs - 1) // max_bs

--- a/pytext/torchscript/tokenizer/bpe.py
+++ b/pytext/torchscript/tokenizer/bpe.py
@@ -137,7 +137,7 @@ class ScriptBPE(torch.jit.ScriptModule):
             # We structure the vocabulary to not have ties, but they can come up anyway,
             # for instance in cases with repeated tokens or when passing in vocabs not
             # created with BPE.load_vocab. In the case of a tie between the value of
-            # joined segments, they'll be joined proiritizing the first pair in the
+            # joined segments, they'll be joined prioritizing the first pair in the
             # token according to byte order, ie. left in LTR and right in RTL languages.
             # For instance, if the vocab contains "aa" but not "aaa", then
             # bpe_tokens("aaa") -> ["aa", "a"]. If the vocab contains "ab" and "bc"


### PR DESCRIPTION
There are small typos in:
- pytext/models/embeddings/int_weighted_multi_category_embedding.py
- pytext/torchscript/batchutils.py
- pytext/torchscript/module.py
- pytext/torchscript/tokenizer/bpe.py

Fixes:
- Should read `dictionary` rather than `doctionary`.
- Should read `prioritizing` rather than `proiritizing`.
- Should read `input` rather than `intput`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md