### PR TITLE
Back out "move PATH_MANAGER to OSS"

### DIFF
--- a/pytext/utils/file_io.py
+++ b/pytext/utils/file_io.py
@@ -9,7 +9,7 @@ import os
 # the import everywhere in PyText
 # TODO: @stevenliu use PathManagerFactory after it's released to PyPI
 from iopath.common.file_io import HTTPURLHandler
-from torchtext.utils import PATH_MANAGER as PathManager  # noqa
+from pytorch.text.fb.utils import PATH_MANAGER as PathManager  # noqa
 
 
 def register_http_url_handler():


### PR DESCRIPTION
Summary:
Original commit changeset: c0046d62e641

Original Phabricator Diff: D39292896 (https://github.com/facebookresearch/PyText/commit/b9324484d0ed67c2b14c014ae1f132c2d638d81d)

torchtext can't depend on iopath as raised in https://github.com/pytorch/text/pull/1905

Reviewed By: Nayef211

Differential Revision: D39639475

